### PR TITLE
Add `IPath` interface to store `XPath` infomation

### DIFF
--- a/src/ShapeCrawler/Extensions/CompositeElementExtensions.cs
+++ b/src/ShapeCrawler/Extensions/CompositeElementExtensions.cs
@@ -34,4 +34,6 @@ internal static class CompositeElementExtensions
             _ => throw new SCException()
         };
     }
+
+    internal static string GetXPath(this OpenXmlCompositeElement compositeElement) => new XmlPath(compositeElement).XPath;
 }

--- a/src/ShapeCrawler/Shapes/IPath.cs
+++ b/src/ShapeCrawler/Shapes/IPath.cs
@@ -1,4 +1,5 @@
-﻿namespace ShapeCrawler.Shapes;
+﻿// ReSharper disable CheckNamespace
+namespace ShapeCrawler;
 
 /// <summary>
 ///     Represents path information of the shape.

--- a/src/ShapeCrawler/Shapes/IPath.cs
+++ b/src/ShapeCrawler/Shapes/IPath.cs
@@ -1,0 +1,12 @@
+﻿namespace ShapeCrawler.Shapes;
+
+/// <summary>
+///     Represents path information of the shape.
+/// </summary>
+public interface IPath
+{
+    /// <summary>
+    ///     Gets the shape's XPath in the slide.
+    /// </summary>
+    public string SDKXPath { get; }
+}

--- a/src/ShapeCrawler/Shapes/IShape.cs
+++ b/src/ShapeCrawler/Shapes/IShape.cs
@@ -8,7 +8,7 @@ namespace ShapeCrawler;
 /// <summary>
 ///     Represents a shape on a slide.
 /// </summary>
-public interface IShape
+public interface IShape : IPath
 {
     /// <summary>
     ///     Gets or sets x-coordinate of the upper-left corner of the shape.

--- a/src/ShapeCrawler/Shapes/SCShape.cs
+++ b/src/ShapeCrawler/Shapes/SCShape.cs
@@ -39,6 +39,7 @@ internal abstract class SCShape : IShape
     public int Id => (int)this.PShapeTreeChild.GetNonVisualDrawingProperties().Id!.Value;
 
     public string Name => this.PShapeTreeChild.GetNonVisualDrawingProperties().Name!;
+    public string SDKXPath => this.PShapeTreeChild.GetXPath();
 
     public bool Hidden =>
         this.DefineHidden(); // TODO: the Shape is inherited by LayoutShape, hence do we need this property?

--- a/src/ShapeCrawler/Shapes/SCShape.cs
+++ b/src/ShapeCrawler/Shapes/SCShape.cs
@@ -39,6 +39,7 @@ internal abstract class SCShape : IShape
     public int Id => (int)this.PShapeTreeChild.GetNonVisualDrawingProperties().Id!.Value;
 
     public string Name => this.PShapeTreeChild.GetNonVisualDrawingProperties().Name!;
+
     public string SDKXPath => this.PShapeTreeChild.GetXPath();
 
     public bool Hidden =>

--- a/src/ShapeCrawler/Texts/ITextFrame.cs
+++ b/src/ShapeCrawler/Texts/ITextFrame.cs
@@ -6,7 +6,9 @@ using System.Text;
 using DocumentFormat.OpenXml;
 using ShapeCrawler.Constants;
 using ShapeCrawler.Exceptions;
+using ShapeCrawler.Extensions;
 using ShapeCrawler.Services;
+using ShapeCrawler.Shapes;
 using ShapeCrawler.Shared;
 using ShapeCrawler.Texts;
 using SkiaSharp;
@@ -17,7 +19,7 @@ namespace ShapeCrawler;
 /// <summary>
 ///     Represents a text frame.
 /// </summary>
-public interface ITextFrame
+public interface ITextFrame : IPath
 {
     /// <summary>
     ///     Gets collection of paragraphs.
@@ -89,6 +91,7 @@ internal sealed class SCTextFrame : ITextFrame
     internal event Action? TextChanged;
 
     public IParagraphCollection Paragraphs => this.paragraphs.Value;
+    public string SDKXPath => this.TextBodyElement.GetXPath();
 
     public string Text
     {

--- a/src/ShapeCrawler/Texts/ITextFrame.cs
+++ b/src/ShapeCrawler/Texts/ITextFrame.cs
@@ -8,7 +8,6 @@ using ShapeCrawler.Constants;
 using ShapeCrawler.Exceptions;
 using ShapeCrawler.Extensions;
 using ShapeCrawler.Services;
-using ShapeCrawler.Shapes;
 using ShapeCrawler.Shared;
 using ShapeCrawler.Texts;
 using SkiaSharp;
@@ -91,6 +90,7 @@ internal sealed class SCTextFrame : ITextFrame
     internal event Action? TextChanged;
 
     public IParagraphCollection Paragraphs => this.paragraphs.Value;
+    
     public string SDKXPath => this.TextBodyElement.GetXPath();
 
     public string Text


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding the `SDKXPath` property to the `IShape` and `ITextFrame` interfaces, and implementing it in the corresponding classes. 

### Detailed summary
- Added `SDKXPath` property to `IShape` interface.
- Added `SDKXPath` property to `ITextFrame` interface.
- Implemented `SDKXPath` property in `SCShape` and `SCTextFrame` classes.
- Added `GetXPath` extension method to `CompositeElementExtensions` class.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->