### PR TITLE
fix adding a new slide

### DIFF
--- a/src/ShapeCrawler/Collections/ISlideCollection.cs
+++ b/src/ShapeCrawler/Collections/ISlideCollection.cs
@@ -189,7 +189,7 @@ internal sealed class SCSlideCollection : ISlideCollection
         var tempStream = new MemoryStream();
         if (sourceSlideInternal.Presentation == this.presentation)
         {
-            this.presentation.ChartWorkbooks.ForEach(c=>c.Close());
+            this.presentation.ChartWorkbooks.ForEach(c => c.Close());
             sourcePresDoc = (PresentationDocument)this.presentation.SDKPresentationInternal.Clone(tempStream);
         }
         else

--- a/src/ShapeCrawler/Collections/ISlideCollection.cs
+++ b/src/ShapeCrawler/Collections/ISlideCollection.cs
@@ -189,6 +189,7 @@ internal sealed class SCSlideCollection : ISlideCollection
         var tempStream = new MemoryStream();
         if (sourceSlideInternal.Presentation == this.presentation)
         {
+            this.presentation.ChartWorkbooks.ForEach(c=>c.Close());
             sourcePresDoc = (PresentationDocument)this.presentation.SDKPresentationInternal.Clone(tempStream);
         }
         else

--- a/src/ShapeCrawler/ShapeCrawler.csproj
+++ b/src/ShapeCrawler/ShapeCrawler.csproj
@@ -24,7 +24,7 @@ This library provides a simplified object model on top of the Open XML SDK for m
     <AssemblyVersion>0.45.1</AssemblyVersion>
     <FileVersion>0.45.1</FileVersion>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
-    <PackageVersion>0.45.2-beta.1</PackageVersion>
+    <PackageVersion>0.45.2-beta.2</PackageVersion>
     <Title>ShapeCrawler</Title>
     <Configurations>Debug;Release</Configurations>
     <Platforms>AnyCPU</Platforms>

--- a/test/ShapeCrawler.Tests.Unit/SlideCollectionTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/SlideCollectionTests.cs
@@ -88,6 +88,23 @@ public class SlideCollectionTests : SCTest
         // Assert
         pres.Slides.Count.Should().Be(expectedSlidesCount);
     }
+    
+    [Test]
+    public void Add_adds_slide_After_updating_chart_series()
+    {
+        // Arrange
+        var pptx = TestHelper.GetStream("charts_bar-chart.pptx");
+        var pres = SCPresentation.Open(pptx);
+        var chart = pres.Slides[0].Shapes.GetByName<IChart>("Bar Chart 1");
+        var expectedSlidesCount = pres.Slides.Count + 1;
+
+        // Act
+        chart.SeriesCollection[0].Points[0].Value = 1;
+        pres.Slides.Add(pres.Slides[0]);
+        
+        // Assert
+        pres.Slides.Count.Should().Be(expectedSlidesCount);
+    }
 
     [Fact]
     public void Add_add_adds_New_slide()


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces changes related to adding a new slide after updating chart series. 

### Detailed summary
- Close chart workbooks before cloning presentation document to avoid file locking.
- Update `ShapeCrawler` package version to `0.45.2-beta.2`.
- Add unit test to validate addition of new slide after updating chart series.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->