### PR TITLE
Fix `Memory stream is not expandable`

### DIFF
--- a/src/ShapeCrawler/Presentations/PresentationCore.cs
+++ b/src/ShapeCrawler/Presentations/PresentationCore.cs
@@ -18,8 +18,17 @@ internal sealed class PresentationCore
     private readonly SlideSize slideSize;
 
     internal PresentationCore(byte[] bytes)
-        : this(new MemoryStream(bytes))
     {
+        var stream = new MemoryStream();
+        stream.Write(bytes, 0, bytes.Length);
+        stream.Position = 0;
+        this.sdkPresDocument = PresentationDocument.Open(stream, true);
+        var sdkMasterParts = this.sdkPresDocument.PresentationPart!.SlideMasterParts;
+        this.SlideMasters = new SlideMasterCollection(sdkMasterParts);
+        this.Sections = new Sections(this.sdkPresDocument);
+        this.Slides = new Slides(this.sdkPresDocument.PresentationPart!.SlideParts);
+        this.Footer = new Footer(this);
+        this.slideSize = new SlideSize(this.sdkPresDocument.PresentationPart!.Presentation.SlideSize!);
     }
 
     internal PresentationCore(Stream stream)


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR improves the initialization process in `PresentationCore` by allowing the constructor to accept both byte array and stream inputs.

### Detailed summary
- Updated `PresentationCore` constructor to accept both byte array and stream inputs for initializing a PowerPoint presentation.
- Improved memory handling by creating a `MemoryStream` object for byte array input.
- Updated initialization of `sdkPresDocument` using the provided stream.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->