### PR TITLE
Add support for add picture to shape collection

### DIFF
--- a/src/ShapeCrawler/Collections/IShapeCollection.cs
+++ b/src/ShapeCrawler/Collections/IShapeCollection.cs
@@ -158,7 +158,7 @@ internal sealed class ShapeCollection : IShapeCollection
         // Chart (<p:graphicFrame /> http://schemas.openxmlformats.org/drawingml/2006/chart) are not in the shape collection, data is referenced.
         // Object (<p:graphicFrame /> http://schemas.openxmlformats.org/presentationml/2006/ole) are not in the shape collection, data is referenced.
         // Alternate content(<mc:AlternateContent /> http://schemas.openxmlformats.org/officeDocument/2006/math"> are not in the shape collection, data is referenced.
-        if (shape is not SCShape scShape || shape is IOLEObject || shape is IChart || shape is IPicture || shape is IAudioShape || shape is IVideoShape)
+        if (shape is not SCShape scShape || shape is IOLEObject || shape is IChart || shape is IAudioShape || shape is IVideoShape)
         {
             throw new SCException($"{shape.GetType().Name} is not supported.");
         }
@@ -173,6 +173,11 @@ internal sealed class ShapeCollection : IShapeCollection
         if (newShape == null)
         {
             throw new SCException($"Cannot create an instancie of type {shape.GetType().Name}.");
+        }
+
+        if (newShape is SCPicture pic)
+        {
+            pic.CopyParts((SlideStructure)scShape.ParentSlideStructureOf.Value);
         }
 
         // Creates a new suffix for the new shape.

--- a/src/ShapeCrawler/Drawing/IPicture.cs
+++ b/src/ShapeCrawler/Drawing/IPicture.cs
@@ -64,26 +64,24 @@ internal sealed class SCPicture : SCShape, IPicture
             return;
         }
 
-        // Get current relationship and try to find the part in current slide.
-        var relId = this.blipEmbed.Value!;
-        var slideStructure = ((SlideStructure)this.SlideStructure);
+        // Get image source part
+        var sSlidePart = sourceSlide.TypedOpenXmlPart;
         
-        // Image part already exists.
-        if (slideStructure.TypedOpenXmlPart.TryGetPartById(relId, out var _))
+        if (sSlidePart.GetPartById(this.blipEmbed.Value!) is not ImagePart imagePart)
         {
             return;
         }
 
         // Creates a new part in this slide with a new Id...
-        var slidePart = slideStructure.TypedOpenXmlPart;
+        var slidePart = ((SlideStructure)this.SlideStructure).TypedOpenXmlPart;
         var imgPartRId = slidePart.GetNextRelationshipId();
-
-        // Get image part
-        var sSlidePart = sourceSlide.TypedOpenXmlPart;
-        var sImagePart = sSlidePart.GetPartById(relId);
-
+        
         // Adds to current slide parts and update relation id.
-        var c = slidePart.AddPart(sImagePart, imgPartRId);
+        var nImagePart = slidePart.AddNewPart<ImagePart>(imagePart.ContentType, imgPartRId);
+        using var stream = imagePart.GetStream(FileMode.Open);
+        stream.Position = 0;
+        nImagePart.FeedData(stream);
+
         this.blipEmbed.Value = imgPartRId;
     }
 


### PR DESCRIPTION
`AutoShapeCreator` works fine, but pictures requires to add the image part from source slide to the target slide.

```cs
if (newShape is SCPicture pic)
{
    pic.CopyParts((SlideStructure)scShape.ParentSlideStructureOf.Value);
}
```

This is my first approach to solve the problem, `CopyParts` copy the relationship to the target slide and update the embed value (a new relationship id is created)

```cs
var sImagePart = sSlidePart.GetPartById(relId);
var c = slidePart.AddPart(sImagePart, imgPartRId);
this.blipEmbed.Value = imgPartRId;
```

wht do you think?

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on improving the shape collection and picture handling in the ShapeCrawler library.

### Detailed summary:
- Removed unsupported shape types from the shape collection.
- Added a method to copy required parts from a source slide to a picture shape.
- Updated the picture shape class to handle copying of parts from a source slide.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->