### PR TITLE
Update GitHub workflows and .NET testing

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -11,7 +11,7 @@ jobs:
     name: Publish beta
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Generate version with timestamp
         id: versioning

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,28 +7,32 @@ on:
   workflow_dispatch:
 
 jobs:  
+
+  test-net472:
+    name: Test on .NET Framework 4.7.2
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test on .NET Framework 4.7.2
+        run: dotnet test -c Release -f net472
+
   test-net48:
     name: Test on .NET Framework 4.8
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Restore packages
-        run: dotnet restore      
-      - name: Test on net48
+      - uses: actions/checkout@v4      
+      - name: Test on .NET Framework 4.8
         run: dotnet test -c Release -f net48
   
   publish-package:
+    needs: [test-net472, test-net48]
     name: Publish package
     runs-on: windows-latest
-    needs: [test-net48]
-    if: needs.test-net48.result == 'success'
     steps:
-      - uses: actions/checkout@v3
-      - name: Restore packages
-        run: dotnet restore
-      - name: Test on net7.0
-        run: dotnet test -c Release -f net7.0 --no-restore --verbosity normal
+      - uses: actions/checkout@v4
+      - name: Test on .NET 8
+        run: dotnet test -c Release -f net8.0 --no-restore --verbosity normal
       - name: Create the package
-        run: dotnet pack --configuration Release
+        run: dotnet pack --configuration Release /p:Version=${{ vars.VERSION }}
       - name: Publish the package to nuget.org      
         run: dotnet nuget push -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json "src\ShapeCrawler\bin\Release\*.nupkg"


### PR DESCRIPTION
This update includes several changes to our GitHub workflows and CI/CD pipeline. Specifically, the GitHub actions are updated to use checkout@v4 from checkout@v3. Additionally, we've introduced testing on .NET Framework 4.7.2 in the pipeline. The dependency between jobs in the release workflow has also been modified to depend on both test-net472 and test-net48 jobs

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the GitHub Actions workflow and adding tests for .NET Framework 4.7.2 and 4.8. 

### Detailed summary
- Updated `actions/checkout` to version 4 in `.github/workflows/beta.yml` and `.github/workflows/release.yml`
- Added a new job `test-net472` to test on .NET Framework 4.7.2
- Added a new job `test-net48` to test on .NET Framework 4.8
- Updated the `publish-package` job to use the new test jobs as dependencies
- Updated the `publish-package` job to test on .NET 8 instead of net7.0
- Added the `/p:Version=${{ vars.VERSION }}` flag to the `dotnet pack` command

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->