### PR TITLE
Clean up

### DIFF
--- a/src/ShapeCrawler/Drawing/IColorFormat.cs
+++ b/src/ShapeCrawler/Drawing/IColorFormat.cs
@@ -120,8 +120,6 @@ internal sealed class ColorFormat : IColorFormat
                 return;
             }
 
-
-            // FontData masterBodyFontData = this.parentSlideMaster.BodyParaLvlToFontData[paragraphLevel];
             if (this.parentSlideMaster.BodyParaLvlToFontData.TryGetValue(paragraphLevel, out var masterBodyFontData) && this.TryFromFontData(masterBodyFontData))
             {
                 return;

--- a/src/ShapeCrawler/Drawing/SCColor.cs
+++ b/src/ShapeCrawler/Drawing/SCColor.cs
@@ -3,22 +3,22 @@
 namespace ShapeCrawler.Drawing;
 
 /// <summary>
-/// Color.
+///     Color.
 /// </summary>
-public class SCColor
+public struct SCColor
 {
     /// <summary>
-    /// Gets a black color.
+    ///     Gets the predefined black color.
     /// </summary>
     public static readonly SCColor Black = new(0, 0, 0);
 
     /// <summary>
-    /// Gets a transparent color.
+    ///     Gets the predefined transparent color.
     /// </summary>
     public static readonly SCColor Transparent = new(0, 0, 0, 0);
 
     /// <summary>
-    /// Gets a white color.
+    ///     Gets the predefined white color.
     /// </summary>
     public static readonly SCColor White = new(255, 255, 255);
 
@@ -59,30 +59,17 @@ public class SCColor
     /// "<paramref name="hex"/>" requires a RGBA value, but alpha (A) is optional.
     /// </remarks>
     /// <param name="hex">RGBA value.</param>
-    public SCColor(string hex) 
+    internal SCColor(string hex) 
         : this(ParseHexValue(hex))
     {
     }
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="SCColor"/> class.
-    /// </summary>
-    /// <param name="red">Red value.</param>
-    /// <param name="green">Green value.</param>
-    /// <param name="blue">Blue value.</param>
-    public SCColor(int red, int green, int blue)
+    private SCColor(int red, int green, int blue)
         : this(red, green, blue, 255)
     {
     }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="SCColor"/> class.
-    /// </summary>
-    /// <param name="red">Red value.</param>
-    /// <param name="green">Green value.</param>
-    /// <param name="blue">Blue value.</param>
-    /// <param name="alpha">Alpha value.</param>
-    public SCColor(int red, int green, int blue, float alpha)
+    
+    private SCColor(int red, int green, int blue, float alpha)
     {
         this.red = red;
         this.green = green;
@@ -90,20 +77,13 @@ public class SCColor
         this.Alpha = alpha;
     }
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="SCColor"/> class.
-    /// </summary>
-    /// <remarks>
-    /// This constructor is reserved for <see cref="SCColor(string)"/>.
-    /// </remarks>
-    /// <param name="color">A RGBA tuple.</param>
     private SCColor((int r, int g, int b, float a) color) 
         : this(color.r, color.g, color.b, color.a)
     {
     }
 
     /// <summary>
-    /// Gets or sets the alpha value.
+    ///     Gets or sets the alpha value.
     /// </summary>
     /// <remarks>
     /// Values are 0 to 255, where 0 is totally transparent.
@@ -111,17 +91,17 @@ public class SCColor
     public float Alpha { get; set; }
 
     /// <summary>
-    /// Gets the blue value.
+    ///     Gets the blue value.
     /// </summary>
     public int B => this.blue;
 
     /// <summary>
-    /// Gets the green value.
+    ///     Gets the green value.
     /// </summary>
     public int G => this.green;
 
     /// <summary>
-    /// Gets the red value.
+    ///     Gets the red value.
     /// </summary>
     public int R => this.red;
 
@@ -141,30 +121,19 @@ public class SCColor
     /// <param name="hex">Hex value.</param>
     /// <param name="result">Color value.</param>
     /// <returns>Returns <see langword="true" /> if hex is a valid value. </returns>
-    public static bool TryGetColorFromHex(string hex, out SCColor result)
+    public static SCColor FromHex(string hex)
     {
-        result = SCColor.Black;
+        // We can try to parse:
+        // 3 or 6 chars without alpha (rgb): F01, FF0011,
+        // 4 or 8 chars with alpha (rgba): F01F, FF0011FF 
+        // Ignores hex values starting with "#" character.
+        var value = hex.StartsWith("#", StringComparison.Ordinal) ? hex.Substring(1) : hex;
 
-        try
-        {
-            // We can try to parse:
-            // 3 or 6 chars without alpha (rgb): F01, FF0011,
-            // 4 or 8 chars with alpha (rgba): F01F, FF0011FF 
-            // Ignores hex values starting with "#" character.
-            var value = hex.StartsWith("#", StringComparison.Ordinal) ? hex.Substring(1) : hex;
+        // Parse value.
+        (int r, int g, int b, float a) = ParseHexValue(value);
 
-            // Parse value.
-            (int r, int g, int b, float a) = ParseHexValue(value);
-
-            // Creates a new instance
-            result = new(r, g, b, a);
-
-            return true;
-        }
-        catch (Exception)
-        {
-            return false;
-        }
+        // Creates a new instance
+        return new(r, g, b, a);
     }
 
     /// <inheritdoc/>

--- a/src/ShapeCrawler/Extensions/RunPropertiesExtensions.cs
+++ b/src/ShapeCrawler/Extensions/RunPropertiesExtensions.cs
@@ -22,18 +22,18 @@ internal static class RunPropertiesExtensions
         arPr.Append(aHighlight);
     }
 
-    internal static void AddAHighlight(this RunProperties arPr, SCColor hex)
+    internal static void AddAHighlight(this RunProperties arPr, SCColor color)
     {
         var aHighlight = arPr.GetFirstChild<A.Highlight>();
         aHighlight?.Remove();
 
-        if (hex.IsTransparent)
+        if (color.IsTransparent)
         {
             return;
         }
 
         aHighlight = new A.Highlight();
-        aHighlight.Append(hex.ToRgbColorModelHex());
+        aHighlight.Append(color.ToRgbColorModelHex());
 
         arPr.Append(aHighlight);
     }

--- a/test/ShapeCrawler.Tests.Unit/ColorTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ColorTests.cs
@@ -2,34 +2,39 @@
 using ShapeCrawler.Drawing;
 using ShapeCrawler.Tests.Unit.Helpers;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using NUnit.Framework;
 using Xunit;
 
 namespace ShapeCrawler.Tests.Unit;
 
+[SuppressMessage("Usage", "xUnit1013:Public method should be marked as test")]
 public class ColorTests : SCTest
 {
-    [Fact]
-    public void Color_IsWhite()
+    [Test]
+    public void R_G_B_and_Alpha_values_of_White_color()
     {
         var color = SCColor.White;
 
+        // Assert
         color.R.Should().Be(255);
         color.G.Should().Be(255);
         color.B.Should().Be(255);
         color.Alpha.Should().Be(255);
     }
 
-    [Theory]
+    [Xunit.Theory]
     [MemberData(nameof(HexValuesData))]
-    public void Color_Parse_from_hex_values(string hexValue, SCColor expected)
+    public void FromHex_create_color_from_hexadecimal_code(string hexString, SCColor expectedColor)
     {
-        var rColor = SCColor.TryGetColorFromHex(hexValue, out var color);
+        // Act
+        var color = SCColor.FromHex(hexString);
 
-        rColor.Should().BeTrue();
-        color.R.Should().Be(expected.R);
-        color.G.Should().Be(expected.G);
-        color.B.Should().Be(expected.B);
-        color.Alpha.Should().Be(expected.Alpha);
+        // Assert
+        color.R.Should().Be(expectedColor.R);
+        color.G.Should().Be(expectedColor.G);
+        color.B.Should().Be(expectedColor.B);
+        color.Alpha.Should().Be(expectedColor.Alpha);
     }
 
     public static IEnumerable<object[]> HexValuesData => 

--- a/test/ShapeCrawler.Tests.Unit/ParagraphPortionTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ParagraphPortionTests.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using FluentAssertions;
+using NUnit.Framework;
 using ShapeCrawler.Drawing;
 using ShapeCrawler.Tests.Shared;
 using ShapeCrawler.Tests.Unit.Helpers;
@@ -11,6 +13,7 @@ using Xunit;
 
 namespace ShapeCrawler.Tests.Unit;
 
+[SuppressMessage("Usage", "xUnit1013:Public method should be marked as test")]
 public class ParagraphPortionTests : SCTest
 {
     [Fact]
@@ -46,7 +49,7 @@ public class ParagraphPortionTests : SCTest
         portion.Text.Should().Be("test");
     }
 
-    [Theory]
+    [Xunit.Theory]
     [MemberData(nameof(TestCasesHyperlinkSetter))]
     public void Hyperlink_Setter_sets_hyperlink(string pptxFile, string shapeName)
     {
@@ -113,7 +116,7 @@ public class ParagraphPortionTests : SCTest
         errors.Should().BeEmpty();
     }
 
-    [Fact]
+    [Test]
     public void TextHighlightColor_Getter_returns_text_highlight_color()
     {
         // Arrange
@@ -122,11 +125,8 @@ public class ParagraphPortionTests : SCTest
         var shape = pres.Slides[0].Shapes.GetByName<IAutoShape>("TextBox 3");
         var portion = shape.TextFrame!.Paragraphs[0].Portions[0];
 
-        // Act
-        var textHighlightColor = portion.TextHighlightColor;
-
-        // Assert
-        textHighlightColor.Should().Be("FFFF00");
+        // Act-Assert
+        portion.TextHighlightColor.ToString().Should().Be("FFFF00");
     }
 
     [Fact]
@@ -138,14 +138,11 @@ public class ParagraphPortionTests : SCTest
         var shape = pres.Slides[0].Shapes.GetByName<IAutoShape>("TextBox 3");
         var portion = shape.TextFrame!.Paragraphs[0].Portions[0];
 
-        // Act
-        var textHighlightColor = portion.GetTextHighlight();
-
-        // Assert
-        textHighlightColor.ToString().Should().Be("FFFF00");
+        // Act-Assert
+        portion.TextHighlightColor.ToString().Should().Be("FFFF00");
     }
 
-    [Fact]
+    [Test]
     public void TextHighlightColor_Setter_sets_text_highlight_color()
     {
         // Arrange
@@ -155,25 +152,26 @@ public class ParagraphPortionTests : SCTest
         var portion = shape.TextFrame!.Paragraphs[0].Portions[0];
 
         // Act
-        portion.TextHighlightColor = "FFFF00";
+        portion.TextHighlightColor = SCColor.FromHex("FFFF00");
 
         // Assert
-        portion.TextHighlightColor.Should().Be("FFFF00");
+        portion.TextHighlightColor.ToString().Should().Be("FFFF00");
     }
 
-    [Fact]
-    public void TextHighlightColor_Setter_sets_text_highlight_sccolor()
+    [Test]
+    public void TextHighlightColor_Setter_sets_text_highlight()
     {
         // Arrange
         var pptx = TestHelperShared.GetStream("autoshape-grouping.pptx");
         var pres = SCPresentation.Open(pptx);
         var shape = pres.Slides[0].Shapes.GetByName<IAutoShape>("TextBox 4");
         var portion = shape.TextFrame!.Paragraphs[0].Portions[0];
+        var color = SCColor.FromHex("FFFF00");
 
         // Act
-        portion.SetTextHighlight(new SCColor("FFFF00"));
+        portion.TextHighlightColor = color;
 
         // Assert
-        portion.GetTextHighlight().ToString().Should().Be("FFFF00");
+        portion.TextHighlightColor.ToString().Should().Be("FFFF00");
     }
 }

--- a/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
@@ -324,7 +324,7 @@ public class ShapeCollectionTests : SCTest
 
 #if DEBUG
     
-    [Test]
+    [Test, Ignore("Not implemented yet")]
     public void AddBarChart_adds_Bar_Chart()
     {
         // Arrange


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds support for text highlight color in ShapeCrawler. Notable changes include:

- `IPortion` now has a `TextHighlightColor` property that gets and sets the highlight color.
- `SCColor` is now a struct instead of a class.
- `SCColor` now has a constructor that takes RGBA values.
- `RunPropertiesExtensions` now has a method `AddAHighlight` that adds a highlight to a run.
- Various test methods were modified or added.

> The following files were skipped due to too many changes: `src/ShapeCrawler/Drawing/SCColor.cs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->