### PR TITLE
Add guidance on submitting confidential files in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Give a star⭐ if you find this useful, please give it a star to show your suppo
 ### Bug Report
 If you encounter an issue, report the bug on the [issue](https://github.com/ShapeCrawler/ShapeCrawler/issues) page.
 
+To be able to reproduce a bug, it's often necessary to have the original presentation file attached to the issue description. If this file contains confidential data and cannot be shared publicly, you can securely send it to theadamo86@gmail.com. We assure you that only the maintainer will access this file, and it will not be shared publicly.
+
 ### Code contributing
 Pull Requests are welcome! Please read the [Contribution Guide](https://github.com/ShapeCrawler/ShapeCrawler/blob/master/CONTRIBUTING.md) for more details.
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Give a star⭐ if you find this useful, please give it a star to show your suppo
 ### Bug Report
 If you encounter an issue, report the bug on the [issue](https://github.com/ShapeCrawler/ShapeCrawler/issues) page.
 
-To be able to reproduce a bug, it's often necessary to have the original presentation file attached to the issue description. If this file contains confidential data and cannot be shared publicly, you can securely send it to theadamo86@gmail.com. We assure you that only the maintainer will access this file, and it will not be shared publicly.
+To be able to reproduce a bug, it's often necessary to have the original presentation file attached to the issue description. If this file contains confidential data and cannot be shared publicly, you can securely send it to theadamo86@gmail.com. Of course, if your security policy allow this. We assure you that only the maintainer will access this file, and it will not be shared publicly.
 
 ### Code contributing
 Pull Requests are welcome! Please read the [Contribution Guide](https://github.com/ShapeCrawler/ShapeCrawler/blob/master/CONTRIBUTING.md) for more details.


### PR DESCRIPTION
This commit adds a paragraph in the Bug Report section of README. Explaining steps to submit the original presentation file for reproducing a bug, it gives a process for secure submission while maintaining data confidentiality.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a section to the README.md file explaining how to securely share confidential presentation files for bug reproduction.

### Detailed summary
- Added a new section to the README.md file.
- Explained the process of securely sharing confidential presentation files.
- Provided an email address to send the files to.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->