### PR TITLE
Update version and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog  
 
-## Version 0.50.0 - Unreleased
+## Version 0.50.1 - 2023-12-08
 🍀Added `IShape.SDKPath` to store the XPath of the underlying Open XML element [#592](https://github.com/ShapeCrawler/ShapeCrawler/issues/592)  
 
 ## Version 0.49.0 - 2023-09-12

--- a/README.md
+++ b/README.md
@@ -85,11 +85,9 @@ If you encounter an issue, report the bug on the [issue](https://github.com/Shap
 ### Code contributing
 Pull Requests are welcome! Please read the [Contribution Guide](https://github.com/ShapeCrawler/ShapeCrawler/blob/master/CONTRIBUTING.md) for more details.
 
+## Changelog  
 
-# Changelog  
-
-## Version 0.49.0 - 2023-09-12
-🍀Added new `SCAudioType` to be able to add audio shape with different types [#579](https://github.com/ShapeCrawler/ShapeCrawler/issues/579)  
-🐞Fixed an issue with Slide Background updating [#577](https://github.com/ShapeCrawler/ShapeCrawler/issues/577)
+### Version 0.50.1 - 2023-12-08
+🍀Added `IShape.SDKPath` to store the XPath of the underlying Open XML element [#592](https://github.com/ShapeCrawler/ShapeCrawler/issues/592)  
 
 Visit [CHANGELOG.md](https://github.com/ShapeCrawler/ShapeCrawler/blob/master/CHANGELOG.md) to see the full log.

--- a/src/ShapeCrawler/ShapeCrawler.csproj
+++ b/src/ShapeCrawler/ShapeCrawler.csproj
@@ -10,8 +10,7 @@ This library provides a simplified object model on top of the Open XML SDK for m
     <PackageTags>ShapeCrawler Presentation PPTX  PowerPoint Slides OpenXml OOXML</PackageTags>
     <NeutralLanguage>en</NeutralLanguage>
     <LangVersion>default</LangVersion>
-    <PackageReleaseNotes>- added new enum SCAudioType to be able to add audio shape with different types
-- fixed an issue with Slide Background updating</PackageReleaseNotes>
+    <PackageReleaseNotes>Added IShape.SDKPath to store the XPath of the underlying Open XML element.</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/ShapeCrawler/ShapeCrawler</PackageProjectUrl>
     <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
     <RepositoryType>Git</RepositoryType>


### PR DESCRIPTION
The latest version (0.50.1) details have been updated in CHANGELOG.md and README.md. This version introduces `IShape.SDKPath` to store the XPath of the underlying Open XML element. The project release notes in ShapeCrawler.csproj have also been updated accordingly to reflect this change.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new feature `IShape.SDKPath` to store the XPath of the underlying Open XML element. 

### Detailed summary
- Added `IShape.SDKPath` to store the XPath of the underlying Open XML element.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->