### PR TITLE
Fix merging cells

### DIFF
--- a/src/ShapeCrawler/ShapeCrawler.csproj
+++ b/src/ShapeCrawler/ShapeCrawler.csproj
@@ -11,7 +11,7 @@ This library provides a simplified object model on top of the Open XML SDK for m
     <PackageTags>ShapeCrawler Presentation PPTX  PowerPoint Slides OpenXml OOXML</PackageTags>
     <NeutralLanguage>en</NeutralLanguage>
     <Copyright></Copyright>
-    <LangVersion>11</LangVersion>
+    <LangVersion>default</LangVersion>
     <ApplicationIcon></ApplicationIcon>
     <PackageReleaseNotes>- added setters for IParagraph.IndentLevel
 - added IParagraph.HeaderAndFooter.AddSlideNumber()</PackageReleaseNotes>
@@ -25,7 +25,7 @@ This library provides a simplified object model on top of the Open XML SDK for m
     <AssemblyVersion>0.47.0</AssemblyVersion>
     <FileVersion>0.47.0</FileVersion>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
-    <PackageVersion>0.47.1-beta.3</PackageVersion>
+    <PackageVersion>0.47.1-beta.4</PackageVersion>
     <Title>ShapeCrawler</Title>
     <Configurations>Debug;Release</Configurations>
     <Platforms>AnyCPU</Platforms>

--- a/src/ShapeCrawler/Tables/IRow.cs
+++ b/src/ShapeCrawler/Tables/IRow.cs
@@ -26,6 +26,9 @@ public interface IRow
     /// </summary>
     IRow Clone();
 
+    /// <summary>
+    ///     Returns <see cref="A.TableRow" />.
+    /// </summary>
     A.TableRow ATableRow();
 }
 

--- a/src/ShapeCrawler/Tables/IRow.cs
+++ b/src/ShapeCrawler/Tables/IRow.cs
@@ -25,6 +25,8 @@ public interface IRow
     ///     Creates a duplicate of the current row and adds this at the table end.
     /// </summary>
     IRow Clone();
+
+    A.TableRow ATableRow();
 }
 
 internal sealed class SCRow : IRow
@@ -59,7 +61,12 @@ internal sealed class SCRow : IRow
 
         return addedRow;
     }
-    
+
+    A.TableRow IRow.ATableRow()
+    {
+        return this.ATableRow;
+    }
+
     private int GetHeight()
     {
         return (int)UnitConverter.EmuToPoint((int)this.ATableRow.Height!.Value);

--- a/src/ShapeCrawler/Tables/ITable.cs
+++ b/src/ShapeCrawler/Tables/ITable.cs
@@ -119,33 +119,7 @@ internal sealed class SCTable : SCShape, ITable
 
         this.rowCollection.Reset();
     }
-
-    private void RemoveRowIfNeeded()
-    {
-        // Delete a:tr if needed
-        for (var rowIdx = 0; rowIdx < this.Rows.Count;)
-        {
-            var allRowCells = this.Rows[rowIdx].Cells.OfType<SCCell>().ToList();
-            var firstRowCell = allRowCells[0];
-            var firstRowCellSpan = firstRowCell.ATableCell.RowSpan?.Value;
-            if (firstRowCellSpan > 1 && allRowCells.All(cell => cell.ATableCell.RowSpan?.Value == firstRowCellSpan))
-            {
-                int deleteRowsCount = firstRowCellSpan.Value - 1;
-
-                foreach (var row in this.Rows.Skip(rowIdx + 1).Take(deleteRowsCount))
-                {
-                    ((SCRow)row).ATableRow.Remove();
-                    this.Rows[rowIdx].Height += row.Height;
-                }
-
-                rowIdx += firstRowCellSpan.Value;
-                continue;
-            }
-
-            rowIdx++;
-        }
-    }
-
+    
     internal override void Draw(SKCanvas canvas)
     {
         throw new NotImplementedException();
@@ -258,6 +232,32 @@ internal sealed class SCTable : SCShape, ITable
         }
 
         return false;
+    }
+    
+    private void RemoveRowIfNeeded()
+    {
+        // Delete a:tr if needed
+        for (var rowIdx = 0; rowIdx < this.Rows.Count;)
+        {
+            var allRowCells = this.Rows[rowIdx].Cells.OfType<SCCell>().ToList();
+            var firstRowCell = allRowCells[0];
+            var firstRowCellSpan = firstRowCell.ATableCell.RowSpan?.Value;
+            if (firstRowCellSpan > 1 && allRowCells.All(cell => cell.ATableCell.RowSpan?.Value == firstRowCellSpan))
+            {
+                int deleteRowsCount = firstRowCellSpan.Value - 1;
+
+                foreach (var row in this.Rows.Skip(rowIdx + 1).Take(deleteRowsCount))
+                {
+                    ((SCRow)row).ATableRow.Remove();
+                    this.Rows[rowIdx].Height += row.Height;
+                }
+
+                rowIdx += firstRowCellSpan.Value;
+                continue;
+            }
+
+            rowIdx++;
+        }
     }
     
     private void MergeVertically(int bottomIndex, int topRowIndex, List<A.TableRow> aTableRows, int leftColIndex, int rightColIndex)

--- a/src/ShapeCrawler/Tables/ITable.cs
+++ b/src/ShapeCrawler/Tables/ITable.cs
@@ -259,10 +259,13 @@ internal sealed class SCTable : SCShape, ITable
     
     private void MergeVertically(int bottomIndex, int topRowIndex, List<A.TableRow> aTableRows, int leftColIndex, int rightColIndex)
     {
-        int verticalMergingCount = bottomIndex - topRowIndex + 1;
+        var verticalMergingCount = bottomIndex - topRowIndex + 1;
     
         // Set row span value for the first cell in the merged cells
-        foreach (var aTblCell in aTableRows[topRowIndex].Elements<A.TableCell>().Skip(leftColIndex).Take(rightColIndex + 1))
+        var numMergingCells = rightColIndex == 0 ? 1 : rightColIndex;
+        var horizontalCells =
+            aTableRows[topRowIndex].Elements<A.TableCell>().Skip(leftColIndex).Take(numMergingCells);
+        foreach (var aTblCell in horizontalCells)
         {
             aTblCell.RowSpan = new Int32Value(verticalMergingCount);
         }

--- a/test/ShapeCrawler.Tests.Unit/TableTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/TableTests.cs
@@ -2,7 +2,6 @@ using System.Diagnostics.CodeAnalysis;
 using FluentAssertions;
 using NUnit.Framework;
 using ShapeCrawler.Tests.Unit.Helpers;
-using Xunit;
 using A = DocumentFormat.OpenXml.Drawing;
 
 namespace ShapeCrawler.Tests.Unit;
@@ -201,7 +200,7 @@ public class TableTests : SCTest
         table.Height.Should().Be(76, "because table height was 38px.");
     }
 
-    [Fact(DisplayName = "MergeCells #1")]
+    [Test]
     public void MergeCells_Merges0x0And0x1CellsOf2x2Table()
     {
         // Arrange
@@ -225,7 +224,7 @@ public class TableTests : SCTest
         table[0, 0].TextFrame.Text.Should().Be($"id5{Environment.NewLine}Text0_1");
     }
 
-    [Fact(DisplayName = "MergeCells #2")]
+    [Test]
     public void MergeCells_Merges0x1And0x2CellsOf3x2Table()
     {
         // Arrange
@@ -252,7 +251,7 @@ public class TableTests : SCTest
         }
     }
 
-    [Fact(DisplayName = "MergeCells #3")]
+    [Test]
     public void MergeCells_Merges0x0And0x1And0x2CellsOf3x2Table()
     {
         // Arrange
@@ -276,7 +275,7 @@ public class TableTests : SCTest
         table[0, 2].IsMergedCell.Should().BeTrue();
     }
 
-    [Fact(DisplayName = "MergeCells #4")]
+    [Test]
     public void MergeCells_Merges0x0And0x1MergedCellsWith0x2CellIn3x2Table()
     {
         // Arrange
@@ -300,7 +299,7 @@ public class TableTests : SCTest
         table[0, 2].IsMergedCell.Should().BeTrue();
     }
 
-    [Fact(DisplayName = "MergeCells #5")]
+    [Test]
     public void MergeCells_merges_0x0_and_1x0_cells_of_2x2_table()
     {
         // Arrange
@@ -360,7 +359,7 @@ public class TableTests : SCTest
         table[1, 0].TextFrame.Text.Should().Be("A");
     }
 
-    [Fact(DisplayName = "MergeCells #6")]
+    [Test]
     public void MergeCells_Merges0x1And1x1CellsOf3x2Table()
     {
         // Arrange
@@ -384,7 +383,7 @@ public class TableTests : SCTest
         table[0, 0].IsMergedCell.Should().BeFalse();
     }
 
-    [Fact(DisplayName = "MergeCells #7")]
+    [Test]
     public void MergeCells_Merges0x0To1x1RangeOf3x3Table()
     {
         // Arrange
@@ -468,7 +467,7 @@ public class TableTests : SCTest
         table[0, 2].IsMergedCell.Should().BeFalse();
     }
 
-    [Fact(DisplayName = "MergeCells #8")]
+    [Test]
     public void MergeCells_converts_2X1_table_into_1X1_when_all_cells_are_merged()
     {
         // Arrange
@@ -495,12 +494,13 @@ public class TableTests : SCTest
         table.Rows[0].Cells.Should().HaveCount(1);
     }
 
-    [Fact(DisplayName = "MergeCells #9")]
+    [Test]
     public void MergeCells_converts_2X2_table_into_1X1_when_all_cells_are_merged()
     {
         // Arrange
-        var pres = SCPresentation.Open(GetInputStream("001.pptx"));
-        var table = (ITable)pres.Slides[2].Shapes.First(sp => sp.Id == 5);
+        var pptx = GetInputStream("001.pptx");
+        var pres = SCPresentation.Open(pptx);
+        var table = pres.Slides[2].Shapes.GetByName<ITable>("Table 5");
         var mStream = new MemoryStream();
         var mergedColumnWidth = table.Columns[0].Width + table.Columns[1].Width;
         var mergedRowHeight = table.Rows[0].Height + table.Rows[1].Height;
@@ -513,20 +513,20 @@ public class TableTests : SCTest
 
         pres.SaveAs(mStream);
         pres = SCPresentation.Open(mStream);
-        table = (ITable)pres.Slides[2].Shapes.First(sp => sp.Id == 5);
+        table = pres.Slides[2].Shapes.GetByName<ITable>("Table 5");
         AssertTable(table, mergedColumnWidth, mergedRowHeight);
 
-        static void AssertTable(ITable tableSc, int expectedMergedColumnWidth, int expectedMergedRowHeight)
+        static void AssertTable(ITable table, int expectedMergedColumnWidth, int expectedMergedRowHeight)
         {
-            tableSc.Columns.Should().HaveCount(1);
-            tableSc.Columns[0].Width.Should().Be(expectedMergedColumnWidth);
-            tableSc.Rows.Should().HaveCount(1);
-            tableSc.Rows[0].Cells.Should().HaveCount(1);
-            tableSc.Rows[0].Height.Should().Be(expectedMergedRowHeight);
+            table.Columns.Should().HaveCount(1);
+            table.Columns[0].Width.Should().Be(expectedMergedColumnWidth);
+            table.Rows.Should().HaveCount(1);
+            table.Rows[0].Cells.Should().HaveCount(1);
+            table.Rows[0].Height.Should().Be(expectedMergedRowHeight);
         }
     }
 
-    [Fact(DisplayName = "MergeCells #10")]
+    [Test]
     public void MergeCells_merges_0x0_And_0x1_cells_in_3x1_table()
     {
         // Arrange
@@ -555,7 +555,7 @@ public class TableTests : SCTest
         }
     }
 
-    [Fact(DisplayName = "MergeCells #11")]
+    [Test]
     public void MergeCells_merges_0x1_and_0x2_cells()
     {
         // Arrange
@@ -658,7 +658,6 @@ public class TableTests : SCTest
         
         // Act
         table.MergeCells(table[0, 1], table[1, 1]);
-        pres.Save();
 
         // Assert
         var aTableRow = table.Rows[0].ATableRow();

--- a/test/ShapeCrawler.Tests.Unit/TableTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/TableTests.cs
@@ -1,17 +1,9 @@
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.Linq;
 using FluentAssertions;
 using NUnit.Framework;
-using ShapeCrawler.Drawing;
-using ShapeCrawler.Tests.Shared;
 using ShapeCrawler.Tests.Unit.Helpers;
-using ShapeCrawler.Tests.Unit.Helpers.Attributes;
 using Xunit;
-using Xunit.Abstractions;
-using Assert = Xunit.Assert;
+using A = DocumentFormat.OpenXml.Drawing;
 
 namespace ShapeCrawler.Tests.Unit;
 
@@ -654,5 +646,22 @@ public class TableTests : SCTest
         
         // Assert
         table[1, 1].Should().BeSameAs(table[1, 2]);
+    }
+
+    [Test]
+    public void MergeCells_merges_0x1_and_1x1()
+    {
+        // Arrange
+        var pres = SCPresentation.Create();
+        var slide = pres.Slides[0];
+        var table = slide.Shapes.AddTable(0, 0, 4, 2);
+        
+        // Act
+        table.MergeCells(table[0, 1], table[1, 1]);
+        pres.Save();
+
+        // Assert
+        var aTableRow = table.Rows[0].ATableRow();
+        aTableRow.Elements<A.TableCell>().ToList()[2].RowSpan.Should().BeNull();
     }
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR focuses on improving the merging functionality of table cells in the ShapeCrawler library.

### Detailed summary:
- Added a new method `RemoveRowIfNeeded()` to remove unnecessary rows in the table.
- Refactored the logic for merging cells vertically.
- Added a new test case to validate the merging of cells in a table.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->