### PR TITLE
Update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog  
 
+## Version 0.45.0 - Unreleased
+🍀Added setters for `IChart.Axes.ValueAxis.Minumum/Maximum` [#482](https://github.com/ShapeCrawler/ShapeCrawler/issues/482)  
+🍀Added `ISeriesCollection.RemoveAt(int index)` [#491](https://github.com/ShapeCrawler/ShapeCrawler/issues/491)  
+
 ## Version 0.44.0 - 2023-04-21
 🍀Added `IShapeCollection.AddPicture()` [#481](https://github.com/ShapeCrawler/ShapeCrawler/issues/481)  
 🍀Added `IChart.FormatAxis.AxisOptions.Bounds.Minimum/Maximum` [#482](https://github.com/ShapeCrawler/ShapeCrawler/issues/482)


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds new features and improvements to the ShapeCrawler library. It adds setters for minimum and maximum values of value axes in charts, a method to remove a series from a series collection, and options to specify minimum and maximum bounds for chart axes. 

### Detailed summary
- Added setters for `IChart.Axes.ValueAxis.Minimum/Maximum`
- Added `ISeriesCollection.RemoveAt(int index)`
- Added `IChart.FormatAxis.AxisOptions.Bounds.Minimum/Maximum`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->