### PR TITLE
Bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog  
 
-## Version 0.49.0 - Unreleased
-🍀Added new `enum SCAudioType` to be able to add audio shape with different types [#579](https://github.com/ShapeCrawler/ShapeCrawler/issues/579)  
+## Version 0.49.0 - 2023-09-12
+🍀Added new `SCAudioType` to be able to add audio shape with different types [#579](https://github.com/ShapeCrawler/ShapeCrawler/issues/579)  
 🐞Fixed an issue with Slide Background updating [#577](https://github.com/ShapeCrawler/ShapeCrawler/issues/577)  
 
 ## Version 0.48.0 - 2023-08-19

--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ How can you contribute?
 
 # Changelog  
 
-## Version 0.47.0 - 2023-07-26
-🍀Added setters for `IParagraph.IndentLevel`  
-🍀Added `IParagraph.HeaderAndFooter.AddSlideNumber()`
+## Version 0.49.0 - 2023-09-12
+🍀Added new `SCAudioType` to be able to add audio shape with different types [#579](https://github.com/ShapeCrawler/ShapeCrawler/issues/579)  
+🐞Fixed an issue with Slide Background updating [#577](https://github.com/ShapeCrawler/ShapeCrawler/issues/577)
 
 Visit [CHANGELOG.md](https://github.com/ShapeCrawler/ShapeCrawler/blob/master/CHANGELOG.md) to see the full log.
 

--- a/src/ShapeCrawler/ShapeCrawler.csproj
+++ b/src/ShapeCrawler/ShapeCrawler.csproj
@@ -25,7 +25,7 @@ This library provides a simplified object model on top of the Open XML SDK for m
     <AssemblyVersion>0.49.0</AssemblyVersion>
     <FileVersion>0.49.0</FileVersion>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
-    <PackageVersion>0.49.0-beta.1</PackageVersion>
+    <PackageVersion>0.49.0</PackageVersion>
     <Title>ShapeCrawler</Title>
     <Configurations>Debug;Release</Configurations>
     <Platforms>AnyCPU</Platforms>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the version number and adding a new `SCAudioType` to the ShapeCrawler library. 

### Detailed summary
- Updated the `PackageVersion` in the ShapeCrawler project file from `0.49.0-beta.1` to `0.49.0`.
- Added a new `SCAudioType` to allow adding audio shapes with different types.
- Fixed an issue with Slide Background updating.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->