### PR TITLE
Fix fill issue

### DIFF
--- a/ShapeCrawler.sln.DotSettings
+++ b/ShapeCrawler.sln.DotSettings
@@ -74,6 +74,7 @@
 	<s:Int64 x:Key="/Default/Environment/SearchAndNavigation/DefaultOccurrencesGroupingIndices/=JetBrains_002EPsiFeatures_002EUIInteractive_002ERefactorings_002ECommonUI_002ECommonControls_002EUsagesDescriptor/@EntryIndexedValue">12</s:Int64>
 	<s:Int64 x:Key="/Default/Environment/SearchAndNavigation/DefaultOccurrencesGroupingIndices/=JetBrains_002EReSharper_002EFeatures_002EInspections_002EAnalyzeReferences_002EAnalyzeReferencesDescriptor/@EntryIndexedValue">2</s:Int64>
 	<s:Int64 x:Key="/Default/Environment/SearchAndNavigation/DefaultOccurrencesGroupingIndices/=JetBrains_002EReSharper_002EFeatures_002EInspections_002EAnalyzeReferences_002ERemoveUnused_002EUnusedReferencesDescriptor/@EntryIndexedValue">0</s:Int64>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EApplication_002EExceptionReport_002EUserLoginInformationMigrateSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EUnitTestFramework_002EMigrations_002EEnableDisabledProvidersMigration/@EntryIndexedValue">True</s:Boolean>
 	
 	
@@ -83,7 +84,7 @@
 	<s:String x:Key="/Default/Environment/UserInterface/ShortcutSchemeName/@EntryValue">VS</s:String>
 	<s:Boolean x:Key="/Default/Housekeeping/FeatureSuggestion/FeatureSuggestionManager/DisabledSuggesters/=AutoNamingFeatureSuggester/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Housekeeping/FeatureSuggestion/FeatureSuggestionManager/DisabledSuggesters/=EditorConfigFeatureSuggester/@EntryIndexedValue">True</s:Boolean>
-	<s:String x:Key="/Default/Housekeeping/FeedbackReport/SelectedUserIdentificator/@EntryValue">anonymous</s:String>
+	
 	<s:Boolean x:Key="/Default/Housekeeping/GlobalSettingsUpgraded/IsUpgraded/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Housekeeping/IntellisenseHousekeeping/HintUsed/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/Housekeeping/Layout/DialogWindows/OptionsDialogView/Position/@EntryValue">[-31,-4](956,792)</s:String>

--- a/src/ShapeCrawler/Extensions/ShapePropertiesExtensions.cs
+++ b/src/ShapeCrawler/Extensions/ShapePropertiesExtensions.cs
@@ -24,7 +24,15 @@ internal static class ShapePropertiesExtensions
         else
         {
             aSolidFill = new A.SolidFill();
-            pShapeProperties.Append(aSolidFill);
+            var aOutline = pShapeProperties.GetFirstChild<A.Outline>();
+            if (aOutline != null)
+            {
+                pShapeProperties.InsertBefore(aSolidFill, aOutline);
+            }
+            else
+            {
+                pShapeProperties.Append(aSolidFill);
+            }
         }
         
         var aRgbColorModelHex = new A.RgbColorModelHex

--- a/test/ShapeCrawler.Tests.Unit/ShapeFillTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeFillTests.cs
@@ -80,4 +80,19 @@ public class ShapeFillTests : SCTest
         // Assert
         imageBytes.Length.Should().BePositive();
     }
+    
+    [Test]
+    public void SetColor_sets_green_color()
+    {
+        // Arrange
+        var pres = SCPresentation.Create();
+        var slide = pres.Slides[0];
+        var shape = slide.Shapes.AddRectangle(0, 0, 100, 100);
+        
+        // Act
+        shape.Fill!.SetColor("00FF00");
+
+        // Assert
+        PptxValidator.Validate(pres).Should().BeEmpty();
+    }
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of this PR:
This PR focuses on modifying the `ShapePropertiesExtensions.cs` file and adding a new test method in the `ShapeFillTests.cs` file.

### Detailed summary:
- In `ShapePropertiesExtensions.cs`:
  - Added a condition to check if `aOutline` is not null.
  - If `aOutline` is not null, `aSolidFill` is inserted before `aOutline`.
  - If `aOutline` is null, `aSolidFill` is appended to `pShapeProperties`.

- In `ShapeFillTests.cs`:
  - Added a new test method `SetColor_sets_green_color` that sets the color of a shape to green and validates the result using `PptxValidator`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->