### PR TITLE
Update `IShape.AsTable()` method and related documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog  
 
+## Version 0.50.3 - 2024-03-06
+🐞Fixed `IShape.AsTable()`
+
 ## Version 0.50.2 - 2024-03-04
 🐞Fixed slide adding
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Pull Requests are welcome! Please read the [Contribution Guide](https://github.c
 
 ## Changelog  
 
-### Version 0.50.2 - 2024-03-04
-🐞Fixed slide adding
+### Version 0.50.3 - 2024-03-06
+🐞Fixed `IShape.AsTable()`
 
 Visit [CHANGELOG.md](https://github.com/ShapeCrawler/ShapeCrawler/blob/master/CHANGELOG.md) to see the full log.

--- a/src/ShapeCrawler/ShapeCrawler.csproj
+++ b/src/ShapeCrawler/ShapeCrawler.csproj
@@ -10,7 +10,7 @@ This library provides a simplified object model on top of the Open XML SDK for m
     <PackageTags>ShapeCrawler Presentation PPTX  PowerPoint Slides OpenXml OOXML</PackageTags>
     <NeutralLanguage>en</NeutralLanguage>
     <LangVersion>default</LangVersion>
-    <PackageReleaseNotes>Added IShape.SDKPath to store the XPath of the underlying Open XML element.</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixed IShape.AsTable()</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/ShapeCrawler/ShapeCrawler</PackageProjectUrl>
     <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
     <RepositoryType>Git</RepositoryType>

--- a/src/ShapeCrawler/Tables/ITable.cs
+++ b/src/ShapeCrawler/Tables/ITable.cs
@@ -270,6 +270,7 @@ internal sealed class Table : CopyableShape, ITable
             if (topColumnCellSpan > 1 && sameGridSpan)
             {
                 var deleteColumnCount = topColumnCellSpan.Value - 1;
+                
                 // Delete a:gridCol elements and append width of deleting column to merged column
                 for (int i = 0; i < deleteColumnCount; i++)
                 {
@@ -277,6 +278,7 @@ internal sealed class Table : CopyableShape, ITable
                     column.AGridColumn.Remove();
                     this.Columns[colIdx].Width += column.Width;
                 }
+                
                 // Delete a:tc elements
                 foreach (var aTblRow in aTableRows)
                 {
@@ -286,6 +288,7 @@ internal sealed class Table : CopyableShape, ITable
                         aTblCell.Remove();
                     }
                 }
+                
                 colIdx += topColumnCellSpan.Value;
             }
             else

--- a/src/ShapeCrawler/Tables/ITable.cs
+++ b/src/ShapeCrawler/Tables/ITable.cs
@@ -124,7 +124,9 @@ internal sealed class Table : CopyableShape, ITable
     }
 
     public override void Remove() => this.pGraphicFrame.Remove();
-    
+
+    public override ITable AsTable() => this;
+
     internal void Draw(SKCanvas canvas)
     {
         throw new NotImplementedException();

--- a/src/ShapeCrawler/Tables/ITable.cs
+++ b/src/ShapeCrawler/Tables/ITable.cs
@@ -243,12 +243,11 @@ internal sealed class Table : CopyableShape, ITable
             foreach (A.TableCell aTblCell in nextMergingCells)
             {
                 aTblCell.HorizontalMerge = new BooleanValue(true);
-
                 this.MergeParagraphs(minRowIndex, minColIndex, aTblCell);
             }
         }
     }
-
+    
     private IReadOnlyList<SCColumn> GetColumnList()
     {
         IEnumerable<A.GridColumn> aGridColumns = this.ATable.TableGrid!.Elements<A.GridColumn>();
@@ -260,8 +259,8 @@ internal sealed class Table : CopyableShape, ITable
 
     private void RemoveColumnIfNeeded(List<A.TableRow> aTableRows)
     {
-        // Delete a:gridCol and a:tc elements if all columns are merged
-        for (var colIdx = 0; colIdx < this.Columns.Count;)
+        int colIdx = 0;
+        while (colIdx < this.Columns.Count)
         {
             var topColumnCell = ((TableRow)this.Rows[0]).ATableRow.Elements<A.TableCell>().ToList()[colIdx];
             var topColumnCellSpan = topColumnCell.GridSpan?.Value;
@@ -271,7 +270,6 @@ internal sealed class Table : CopyableShape, ITable
             if (topColumnCellSpan > 1 && sameGridSpan)
             {
                 var deleteColumnCount = topColumnCellSpan.Value - 1;
-
                 // Delete a:gridCol elements and append width of deleting column to merged column
                 for (int i = 0; i < deleteColumnCount; i++)
                 {
@@ -279,7 +277,6 @@ internal sealed class Table : CopyableShape, ITable
                     column.AGridColumn.Remove();
                     this.Columns[colIdx].Width += column.Width;
                 }
-
                 // Delete a:tc elements
                 foreach (var aTblRow in aTableRows)
                 {
@@ -289,7 +286,6 @@ internal sealed class Table : CopyableShape, ITable
                         aTblCell.Remove();
                     }
                 }
-
                 colIdx += topColumnCellSpan.Value;
             }
             else

--- a/src/ShapeCrawler/Tables/ITable.cs
+++ b/src/ShapeCrawler/Tables/ITable.cs
@@ -150,16 +150,17 @@ internal sealed class Table : CopyableShape, ITable
 
     private void RemoveRowIfNeeded()
     {
-        // Delete a:tr if needed
-        for (var rowIdx = 0; rowIdx < this.Rows.Count;)
+        int rowIdx = 0;
+    
+        while (rowIdx < this.Rows.Count)
         {
             var cells = this.Rows[rowIdx].Cells.OfType<TableCell>().ToList();
             var firstCell = cells[0];
             var firstCellSpan = firstCell.ATableCell.RowSpan?.Value;
+
             if (firstCellSpan > 1 && cells.All(cell => cell.ATableCell.RowSpan?.Value == firstCellSpan))
             {
                 int deleteRowsCount = firstCellSpan.Value - 1;
-
                 foreach (var row in this.Rows.Skip(rowIdx + 1).Take(deleteRowsCount))
                 {
                     ((TableRow)row).ATableRow.Remove();
@@ -167,13 +168,14 @@ internal sealed class Table : CopyableShape, ITable
                 }
 
                 rowIdx += firstCellSpan.Value;
-                continue;
             }
-
-            rowIdx++;
+            else
+            {
+                rowIdx++;
+            }
         }
     }
-
+    
     private void MergeVertically(
         int bottomIndex,
         int topRowIndex,

--- a/test/ShapeCrawler.Tests.Unit/ShapeTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeTests.cs
@@ -468,4 +468,19 @@ public class ShapeTests : SCTest
         // Assert
         shapeId.Should().Be(expectedShapeId);
     }
+    
+    [Test]
+    public void AsTable_returns_ITable()
+    {
+        // Arrange
+        var pres = new Presentation(StreamOf("table-case001.pptx"));
+        var slide = pres.Slides[0];
+        var table = slide.Shapes.GetByName<ITable>("Table 1");
+
+        // Act
+        var castingToITable = () => table.AsTable();
+
+        // Assert
+        castingToITable.Should().NotThrow();
+    }
 }


### PR DESCRIPTION
The `IShape.AsTable()` method was updated to fix a bug that caused exceptions. Corresponding unit tests were modified to validate changes. Changelog and README documentation were also updated to reflect the changes in version 0.50.3.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to fix the `IShape.AsTable()` method and update related documentation.

### Detailed summary
- Added `IShape.AsTable()` method to return `ITable`
- Updated `ShapeTests.cs` with a test for `AsTable()`
- Updated `ShapeCrawler.csproj` to reflect the fix
- Implemented `AsTable()` method in `ITable.cs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->