### PR TITLE
Update test strategy on Github Actions workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,26 +6,21 @@ on:
       - 'v*'
   workflow_dispatch:
 
-jobs:  
-
-  test-net472:
-    name: Test on .NET Framework 4.7.2
+jobs:
+  
+  test:
+    name: Test on .NET Framework ${{ matrix.framework_version }}
     runs-on: windows-latest
+    strategy:
+      matrix:
+        framework_version: [ 'net472', 'net48' ]
     steps:
       - uses: actions/checkout@v4
-      - name: Test on .NET Framework 4.7.2
-        run: dotnet test -c Release -f net472
+      - name: Test
+        run: dotnet test -c Release -f ${{ matrix.framework_version }}
 
-  test-net48:
-    name: Test on .NET Framework 4.8
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4      
-      - name: Test on .NET Framework 4.8
-        run: dotnet test -c Release -f net48
-  
   publish-package:
-    needs: [test-net472, test-net48]
+    needs: test
     name: Publish package
     runs-on: windows-latest
     steps:
@@ -34,5 +29,5 @@ jobs:
         run: dotnet test -c Release -f net8.0 --no-restore --verbosity normal
       - name: Create the package
         run: dotnet pack --configuration Release /p:Version=${{ vars.VERSION }}
-      - name: Publish the package to nuget.org      
+      - name: Publish the package to nuget.org
         run: dotnet nuget push -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json "src\ShapeCrawler\bin\Release\*.nupkg"

--- a/test/ShapeCrawler.Tests.Unit.xUnit/ShapeCrawler.Tests.Unit.xUnit.csproj
+++ b/test/ShapeCrawler.Tests.Unit.xUnit/ShapeCrawler.Tests.Unit.xUnit.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-    <TargetFrameworks>net8.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;netstandard2.0;net472</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/ShapeCrawler.Tests.Unit/ShapeCrawler.Tests.Unit.csproj
+++ b/test/ShapeCrawler.Tests.Unit/ShapeCrawler.Tests.Unit.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-    <TargetFrameworks>net8.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;netstandard2.0;net472</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This commit simplifies and consolidates the testing strategy within the Github Actions workflow for .Net framework versions. The tests have been combined into a single matrix job, easing the run on different .Net frameworks. Additionally, the target frameworks in the test projects have been adjusted to include `netstandard2.0` and `net472`.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the target frameworks for the test projects and modifying the workflow to test on different .NET Framework versions.

### Detailed summary
- Updated the target frameworks for the test projects to include netstandard2.0 and net472.
- Modified the workflow to test on different .NET Framework versions using a matrix strategy.
- Renamed the job for testing on .NET Framework 4.7.2 to "Test".
- Updated the "dotnet test" command in the workflow to use the matrix framework version.
- Removed the separate job for testing on .NET Framework 4.8.
- Updated the "needs" dependency in the "publish-package" job to depend on the "test" job.
- Removed the unused steps related to creating and publishing the package.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->