### PR TITLE
Bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog  
 
-## Version 0.45.2 - Unreleased
+## Version 0.45.2 - 2023-06-18
 🐞Fixed bug in `IPresentation.BinaryData` [#515](https://github.com/ShapeCrawler/ShapeCrawler/issues/515)
 
 ## Version 0.45.1 - 2023-05-18

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ How can you contribute?
 
 # Changelog  
 
-## Version 0.45.1 - 2023-05-18
-🐞Fixed bug where `ISlideCollection.Add()` doesn't copy placeholder shapes [#508](https://github.com/ShapeCrawler/ShapeCrawler/issues/508)
+## Version 0.45.2 - 2023-06-18
+🐞Fixed bug in `IPresentation.BinaryData` [#515](https://github.com/ShapeCrawler/ShapeCrawler/issues/515)
 
 Visit [CHANGELOG.md](https://github.com/ShapeCrawler/ShapeCrawler/blob/master/CHANGELOG.md) to see the full log.
 

--- a/src/ShapeCrawler/ShapeCrawler.csproj
+++ b/src/ShapeCrawler/ShapeCrawler.csproj
@@ -21,10 +21,10 @@ This library provides a simplified object model on top of the Open XML SDK for m
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <AssemblyVersion>0.45.1</AssemblyVersion>
-    <FileVersion>0.45.1</FileVersion>
+    <AssemblyVersion>0.45.2</AssemblyVersion>
+    <FileVersion>0.45.2</FileVersion>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
-    <PackageVersion>0.45.2-beta.2</PackageVersion>
+    <PackageVersion>0.45.2</PackageVersion>
     <Title>ShapeCrawler</Title>
     <Configurations>Debug;Release</Configurations>
     <Platforms>AnyCPU</Platforms>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the version number and fixes a bug in `IPresentation.BinaryData`. 

### Detailed summary
- Updates the version number to 0.45.2
- Fixes a bug in `IPresentation.BinaryData`
- Removes the `-beta.2` suffix from the package version

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->