### PR TITLE
Remove table column

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
+# macOS
+*.DS_Store
+
 # User-specific files
 *.rsuser
 *.suo

--- a/src/ShapeCrawler/Tables/ITable.cs
+++ b/src/ShapeCrawler/Tables/ITable.cs
@@ -41,7 +41,7 @@ public interface ITable : IShape
     void MergeCells(ICell cell1, ICell cell2);
 
     /// <summary>
-    ///     Deletes a column at specified index
+    ///     Removes a column at specified index.
     /// </summary>
     void RemoveColumn(int columnIndex);
 }

--- a/src/ShapeCrawler/Tables/ITable.cs
+++ b/src/ShapeCrawler/Tables/ITable.cs
@@ -39,6 +39,11 @@ public interface ITable : IShape
     ///     Merge neighbor cells.
     /// </summary>
     void MergeCells(ICell cell1, ICell cell2);
+
+    /// <summary>
+    ///     Deletes a column at specified index
+    /// </summary>
+    void RemoveColumn(int columnIndex);
 }
 
 internal sealed class SCTable : SCShape, ITable
@@ -68,6 +73,20 @@ internal sealed class SCTable : SCShape, ITable
     private A.Table ATable => this.pGraphicFrame.GetATable();
 
     public ICell this[int rowIndex, int columnIndex] => this.Rows[rowIndex].Cells[columnIndex];
+
+    public void RemoveColumn(int columnIndex)
+    {
+        var column = this.Columns[columnIndex] as SCColumn;
+        column!.AGridColumn.Remove();
+        
+        var aTableRows = this.ATable.Elements<A.TableRow>();
+
+        foreach (var aTableRow in aTableRows)
+        {
+            var aTableCell = aTableRow.Elements<A.TableCell>().ElementAt(columnIndex);
+            aTableCell.Remove();
+        }
+    }
 
     public void MergeCells(ICell inputCell1, ICell inputCell2)
     {

--- a/test/ShapeCrawler.Tests.Unit/TableTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/TableTests.cs
@@ -35,18 +35,22 @@ public class TableTests : SCTest
     [Fact]
     public void Columns_RemoveColumn_Removes_Column_With_Specified_Index()
     {
+        // Arrange
         using var ms = new MemoryStream();
         using var pptx = TestHelperShared.GetStream("table-case001.pptx");
         using var pres = SCPresentation.Open(pptx);
         var table = pres.Slides[0].Shapes.GetByName<ITable>("Table 1");
+        var originalColumnCount = table.Columns.Count;
         
-        table.Columns.Should().HaveCount(2);
+        // Act
         table.RemoveColumn(1);
+        
+        // Assert
+        table.Columns.Should().HaveCountLessThan(originalColumnCount);
         pres.SaveAs(ms);
-
         using var pres2 = SCPresentation.Open(ms);
         var table2 = pres2.Slides[0].Shapes.GetByName<ITable>("Table 1");
-        table2.Columns.Should().HaveCount(1);
+        table2.Columns.Should().HaveCountLessThan(originalColumnCount);
     }
     
     [Fact]

--- a/test/ShapeCrawler.Tests.Unit/TableTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/TableTests.cs
@@ -31,6 +31,23 @@ public class TableTests : SCTest
         // Assert
         rowsCount.Should().Be(expectedCount);
     }
+
+    [Fact]
+    public void Columns_RemoveColumn_Removes_Column_With_Specified_Index()
+    {
+        using var ms = new MemoryStream();
+        using var pptx = TestHelperShared.GetStream("table-case001.pptx");
+        using var pres = SCPresentation.Open(pptx);
+        var table = pres.Slides[0].Shapes.GetByName<ITable>("Table 1");
+        
+        table.Columns.Should().HaveCount(2);
+        table.RemoveColumn(1);
+        pres.SaveAs(ms);
+
+        using var pres2 = SCPresentation.Open(ms);
+        var table2 = pres2.Slides[0].Shapes.GetByName<ITable>("Table 1");
+        table2.Columns.Should().HaveCount(1);
+    }
     
     [Fact]
     public void Rows_RemoveAt_removes_row_with_specified_index()


### PR DESCRIPTION
Ignore this if it's already possible, or if you plan a different approach. I couldn't find a way to remove a table column.

I'm not too familiar with the OpenXML specs and schema, but this patch works in our environment. I looked at the MergeCells method and used the same approach. Seems to work with merged cells as well.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new method to remove a table column in ShapeCrawler. 

### Detailed summary
- Added `RemoveColumn` method to `ITable` interface
- Implemented `RemoveColumn` method in `SCTable` class
- Added a new unit test to test the `RemoveColumn` method

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->