### PR TITLE
Fix updating table height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Version 0.46.0 - Unreleased
 🍀Added setters for `IPresentation.SlideHeight/SlideWidth` [#522](https://github.com/ShapeCrawler/ShapeCrawler/issues/522)  
 🍀Added `IShapeCollection.Add()` [#264](https://github.com/ShapeCrawler/ShapeCrawler/issues/264)  
-🐞Fixed `ISlide.Number` setter
+🐞Fixed `ISlide.Number` setter  
+🐞Fixed updating height of table row [#532](https://github.com/ShapeCrawler/ShapeCrawler/issues/532)
 
 ## Version 0.45.3 - 2023-06-24
 🐞Fixed updating Hyperlink [#518](https://github.com/ShapeCrawler/ShapeCrawler/issues/518)

--- a/src/ShapeCrawler/PowerPoint/SCShape.cs
+++ b/src/ShapeCrawler/PowerPoint/SCShape.cs
@@ -69,7 +69,7 @@ internal abstract class SCShape : IShape
 
     public int Height
     {
-        get => this.GetHeightPixels();
+        get => this.GetHeight();
         set => this.SetHeight(value);
     }
 
@@ -286,7 +286,7 @@ internal abstract class SCShape : IShape
         return UnitConverter.HorizontalEmuToPixel(aExtents.Cx!);
     }
 
-    private int GetHeightPixels()
+    private int GetHeight()
     {
         var aExtents = this.PShapeTreeChild.Descendants<A.Extents>().FirstOrDefault();
         if (aExtents == null)

--- a/src/ShapeCrawler/ShapeCrawler.csproj
+++ b/src/ShapeCrawler/ShapeCrawler.csproj
@@ -21,10 +21,10 @@ This library provides a simplified object model on top of the Open XML SDK for m
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <AssemblyVersion>0.45.3</AssemblyVersion>
-    <FileVersion>0.45.3</FileVersion>
+    <AssemblyVersion>0.46.0</AssemblyVersion>
+    <FileVersion>0.46.0</FileVersion>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
-    <PackageVersion>0.46.0-beta.2</PackageVersion>
+    <PackageVersion>0.46.0-beta.3</PackageVersion>
     <Title>ShapeCrawler</Title>
     <Configurations>Debug;Release</Configurations>
     <Platforms>AnyCPU</Platforms>

--- a/src/ShapeCrawler/Tables/IRow.cs
+++ b/src/ShapeCrawler/Tables/IRow.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using ShapeCrawler.Shared;
 using A = DocumentFormat.OpenXml.Drawing;
 
 // ReSharper disable CheckNamespace
@@ -16,9 +17,9 @@ public interface IRow
     IReadOnlyList<ICell> Cells { get; }
 
     /// <summary>
-    ///     Gets or sets height.
+    ///     Gets or sets height in points.
     /// </summary>
-    long Height { get; set; }
+    int Height { get; set; }
 
     /// <summary>
     ///     Creates a duplicate of the current row and adds this at the table end.
@@ -41,10 +42,40 @@ internal sealed class SCRow : IRow
 
     public IReadOnlyList<ICell> Cells => this.cells.Value;
 
-    public long Height
+    public int Height
     {
-        get => this.ATableRow.Height!.Value;
-        set => this.ATableRow.Height!.Value = value;
+        get => this.GetHeight();
+        set => this.SetHeight(value);
+    }
+
+    private void SetHeight(int newPoints)
+    {
+        var currentPoints = this.GetHeight();
+        if (currentPoints == newPoints)
+        {
+            return;
+        }
+        
+        var newEmu = UnitConverter.PointToEmu(newPoints);
+        this.ATableRow.Height!.Value = newEmu;
+
+        if (newPoints > currentPoints)
+        {
+            var diffPoints = newPoints - currentPoints;
+            var diffPixels = (int)UnitConverter.PointToPixel(diffPoints);
+            this.ParentTable.Height += diffPixels;
+        }
+        else
+        {
+            var diffPoints = currentPoints - newPoints;
+            var diffPixels = (int)UnitConverter.PointToPixel(diffPoints);
+            this.ParentTable.Height -= diffPixels;
+        }
+    }
+
+    private int GetHeight()
+    {
+        return (int)UnitConverter.EmuToPoint((int)this.ATableRow.Height!.Value);
     }
 
     internal SCTable ParentTable { get; }

--- a/src/ShapeCrawler/Tables/IRow.cs
+++ b/src/ShapeCrawler/Tables/IRow.cs
@@ -48,6 +48,23 @@ internal sealed class SCRow : IRow
         set => this.SetHeight(value);
     }
 
+    internal SCTable ParentTable { get; }
+
+    internal A.TableRow ATableRow { get; }
+
+    public IRow Clone()
+    {
+        var clonedRow = (A.TableRow)this.ATableRow.Clone();
+        var addedRow = this.ParentTable.AppendRow(clonedRow);
+
+        return addedRow;
+    }
+    
+    private int GetHeight()
+    {
+        return (int)UnitConverter.EmuToPoint((int)this.ATableRow.Height!.Value);
+    }
+    
     private void SetHeight(int newPoints)
     {
         var currentPoints = this.GetHeight();
@@ -72,24 +89,7 @@ internal sealed class SCRow : IRow
             this.ParentTable.Height -= diffPixels;
         }
     }
-
-    private int GetHeight()
-    {
-        return (int)UnitConverter.EmuToPoint((int)this.ATableRow.Height!.Value);
-    }
-
-    internal SCTable ParentTable { get; }
-
-    internal A.TableRow ATableRow { get; }
-
-    public IRow Clone()
-    {
-        var clonedRow = (A.TableRow)this.ATableRow.Clone();
-        var addedRow = this.ParentTable.AppendRow(clonedRow);
-
-        return addedRow;
-    }
-
+    
     private List<SCCell> GetCells()
     {
         var cellList = new List<SCCell?>();

--- a/test/ShapeCrawler.Tests.Unit/TableTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/TableTests.cs
@@ -15,6 +15,7 @@ namespace ShapeCrawler.Tests.Unit;
 
 [SuppressMessage("ReSharper", "SuggestVarOrType_SimpleTypes")]
 [SuppressMessage("ReSharper", "SuggestVarOrType_BuiltInTypes")]
+[SuppressMessage("Usage", "xUnit1013:Public method should be marked as test")]
 public class TableTests : SCTest
 {
     [Xunit.Theory]
@@ -41,10 +42,10 @@ public class TableTests : SCTest
         var pres = SCPresentation.Open(pptx);
         var table = pres.Slides[0].Shapes.GetByName<ITable>("Table 1");
         var expectedColumnsCount = table.Columns.Count - 1;
-        
+
         // Act
         table.RemoveColumnAt(1);
-        
+
         // Assert
         table.Columns.Should().HaveCount(expectedColumnsCount);
         pres.SaveAs(ms);
@@ -53,7 +54,7 @@ public class TableTests : SCTest
         table.Columns.Should().HaveCount(expectedColumnsCount);
         PptxValidator.Validate(pres);
     }
-    
+
     [Fact]
     public void Rows_RemoveAt_removes_row_with_specified_index()
     {
@@ -84,18 +85,19 @@ public class TableTests : SCTest
 
         // Act
         table.Rows.Add();
-        
+
         // Assert
         table.Rows.Should().HaveCount(2);
         var errors = PptxValidator.Validate(pres);
         errors.Should().BeEmpty();
     }
-    
+
     [Fact]
     public void Row_Cells_Count_returns_number_of_cells_in_the_row()
     {
         // Arrange
-        var table = (ITable)SCPresentation.Open(GetTestStream("009_table.pptx")).Slides[2].Shapes.First(sp => sp.Id == 3);
+        var table = (ITable)SCPresentation.Open(GetTestStream("009_table.pptx")).Slides[2].Shapes
+            .First(sp => sp.Id == 3);
 
         // Act
         var cellsCount = table.Rows[0].Cells.Count;
@@ -104,19 +106,19 @@ public class TableTests : SCTest
         cellsCount.Should().Be(3);
     }
 
-    [Fact]
-    public void Row_Height_Getter_returns_height_of_row()
+    [Test]
+    public void Row_Height_Getter_returns_row_height_in_points()
     {
         // Arrange
         var pptx = GetTestStream("001.pptx");
         var pres = SCPresentation.Open(pptx);
         var table = (ITable)pres.Slides[1].Shapes.First(sp => sp.Id == 3);
-        
+
         // Act
-        var rowHeight = table.Rows[0].Height; 
+        var rowHeight = table.Rows[0].Height;
 
         // Act-Assert
-        rowHeight.Should().Be(370840);
+        rowHeight.Should().Be(29);
     }
 
     [Xunit.Theory]
@@ -133,17 +135,17 @@ public class TableTests : SCTest
     {
         var pptx = GetTestStream("001.pptx");
         var table1 = SCPresentation.Open(pptx).Slides[1].Shapes.GetById<ITable>(3);
-        yield return new object[] {table1[0, 0], table1[1, 0]};
-        
+        yield return new object[] { table1[0, 0], table1[1, 0] };
+
         var pptx2 = GetTestStream("001.pptx");
         var pres2 = SCPresentation.Open(pptx2);
         var table2 = pres2.Slides[1].Shapes.GetByName<ITable>("Table 5");
-        yield return new object[] {table2[1, 1], table2[2, 1]};
-        
+        yield return new object[] { table2[1, 1], table2[2, 1] };
+
         var pptx3 = GetTestStream("001.pptx");
         var pres3 = SCPresentation.Open(pptx3);
         var table3 = pres3.Slides[3].Shapes.GetById<ITable>(4);
-        yield return new object[] {table3[0, 1], table3[1, 1]};
+        yield return new object[] { table3[0, 1], table3[1, 1] };
     }
 
     [Fact]
@@ -192,7 +194,7 @@ public class TableTests : SCTest
         table = (ITable)pres.Slides[1].Shapes.First(sp => sp.Id == 3);
         table.Columns[0].Width.Should().Be(newColumnWidth);
     }
-    
+
     [Fact]
     public void Row_Cell_IsMergedCell_returns_True_When_cell_is_merged()
     {
@@ -205,14 +207,14 @@ public class TableTests : SCTest
 
         // Act
         var isMerged1 = cell1X0.IsMergedCell;
-        var isMerged2 = cell1X1.IsMergedCell; 
-        
+        var isMerged2 = cell1X1.IsMergedCell;
+
         // Act-Assert
         isMerged1.Should().BeTrue();
         isMerged2.Should().BeTrue();
         cell1X0.Should().BeSameAs(cell1X1);
     }
-    
+
     [Fact]
     public void Row_Clone_cloning_row_increases_row_count_by_one()
     {
@@ -221,7 +223,7 @@ public class TableTests : SCTest
         var pres = SCPresentation.Open(pptx);
         var targetTable = pres.Slides.First().Shapes.OfType<ITable>().FirstOrDefault();
         var rowCountBefore = targetTable.Rows.Count;
-        var row = targetTable.Rows.Last(); 
+        var row = targetTable.Rows.Last();
 
         // Act
         row.Clone();
@@ -231,7 +233,22 @@ public class TableTests : SCTest
         rowCountAfter.Should().Be(rowCountBefore + 1);
     }
 
-#if DEBUG
+    [Test]
+    public void Row_Height_Setter_sets_height_of_table_row_in_points()
+    {
+        // Arrange
+        var pptx = GetTestStream("table-case001.pptx");
+        var pres = SCPresentation.Open(pptx);
+        var table = pres.Slides[0].Shapes.GetByName<ITable>("Table 1");
+        var row = table.Rows[0];
+
+        // Act
+        row.Height = 58;
+
+        // Assert
+        row.Height.Should().Be(58);
+        table.Height.Should().Be(76, "because table height was 38px.");
+    }
 
     [Xunit.Theory]
     [InlineData(0, 0, 0, 1)]
@@ -298,6 +315,7 @@ public class TableTests : SCTest
         presentation = SCPresentation.Open(mStream);
         table = (ITable)presentation.Slides[2].Shapes.First(sp => sp.Id == 3);
         AssertTable(table);
+
         static void AssertTable(ITable tableSc)
         {
             tableSc[0, 1].IsMergedCell.Should().BeTrue();
@@ -383,7 +401,7 @@ public class TableTests : SCTest
             table[1, 0].TextFrame.Text.Should().Be(expectedText);
         }
     }
-    
+
     [Fact]
     public void MergeCells_merges_cells()
     {
@@ -407,10 +425,10 @@ public class TableTests : SCTest
         var table = pres.Slides[0].Shapes.AddTable(10, 10, 3, 4);
         table[1, 0].TextFrame.Text = "A";
         table[3, 0].TextFrame.Text = "B";
-        
+
         // Act
-        table.MergeCells(table[1, 0],table[2, 0]);
-        
+        table.MergeCells(table[1, 0], table[2, 0]);
+
         // Assert
         table[1, 0].TextFrame.Text.Should().Be("A");
     }
@@ -555,23 +573,23 @@ public class TableTests : SCTest
     {
         // Arrange
         var pres = SCPresentation.Open(GetTestStream("001.pptx"));
-        var table = (ITable)pres.Slides[2].Shapes.First(sp => sp.Id == 5) ;
+        var table = (ITable)pres.Slides[2].Shapes.First(sp => sp.Id == 5);
         var mStream = new MemoryStream();
         var mergedColumnWidth = table.Columns[0].Width + table.Columns[1].Width;
         var mergedRowHeight = table.Rows[0].Height + table.Rows[1].Height;
 
         // Act
-        table.MergeCells(table[0, 0], table[1,1]);
+        table.MergeCells(table[0, 0], table[1, 1]);
 
         // Assert
         AssertTable(table, mergedColumnWidth, mergedRowHeight);
 
         pres.SaveAs(mStream);
         pres = SCPresentation.Open(mStream);
-        table = (ITable)pres.Slides[2].Shapes.First(sp => sp.Id == 5) ;
+        table = (ITable)pres.Slides[2].Shapes.First(sp => sp.Id == 5);
         AssertTable(table, mergedColumnWidth, mergedRowHeight);
 
-        static void AssertTable(ITable tableSc, int expectedMergedColumnWidth, long expectedMergedRowHeight)
+        static void AssertTable(ITable tableSc, int expectedMergedColumnWidth, int expectedMergedRowHeight)
         {
             tableSc.Columns.Should().HaveCount(1);
             tableSc.Columns[0].Width.Should().Be(expectedMergedColumnWidth);
@@ -586,7 +604,7 @@ public class TableTests : SCTest
     {
         // Arrange
         var presentation = SCPresentation.Open(GetTestStream("001.pptx"));
-        var table = (ITable)presentation.Slides[3].Shapes.First(sp => sp.Id == 6) ;
+        var table = (ITable)presentation.Slides[3].Shapes.First(sp => sp.Id == 6);
         var mStream = new MemoryStream();
         var mergedColumnWidth = table.Columns[0].Width + table.Columns[1].Width;
 
@@ -598,7 +616,7 @@ public class TableTests : SCTest
 
         presentation.SaveAs(mStream);
         presentation = SCPresentation.Open(mStream);
-        table = (ITable)presentation.Slides[3].Shapes.First(sp => sp.Id == 6) ;
+        table = (ITable)presentation.Slides[3].Shapes.First(sp => sp.Id == 6);
         AssertTable(table, mergedColumnWidth);
 
         void AssertTable(ITable tableSc, int expectedMergedColumnWidth)
@@ -628,7 +646,7 @@ public class TableTests : SCTest
 
         pres.SaveAs(mStream);
         pres = SCPresentation.Open(mStream);
-        table = (ITable)pres.Slides[3].Shapes.First(sp => sp.Id == 6) ;
+        table = (ITable)pres.Slides[3].Shapes.First(sp => sp.Id == 6);
         AssertTable(table, expectedNewColumnWidth);
 
         static void AssertTable(ITable table, int expectedNewColumnWidth)
@@ -638,7 +656,7 @@ public class TableTests : SCTest
             table.Rows[0].Cells.Should().HaveCount(2);
         }
     }
-    
+
     [Fact]
     public void MergeCells_updates_columns_count()
     {
@@ -653,15 +671,15 @@ public class TableTests : SCTest
         // Assert
         table.Columns.Should().HaveCount(2);
     }
-    
-#endif
 
     [Fact]
     public void Indexer_ReturnsCellByRowAndColumnIndexes()
     {
         // Arrange
-        ITable tableCase1 = (ITable)SCPresentation.Open(GetTestStream("001.pptx")).Slides[1].Shapes.First(sp => sp.Id == 4);
-        ITable tableCase2 = (ITable)SCPresentation.Open(GetTestStream("001.pptx")).Slides[3].Shapes.First(sp => sp.Id == 4);
+        ITable tableCase1 =
+            (ITable)SCPresentation.Open(GetTestStream("001.pptx")).Slides[1].Shapes.First(sp => sp.Id == 4);
+        ITable tableCase2 =
+            (ITable)SCPresentation.Open(GetTestStream("001.pptx")).Slides[3].Shapes.First(sp => sp.Id == 4);
 
         // Act
         ICell scCellCase1 = tableCase1[0, 0];


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- The `Height` property in the `SCShape` class has been modified to use the `GetHeight()` and `SetHeight()` methods instead of `GetHeightPixels()`.
- The `IRow` interface now has an `int` type `Height` property instead of `long`.
- The `GetHeight()` and `SetHeight()` methods have been added to the `SCTable` class to handle row height calculations.
- Various unit tests have been added and modified to test the changes.

> The following files were skipped due to too many changes: `test/ShapeCrawler.Tests.Unit/TableTests.cs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->