### PR TITLE
Update condition for SkiaSharp error test

### DIFF
--- a/test/ShapeCrawler.Tests.Unit/TextFrameTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/TextFrameTests.cs
@@ -79,7 +79,7 @@ namespace ShapeCrawler.Tests.Unit.xUnit
             textFrame.Text.Should().Contain("confirm that");
         }
 
-#if !NET48 // SkiaSharp throws error "Attempted to read or write protected memory. This is often an indication that other memory is corrupt."
+#if !NET472 && !NET48 // SkiaSharp throws error "Attempted to read or write protected memory. This is often an indication that other memory is corrupt."
         [Test]
         public void Text_Setter_updates_text_box_content_and_Reduces_font_size_When_text_is_Overflow()
         {


### PR DESCRIPTION
The condition under which the SkiaSharp error test is not run has been extended to include .NET 4.72 in addition to .NET 4.8. This is due to the fact that SkiaSharp may throw a protected memory access error on these versions.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the conditional compilation in `TextFrameTests.cs` to exclude .NET 4.7.2 in addition to .NET 4.8 to prevent SkiaSharp memory error. 

### Detailed summary
- Updated conditional compilation to exclude .NET 4.7.2 in `TextFrameTests.cs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->