### PR TITLE
Bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog  
 
+## Version 0.45.1 - 2023-05-18
+🐞Fixed bug where `ISlideCollection.Add()` doesn't copy placeholder shapes [#508](https://github.com/ShapeCrawler/ShapeCrawler/issues/508)
+
 ## Version 0.45.0 - 2023-05-05
-🍀Added setters for `IChart.Axes.ValueAxis.Minumum/Maximum` [#482](https://github.com/ShapeCrawler/ShapeCrawler/issues/482)  
+🍀Added setters for `IChart.Axes.ValueAxis.Minumum/Maximum`[#482](https://github.com/ShapeCrawler/ShapeCrawler/issues/482)  
 🍀Added `ISeriesCollection.RemoveAt(int index)` [#491](https://github.com/ShapeCrawler/ShapeCrawler/issues/491)  
 🍀Added `ITable.RemoveColumnAt(int columnIndex)` [#501](https://github.com/ShapeCrawler/ShapeCrawler/issues/501)  
 🐞Fixed updating text of the grouped shape [#452](https://github.com/ShapeCrawler/ShapeCrawler/issues/452)  

--- a/README.md
+++ b/README.md
@@ -69,12 +69,10 @@ How can you contribute?
 - **Code contributing**. Pull Requests are welcome! Please read the [Contribution Guide](https://github.com/ShapeCrawler/ShapeCrawler/blob/master/CONTRIBUTING.md) for more details.
 
 
-## Changelog
-## Version 0.45.0 - 2023-05-05
-🍀Added setters for `IChart.Axes.ValueAxis.Minumum/Maximum` [#482](https://github.com/ShapeCrawler/ShapeCrawler/issues/482)  
-🍀Added `ISeriesCollection.RemoveAt(int index)` [#491](https://github.com/ShapeCrawler/ShapeCrawler/issues/491)  
-🍀Added `ITable.RemoveColumnAt(int columnIndex)` [#501](https://github.com/ShapeCrawler/ShapeCrawler/issues/501)  
-🐞Fixed updating text of the grouped shape [#452](https://github.com/ShapeCrawler/ShapeCrawler/issues/452)  
+# Changelog  
+
+## Version 0.45.1 - 2023-05-18
+🐞Fixed bug where `ISlideCollection.Add()` doesn't copy placeholder shapes [#508](https://github.com/ShapeCrawler/ShapeCrawler/issues/508)
 
 Visit [CHANGELOG.md](https://github.com/ShapeCrawler/ShapeCrawler/blob/master/CHANGELOG.md) to see the full log.
 

--- a/src/ShapeCrawler/ShapeCrawler.csproj
+++ b/src/ShapeCrawler/ShapeCrawler.csproj
@@ -13,10 +13,7 @@ This library provides a simplified object model on top of the Open XML SDK for m
     <Copyright></Copyright>
     <LangVersion>11</LangVersion>
     <ApplicationIcon></ApplicationIcon>
-    <PackageReleaseNotes>- added setters for IChart.Axes.ValueAxis.Minumum/Maximum
-- added `ISeriesCollection.RemoveAt(int index)
-- added `ITable.RemoveColumnAt(int columnIndex)
-- fixed updating text of the grouped shape</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixed bug where ISlideCollection.Add() doesn't copy placeholder shapes</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/ShapeCrawler/ShapeCrawler</PackageProjectUrl>
     <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
     <RepositoryType>Git</RepositoryType>
@@ -24,10 +21,10 @@ This library provides a simplified object model on top of the Open XML SDK for m
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <AssemblyVersion>0.45.0</AssemblyVersion>
-    <FileVersion>0.45.0</FileVersion>
+    <AssemblyVersion>0.45.1</AssemblyVersion>
+    <FileVersion>0.45.1</FileVersion>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
-    <PackageVersion>0.45.0</PackageVersion>
+    <PackageVersion>0.45.1</PackageVersion>
     <Title>ShapeCrawler</Title>
     <Configurations>Debug;Release</Configurations>
     <Platforms>AnyCPU</Platforms>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `CHANGELOG.md` and `ShapeCrawler.csproj` files to reflect version 0.45.1 of the ShapeCrawler library. Notable changes include fixing a bug with `ISlideCollection.Add()` and adding setters for `IChart.Axes.ValueAxis.Minumum/Maximum`.

### Detailed summary
- Fixed bug where `ISlideCollection.Add()` doesn't copy placeholder shapes
- Added setters for `IChart.Axes.ValueAxis.Minumum/Maximum`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->