### PR TITLE
Fix `Memory stream is not expandable`

### DIFF
--- a/src/ShapeCrawler/Presentations/PresentationCore.cs
+++ b/src/ShapeCrawler/Presentations/PresentationCore.cs
@@ -18,8 +18,17 @@ internal sealed class PresentationCore
     private readonly SlideSize slideSize;
 
     internal PresentationCore(byte[] bytes)
-        : this(new MemoryStream(bytes))
     {
+        var stream = new MemoryStream();
+        stream.Write(bytes, 0, bytes.Length);
+        stream.Position = 0;
+        this.sdkPresDocument = PresentationDocument.Open(stream, true);
+        var sdkMasterParts = this.sdkPresDocument.PresentationPart!.SlideMasterParts;
+        this.SlideMasters = new SlideMasterCollection(sdkMasterParts);
+        this.Sections = new Sections(this.sdkPresDocument);
+        this.Slides = new Slides(this.sdkPresDocument.PresentationPart!.SlideParts);
+        this.Footer = new Footer(this);
+        this.slideSize = new SlideSize(this.sdkPresDocument.PresentationPart!.Presentation.SlideSize!);
     }
 
     internal PresentationCore(Stream stream)

--- a/src/ShapeCrawler/ShapeCollection/GroupedShapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/GroupedShapes.cs
@@ -28,7 +28,11 @@ internal sealed class GroupedShapes : IShapes
     
     public T GetById<T>(int id) where T : IShape => (T)this.GroupedShapesCore().First(shape => shape.Id == id);
     
+    public T? TryGetById<T>(int id) where T : IShape => (T?)this.GroupedShapesCore().FirstOrDefault(shape => shape.Id == id);
+    
     T IShapes.GetByName<T>(string name) => (T)this.GroupedShapesCore().First(shape => shape.Name == name);
+    
+    T? IShapes.TryGetByName<T>(string name) where T : default => (T?)this.GroupedShapesCore().FirstOrDefault(shape => shape.Name == name);
     
     public IShape GetByName(string name) => this.GroupedShapesCore().First(shape => shape.Name == name);
     

--- a/src/ShapeCrawler/ShapeCollection/IShapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/IShapes.cs
@@ -15,10 +15,22 @@ public interface IShapes : IReadOnlyList<IShape>
     T GetById<T>(int id) where T : IShape;
 
     /// <summary>
+    ///     Tries to get shape by identifier, returns null if shape is not found.
+    /// </summary>
+    /// <typeparam name="T">Shape type.</typeparam>
+    T? TryGetById<T>(int id) where T : IShape;
+
+    /// <summary>
     ///     Gets shape by name.
     /// </summary>
     /// <typeparam name="T">Shape type.</typeparam>
     T GetByName<T>(string name) where T : IShape;
+    
+    /// <summary>
+    ///     Tries to get shape by name, returns null if shape is not found.
+    /// </summary>
+    /// <typeparam name="T">Shape type.</typeparam>
+    T? TryGetByName<T>(string name) where T : IShape;
 
     /// <summary>
     ///     Gets shape by name.

--- a/src/ShapeCrawler/ShapeCollection/Shapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/Shapes.cs
@@ -29,11 +29,11 @@ internal sealed class Shapes : IShapes
     
     public T GetById<T>(int id) where T : IShape => (T)this.ShapesCore().First(shape => shape.Id == id);
     
-    public T? TryGetById<T>(int id) where T : IShape => (T?)this.ShapesCore().FirstOrDefault(shape => shape?.Id == id, null);
+    public T? TryGetById<T>(int id) where T : IShape => (T?)this.ShapesCore().FirstOrDefault(shape => shape.Id == id);
     
     public T GetByName<T>(string name) where T : IShape => (T)this.GetByName(name);
     
-    public T? TryGetByName<T>(string name) where T : IShape => (T?)this.ShapesCore().FirstOrDefault(shape => shape?.Name == name, null);
+    public T? TryGetByName<T>(string name) where T : IShape => (T?)this.ShapesCore().FirstOrDefault(shape => shape.Name == name);
     
     public IShape GetByName(string name) => this.ShapesCore().First(shape => shape.Name == name);
     

--- a/src/ShapeCrawler/ShapeCollection/Shapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/Shapes.cs
@@ -29,7 +29,11 @@ internal sealed class Shapes : IShapes
     
     public T GetById<T>(int id) where T : IShape => (T)this.ShapesCore().First(shape => shape.Id == id);
     
+    public T? TryGetById<T>(int id) where T : IShape => (T?)this.ShapesCore().FirstOrDefault(shape => shape?.Id == id, null);
+    
     public T GetByName<T>(string name) where T : IShape => (T)this.GetByName(name);
+    
+    public T? TryGetByName<T>(string name) where T : IShape => (T?)this.ShapesCore().FirstOrDefault(shape => shape?.Name == name, null);
     
     public IShape GetByName(string name) => this.ShapesCore().First(shape => shape.Name == name);
     

--- a/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
@@ -432,7 +432,11 @@ internal sealed class SlideShapes : ISlideShapes
     
     public T GetById<T>(int id) where T : IShape => this.shapes.GetById<T>(id);
     
+    public T? TryGetById<T>(int id) where T : IShape => this.shapes.TryGetById<T>(id);
+    
     public T GetByName<T>(string name) where T : IShape => this.shapes.GetByName<T>(name);
+    
+    public T? TryGetByName<T>(string name) where T : IShape => this.shapes.TryGetByName<T>(name);
     
     public IShape GetByName(string name) => this.shapes.GetByName(name);
     

--- a/test/ShapeCrawler.Tests.Unit.xUnit/Helpers/SCTest.cs
+++ b/test/ShapeCrawler.Tests.Unit.xUnit/Helpers/SCTest.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Reflection;
 using ClosedXML.Excel;
+using NUnit.Framework;
 
 namespace ShapeCrawler.Tests.Unit.Helpers;
 

--- a/test/ShapeCrawler.Tests.Unit.xUnit/ShapeTests.cs
+++ b/test/ShapeCrawler.Tests.Unit.xUnit/ShapeTests.cs
@@ -137,4 +137,76 @@ public class ShapeTests : SCTest
         yield return new object[] { shapeCase1, Geometry.Rectangle };
         yield return new object[] { shapeCase2, Geometry.Ellipse };
     }
+    
+    public static IEnumerable<object[]> TestCasesGetShapeById()
+    {
+        yield return new object[]
+        {
+            "054_get_shape_xpath.pptx", 0, 1, null
+        };
+        yield return new object[]
+        {
+            "054_get_shape_xpath.pptx", 0, 2, "Title 1"
+        };
+        yield return new object[]
+        {
+            "054_get_shape_xpath.pptx", 0, 3, "SubTitle 2"
+        };
+        yield return new object[]
+        {
+            "054_get_shape_xpath.pptx", 0, 4, null
+        };
+    }
+
+    [Theory]
+    [MemberData(nameof(TestCasesGetShapeById))]
+    public void TryGetSlideShapeById(string presentationName, int slideNumber, int shapeId, string? expectedShapeName)
+    {
+        // Arrange
+        var pres = new Presentation(StreamOf(presentationName));
+        var slide = pres.Slides[slideNumber];
+        var shape = slide.Shapes.TryGetById<IShape>(shapeId);
+
+        // Act
+        var shapeName = shape?.Name;
+
+        // Assert
+        shapeName.Should().Be(expectedShapeName);
+    }
+
+    public static IEnumerable<object[]> TestCasesGetShapeByName()
+    {
+        yield return new object[]
+        {
+            "054_get_shape_xpath.pptx", 0, "Foo", null
+        };
+        yield return new object[]
+        {
+            "054_get_shape_xpath.pptx", 0, "Title 1", 2
+        };
+        yield return new object[]
+        {
+            "054_get_shape_xpath.pptx", 0, "SubTitle 2", 3
+        };
+        yield return new object[]
+        {
+            "054_get_shape_xpath.pptx", 0, "Bar", null
+        };
+    }
+
+    [Theory]
+    [MemberData(nameof(TestCasesGetShapeByName))]
+    public void TryGetSlideShapeByName(string presentationName, int slideNumber, string shapeName,int? expectedShapeId)
+    {
+        // Arrange
+        var pres = new Presentation(StreamOf(presentationName));
+        var slide = pres.Slides[slideNumber];
+        var shape = slide.Shapes.TryGetByName<IShape>(shapeName);
+
+        // Act
+        var shapeId = shape?.Id;
+
+        // Assert
+        shapeId.Should().Be(expectedShapeId);
+    }
 }

--- a/test/ShapeCrawler.Tests.Unit/ShapeTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeTests.cs
@@ -430,4 +430,42 @@ public class ShapeTests : SCTest
         // Assert
         placeholderType.Should().Be(expectedType);
     }
+
+    [Test]
+    [TestCase("054_get_shape_xpath.pptx", 1, 1, null)]
+    [TestCase("054_get_shape_xpath.pptx", 1, 2, "Title 1")]
+    [TestCase("054_get_shape_xpath.pptx", 1, 3, "SubTitle 2")]
+    [TestCase("054_get_shape_xpath.pptx", 1, 4, null)]
+    public void TryGetSlideShapeById(string presentationName,int slideNumber, int shapeId, string? expectedShapeName)
+    {
+        // Arrange
+        var pres = new Presentation(StreamOf(presentationName));
+        var slide = pres.Slides[slideNumber - 1];
+        var shape = slide.Shapes.TryGetById<IShape>(shapeId);
+
+        // Act
+        var shapeName = shape?.Name;
+
+        // Assert
+        shapeName.Should().Be(expectedShapeName);
+    }
+    
+    [Test]
+    [TestCase("054_get_shape_xpath.pptx", 1, "Foo", null)]
+    [TestCase("054_get_shape_xpath.pptx", 1, "Title 1", 2)]
+    [TestCase("054_get_shape_xpath.pptx", 1, "SubTitle 2", 3)]
+    [TestCase("054_get_shape_xpath.pptx", 1, "Bar", null)]
+    public void TryGetSlideShapeByName(string presentationName, int slideNumber, string shapeName, int? expectedShapeId)
+    {
+        // Arrange
+        var pres = new Presentation(StreamOf(presentationName));
+        var slide = pres.Slides[slideNumber - 1];
+        var shape = slide.Shapes.TryGetByName<IShape>(shapeName);
+
+        // Act
+        var shapeId = shape?.Id;
+
+        // Assert
+        shapeId.Should().Be(expectedShapeId);
+    }
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces new methods `TryGetById` and `TryGetByName` to safely retrieve shapes by ID or name, returning null if not found. It also adds test cases for these methods.

### Detailed summary
- Added `TryGetById` and `TryGetByName` methods in `SlideShapes`, `Shapes`, and `IShapes` classes.
- Updated corresponding test cases in `ShapeTests.cs` to test the new methods.
- Modified the `PresentationCore` constructor to handle byte array input.


> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->