### PR TITLE
Remove nodes in `CommonSlideData` when add an empty slide from a layout.

### DIFF
--- a/src/ShapeCrawler/Collections/ISlideCollection.cs
+++ b/src/ShapeCrawler/Collections/ISlideCollection.cs
@@ -144,7 +144,7 @@ internal sealed class SCSlideCollection : ISlideCollection
                     ShapeProperties = new P.ShapeProperties()
                 });
 
-            slidePart.Slide.CommonSlideData = new P.CommonSlideData(placeholderShapes)
+            slidePart.Slide.CommonSlideData = new P.CommonSlideData()
             {
                 ShapeTree = new P.ShapeTree(placeholderShapes)
                 {

--- a/src/ShapeCrawler/Collections/ISlideCollection.cs
+++ b/src/ShapeCrawler/Collections/ISlideCollection.cs
@@ -136,11 +136,7 @@ internal sealed class SCSlideCollection : ISlideCollection
                         (P.NonVisualShapeProperties)shape.NonVisualShapeProperties!.CloneNode(true),
 
                     // Creates a new TextBody with no content.
-                    TextBody = new P.TextBody(new[] { new A.Paragraph(new A.EndParagraphRunProperties()) })
-                    {
-                        BodyProperties = new A.BodyProperties(),
-                        ListStyle = new A.ListStyle()
-                    },
+                    TextBody = ResolveTextBody(shape),
                     ShapeProperties = new P.ShapeProperties()
                 });
 
@@ -153,6 +149,21 @@ internal sealed class SCSlideCollection : ISlideCollection
                         (P.NonVisualGroupShapeProperties)shapeTree.NonVisualGroupShapeProperties!.CloneNode(true)
                 }
             };
+        }
+
+        static P.TextBody ResolveTextBody(P.Shape shape)
+        {
+            // Creates a new TextBody
+            if (shape.TextBody is null)
+            {
+                return new P.TextBody(new OpenXmlElement[] { new A.Paragraph(new OpenXmlElement[] { new A.EndParagraphRunProperties() }) })
+                {
+                    BodyProperties = new A.BodyProperties(),
+                    ListStyle = new A.ListStyle(),
+                };
+            }
+
+            return (P.TextBody)shape.TextBody.CloneNode(true);
         }
 
         var pSlideIdList = this.presPart.Presentation.SlideIdList!;


### PR DESCRIPTION
I found a problem in the `SCSlideCollection.AddEmptySlide(ISlideLayout)`. It copies all placeholders in the layout, but the constructor of `CommonSlideData` has the placeholder, but must to be in the `ShapeTree`.

Sorry for the delay of new commits :blush: