### PR TITLE
Fix slide background updating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog  
 
+## Version 0.48.1 - Unreleased
+🐞Fixed an issue with Slide Background updating [#577](https://github.com/ShapeCrawler/ShapeCrawler/issues/577)  
+
 ## Version 0.48.0 - 2023-08-19
 🍀Added new properties: `IShapeFill.AlphaPercentage`, `IShapeFill.LuminanceModulationPercentage` and `IShapeFill.LuminanceOffsetPercentage` to the in shape filling object [#567](https://github.com/ShapeCrawler/ShapeCrawler/issues/567)   
 🍀Added a new property: `Shape.Rotation` to the shape object  

--- a/src/ShapeCrawler/Drawing/IImage.cs
+++ b/src/ShapeCrawler/Drawing/IImage.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
+using ShapeCrawler.Drawing;
 using ShapeCrawler.Shapes;
 using A = DocumentFormat.OpenXml.Drawing;
 
@@ -53,7 +54,7 @@ internal sealed class SCImage : IImage
     private readonly OpenXmlPart openXmlPart;
     private byte[]? bytes;
 
-    private SCImage(
+    internal SCImage(
         ImagePart imagePart,
         StringValue blipEmbed,
         OpenXmlPart openXmlPart,
@@ -111,19 +112,19 @@ internal sealed class SCImage : IImage
         return new SCImage(imagePart, blipEmbed, openXmlPart, slideStructureCore.PresentationInternal);
     }
 
-    internal static SCImage? ForBackground(SCSlide slide)
+    internal static IImage ForBackground(SCSlide slide)
     {
         var pBackground = slide.SDKSlidePart.Slide.CommonSlideData!.Background;
         if (pBackground == null)
         {
-            return null;
+            return new NoBackground(slide);
         }
 
         var aBlipFill = pBackground.Descendants<A.BlipFill>().SingleOrDefault();
         var picReference = aBlipFill?.Blip?.Embed;
         if (picReference == null)
         {
-            return null;
+            return new NoBackground(slide);
         }
 
         var imagePart = (ImagePart)slide.SDKSlidePart.GetPartById(picReference.Value!);

--- a/src/ShapeCrawler/Drawing/NoBackground.cs
+++ b/src/ShapeCrawler/Drawing/NoBackground.cs
@@ -20,8 +20,11 @@ internal class NoBackground : IImage
     }
 
     public string MIME => this.image.Value.MIME;
+
     public Task<byte[]> BinaryData => this.image.Value.BinaryData;
+
     public string Name => this.image.Value.Name;
+
     public void SetImage(Stream stream)
     {
         this.image.Value.SetImage(stream);
@@ -45,35 +48,13 @@ internal class NoBackground : IImage
                 new A.BlipFill(
                     new A.Blip { Embed = rId })));
         this.slide.SDKSlidePart.Slide.CommonSlideData!.InsertAt(pBackground, 0);
-        
-        // this.slide.SDKSlidePart.AddNewPart<ImagePart>("image/png", rId);
-        // this.blipEmbed.Value = rId;
-        
-        // // var pBackground = slide.SDKSlidePart.Slide.CommonSlideData!.Background;
-        // if (pBackground == null)
-        // {
-        //     return new NoBackground(slide);
-        // }
 
         var aBlipFill = pBackground.Descendants<A.BlipFill>().SingleOrDefault();
         var picReference = aBlipFill?.Blip?.Embed!;
 
-        // var imagePart = (ImagePart)this.slide.SDKSlidePart.GetPartById(picReference.Value!);
         var imagePart = this.slide.SDKSlidePart.AddNewPart<ImagePart>("image/png", rId);
         var backgroundImage = new SCImage(imagePart, picReference, this.slide.SDKSlidePart, this.slide.PresentationInternal);
 
         return backgroundImage;
-        
-        // var isSharedImagePart = this.presentation.ImageParts.Count(imgPart => imgPart == this.SDKImagePart) > 1;
-        // if (isSharedImagePart)
-        // {
-        //     var rId = $"rId-{Guid.NewGuid().ToString("N").Substring(0, 5)}";
-        //     this.SDKImagePart = this.openXmlPart.AddNewPart<ImagePart>("image/png", rId);
-        //     this.blipEmbed.Value = rId;
-        // }
-        //
-        // stream.Position = 0;
-        // this.SDKImagePart.FeedData(stream);
-        // this.bytes = null; // to reset cache
     }
 }

--- a/src/ShapeCrawler/Drawing/NoBackground.cs
+++ b/src/ShapeCrawler/Drawing/NoBackground.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using DocumentFormat.OpenXml.Packaging;
+using A = DocumentFormat.OpenXml.Drawing;
+using P = DocumentFormat.OpenXml.Presentation;
+
+namespace ShapeCrawler.Drawing;
+
+internal class NoBackground : IImage
+{
+    private readonly SCSlide slide;
+    private readonly Lazy<SCImage> image;
+
+    public NoBackground(SCSlide slide)
+    {
+        this.slide = slide;
+        this.image = new Lazy<SCImage>(this.CreateImage);
+    }
+
+    public string MIME => this.image.Value.MIME;
+    public Task<byte[]> BinaryData => this.image.Value.BinaryData;
+    public string Name => this.image.Value.Name;
+    public void SetImage(Stream stream)
+    {
+        this.image.Value.SetImage(stream);
+    }
+
+    public void SetImage(byte[] bytes)
+    {
+        this.image.Value.SetImage(bytes);
+    }
+
+    public void SetImage(string filePath)
+    {
+        this.image.Value.SetImage(filePath);
+    }
+    
+    private SCImage CreateImage()
+    {
+        var rId = $"rId-{Guid.NewGuid().ToString("N").Substring(0, 5)}";
+        var pBackground = new P.Background(
+            new P.BackgroundProperties(
+                new A.BlipFill(
+                    new A.Blip { Embed = rId })));
+        this.slide.SDKSlidePart.Slide.CommonSlideData!.InsertAt(pBackground, 0);
+        
+        // this.slide.SDKSlidePart.AddNewPart<ImagePart>("image/png", rId);
+        // this.blipEmbed.Value = rId;
+        
+        // // var pBackground = slide.SDKSlidePart.Slide.CommonSlideData!.Background;
+        // if (pBackground == null)
+        // {
+        //     return new NoBackground(slide);
+        // }
+
+        var aBlipFill = pBackground.Descendants<A.BlipFill>().SingleOrDefault();
+        var picReference = aBlipFill?.Blip?.Embed!;
+
+        // var imagePart = (ImagePart)this.slide.SDKSlidePart.GetPartById(picReference.Value!);
+        var imagePart = this.slide.SDKSlidePart.AddNewPart<ImagePart>("image/png", rId);
+        var backgroundImage = new SCImage(imagePart, picReference, this.slide.SDKSlidePart, this.slide.PresentationInternal);
+
+        return backgroundImage;
+        
+        // var isSharedImagePart = this.presentation.ImageParts.Count(imgPart => imgPart == this.SDKImagePart) > 1;
+        // if (isSharedImagePart)
+        // {
+        //     var rId = $"rId-{Guid.NewGuid().ToString("N").Substring(0, 5)}";
+        //     this.SDKImagePart = this.openXmlPart.AddNewPart<ImagePart>("image/png", rId);
+        //     this.blipEmbed.Value = rId;
+        // }
+        //
+        // stream.Position = 0;
+        // this.SDKImagePart.FeedData(stream);
+        // this.bytes = null; // to reset cache
+    }
+}

--- a/src/ShapeCrawler/Presentation/ISlide.cs
+++ b/src/ShapeCrawler/Presentation/ISlide.cs
@@ -12,9 +12,9 @@ namespace ShapeCrawler;
 public interface ISlide : ISlideStructure
 {
     /// <summary>
-    ///     Gets background image if it exist, otherwise <see langword="null"/>.
+    ///     Gets background image.
     /// </summary>
-    IImage? Background { get; }
+    IImage Background { get; }
 
     /// <summary>
     ///     Gets or sets custom data. It returns <see langword="null"/> if custom data is not presented.

--- a/src/ShapeCrawler/Presentation/SCSlide.cs
+++ b/src/ShapeCrawler/Presentation/SCSlide.cs
@@ -21,7 +21,7 @@ namespace ShapeCrawler;
 internal sealed class SCSlide : SlideStructure, ISlide
 {
     private readonly ResetAbleLazy<ShapeCollection> shapes;
-    private readonly Lazy<SCImage?> backgroundImage;
+    private readonly Lazy<IImage> backgroundImage;
     private Lazy<CustomXmlPart?> customXmlPart;
 
     internal SCSlide(SCPresentation pres, SlidePart slidePart, SlideId slideId)
@@ -30,7 +30,7 @@ internal sealed class SCSlide : SlideStructure, ISlide
         this.Presentation = pres;
         this.SDKSlidePart = slidePart;
         this.shapes = new ResetAbleLazy<ShapeCollection>(() => new ShapeCollection(this.SDKSlidePart, this));
-        this.backgroundImage = new Lazy<SCImage?>(() => SCImage.ForBackground(this));
+        this.backgroundImage = new Lazy<IImage>(() => SCImage.ForBackground(this));
         this.customXmlPart = new Lazy<CustomXmlPart?>(this.GetSldCustomXmlPart);
         this.SlideId = slideId;
     }

--- a/src/ShapeCrawler/ShapeCrawler.csproj
+++ b/src/ShapeCrawler/ShapeCrawler.csproj
@@ -27,7 +27,7 @@ This library provides a simplified object model on top of the Open XML SDK for m
     <AssemblyVersion>0.48.0</AssemblyVersion>
     <FileVersion>0.48.0</FileVersion>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
-    <PackageVersion>0.48.0</PackageVersion>
+    <PackageVersion>0.48.1-beta.1</PackageVersion>
     <Title>ShapeCrawler</Title>
     <Configurations>Debug;Release</Configurations>
     <Platforms>AnyCPU</Platforms>

--- a/test/ShapeCrawler.Tests.Unit/SlideTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/SlideTests.cs
@@ -18,7 +18,7 @@ namespace ShapeCrawler.Tests.Unit;
 [SuppressMessage("Usage", "xUnit1013:Public method should be marked as test")]
 public class SlideTests : SCTest
 {
-    [Fact]
+    [Test]
     public void Hide_MethodHidesSlide_WhenItIsExecuted()
     {
         // Arrange
@@ -33,7 +33,7 @@ public class SlideTests : SCTest
         slide.Hidden.Should().Be(true);
     }
 
-    [Fact]
+    [Test]
     public void Hidden_GetterReturnsTrue_WhenTheSlideIsHidden()
     {
         // Arrange
@@ -48,8 +48,8 @@ public class SlideTests : SCTest
         hidden.Should().BeTrue();
     }
 
-    [Fact]
-    public async void Background_SetImage_updates_background()
+    [Test]
+    public async Task Background_SetImage_updates_background()
     {
         // Arrange
         var pptx = GetInputStream("009_table.pptx");
@@ -66,20 +66,37 @@ public class SlideTests : SCTest
         bytesAfter.Length.Should().NotBe(bytesBefore.Length);
     }
 
-    [Fact]
+    [Test]
+    public void Background_SetImage_updates_background_of_new_slide()
+    {
+        // Arrange
+        var pres = SCPresentation.Create();
+        var slide = pres.Slides.AddEmptySlide(SCSlideLayoutType.Blank);
+        var bgImage = GetInputStream("test-image-2.png");
+        
+        // Act
+        slide.Background.SetImage(bgImage);
+        
+        // Assert
+        slide.Background.Should().NotBeNull();
+    }
+
+    [Test]
     public void Background_ImageIsNull_WhenTheSlideHasNotBackground()
     {
         // Arrange
-        var slide = SCPresentation.Open(GetInputStream("009_table.pptx")).Slides[1];
+        var pptx = GetInputStream("009_table.pptx");
+        var pres = SCPresentation.Open(pptx);
+        var slide = pres.Slides[1];
 
         // Act
-        var backgroundImage = slide.Background;
+        var backgroundContent = slide.Background.BinaryData.Result;
 
         // Assert
-        backgroundImage.Should().BeNull();
+        backgroundContent.Should().BeEmpty();
     }
 
-    [Fact]
+    [Test]
     public void CustomData_ReturnsData_WhenCustomDataWasAssigned()
     {
         // Arrange
@@ -99,7 +116,7 @@ public class SlideTests : SCTest
         customData.Should().Be(customDataString);
     }
 
-    [Fact]
+    [Test]
     public void CustomData_PropertyIsNull_WhenTheSlideHasNotCustomData()
     {
         // Arrange
@@ -112,7 +129,7 @@ public class SlideTests : SCTest
         sldCustomData.Should().BeNull();
     }
 
-    [Fact]
+    [Test]
     public void Number_Setter_moves_slide_to_specified_number_position()
     {
         // Arrange
@@ -136,7 +153,7 @@ public class SlideTests : SCTest
         slide2.Number.Should().Be(2);
     }
 
-    [Fact]
+    [Test]
     public void Number_Setter()
     {
         // Arrange
@@ -150,7 +167,7 @@ public class SlideTests : SCTest
         slide.Number.Should().Be(1);
     }
 
-    [Fact]
+    [Test]
     public void GetAllTextboxes_contains_all_textboxes_withTable()
     {
         // Arrange
@@ -165,7 +182,7 @@ public class SlideTests : SCTest
         textboxes.Count.Should().Be(11);
     }
 
-    [Fact]
+    [Test]
     public void GetAllTextboxes_contains_all_textboxes_withoutTable()
     {
         // Arrange
@@ -194,7 +211,7 @@ public class SlideTests : SCTest
         slide.SaveAsPng(mStream);
     }
     
-    [Fact]
+    [Test]
     public void ToHTML_converts_slide_to_HTML()
     {
         // Arrange


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR focuses on improving the handling of slide background images in the ShapeCrawler library.

### Detailed summary:
- Updated the `ISlide` interface to remove the nullable annotation for the `Background` property.
- Updated the `ShapeCrawler.csproj` file to update the package version to `0.48.1-beta.1`.
- Added a new class `NoBackground` to handle slides without a background image.
- Modified the `SCSlide` class to use the `NoBackground` class for slides without a background image.
- Added new tests for setting and retrieving slide background images.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->