### PR TITLE
Refactor fields to properties in Chart and Slide classes

### DIFF
--- a/src/ShapeCrawler/Charts/IChart.cs
+++ b/src/ShapeCrawler/Charts/IChart.cs
@@ -22,6 +22,21 @@ public interface IChart : IShape
     public bool HasTitle { get; }
     
     /// <summary>
+    ///     Gets underlying instance of <see cref="DocumentFormat.OpenXml.Presentation.GraphicFrame"/>.
+    /// </summary>
+    public P.GraphicFrame SDKGraphicFrame { get; }
+    
+    /// <summary>
+    ///     Gets underlying instance of <see cref="DocumentFormat.OpenXml.Packaging.ChartPart"/>.
+    /// </summary>
+    public ChartPart SDKChartPart { get; }
+    
+    /// <summary>
+    ///     Gets underlying instance of <see cref="DocumentFormat.OpenXml.Drawing.Charts.PlotArea"/>.
+    /// </summary>
+    public C.PlotArea SDKPlotArea { get; }
+    
+    /// <summary>
     ///     Gets chart title.
     /// </summary>
     string Title { get; }
@@ -60,19 +75,4 @@ public interface IChart : IShape
     ///     Gets byte array of excel book containing chart data source.
     /// </summary>
     byte[] BookByteArray();
-    
-    /// <summary>
-    ///     Gets underlying instance of <see cref="DocumentFormat.OpenXml.Presentation.GraphicFrame"/>.
-    /// </summary>
-    public P.GraphicFrame SDKGraphicFrame { get; }
-    
-    /// <summary>
-    ///     Gets underlying instance of <see cref="DocumentFormat.OpenXml.Packaging.ChartPart"/>.
-    /// </summary>
-    public ChartPart SDKChartPart { get; }
-    
-    /// <summary>
-    ///     Gets underlying instance of <see cref="DocumentFormat.OpenXml.Drawing.Charts.PlotArea"/>.
-    /// </summary>
-    public C.PlotArea SDKPlotArea { get; }
 }

--- a/src/ShapeCrawler/Charts/IChart.cs
+++ b/src/ShapeCrawler/Charts/IChart.cs
@@ -1,4 +1,7 @@
 ﻿using System.Collections.Generic;
+using DocumentFormat.OpenXml.Packaging;
+using P = DocumentFormat.OpenXml.Presentation;
+using C = DocumentFormat.OpenXml.Drawing.Charts;
 
 // ReSharper disable once CheckNamespace
 namespace ShapeCrawler;
@@ -57,4 +60,19 @@ public interface IChart : IShape
     ///     Gets byte array of excel book containing chart data source.
     /// </summary>
     byte[] BookByteArray();
+    
+    /// <summary>
+    ///     Gets underlying instance of <see cref="DocumentFormat.OpenXml.Presentation.GraphicFrame"/>.
+    /// </summary>
+    public P.GraphicFrame SDKGraphicFrame { get; }
+    
+    /// <summary>
+    ///     Gets underlying instance of <see cref="DocumentFormat.OpenXml.Packaging.ChartPart"/>.
+    /// </summary>
+    public ChartPart SDKChartPart { get; }
+    
+    /// <summary>
+    ///     Gets underlying instance of <see cref="DocumentFormat.OpenXml.Drawing.Charts.PlotArea"/>.
+    /// </summary>
+    public C.PlotArea SDKPlotArea { get; }
 }

--- a/src/ShapeCrawler/Presentations/ISlide.cs
+++ b/src/ShapeCrawler/Presentations/ISlide.cs
@@ -32,6 +32,11 @@ public interface ISlide
     int Number { get; set; }
     
     /// <summary>
+    ///     Gets underlying instance of <see cref="DocumentFormat.OpenXml.Packaging.SlidePart"/>.
+    /// </summary>
+    SlidePart SDKSlidePart { get; }
+    
+    /// <summary>
     ///     Gets shape collection.
     /// </summary>
     ISlideShapes Shapes { get; }
@@ -61,11 +66,6 @@ public interface ISlide
     /// </summary>
     ITable TableWithName(string table);
     
-    /// <summary>
-    ///     Gets underlying instance of <see cref="DocumentFormat.OpenXml.Packaging.SlidePart"/>.
-    /// </summary>
-    SlidePart SDKSlidePart { get; }
-
 #if DEBUG
     
     /// <summary>

--- a/src/ShapeCrawler/Presentations/ISlide.cs
+++ b/src/ShapeCrawler/Presentations/ISlide.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using DocumentFormat.OpenXml.Packaging;
 #if DEBUG
 using System.Threading.Tasks;
 #endif
@@ -59,6 +60,11 @@ public interface ISlide
     ///     Gets table by name.
     /// </summary>
     ITable TableWithName(string table);
+    
+    /// <summary>
+    ///     Gets underlying instance of <see cref="DocumentFormat.OpenXml.Packaging.SlidePart"/>.
+    /// </summary>
+    SlidePart SDKSlidePart { get; }
 
 #if DEBUG
     

--- a/src/ShapeCrawler/Presentations/Slide.cs
+++ b/src/ShapeCrawler/Presentations/Slide.cs
@@ -56,7 +56,7 @@ internal sealed class Slide : ISlide
         set => this.SetCustomData(value);
     }
 
-    public bool Hidden() => this.SDKSlidePart.Slide.Show is not null && this.SDKSlidePart.Slide.Show.Value == false;
+    public bool Hidden() => this.SDKSlidePart.Slide.Show is not null && !this.SDKSlidePart.Slide.Show.Value;
 
     public void Hide()
     {

--- a/src/ShapeCrawler/Presentations/Slide.cs
+++ b/src/ShapeCrawler/Presentations/Slide.cs
@@ -19,7 +19,6 @@ namespace ShapeCrawler;
 internal sealed class Slide : ISlide
 {
     private readonly Lazy<SlideBgImage> backgroundImage;
-    private readonly SlidePart sdkSlidePart;
     private readonly SlideSize slideSize;
     private Lazy<CustomXmlPart?> sdkCustomXmlPart;
 
@@ -28,16 +27,18 @@ internal sealed class Slide : ISlide
         ISlideLayout slideLayout,
         SlideSize slideSize)
     {
-        this.sdkSlidePart = sdkSlidePart;
+        this.SDKSlidePart = sdkSlidePart;
         this.slideSize = slideSize;
         this.backgroundImage = new Lazy<SlideBgImage>(() =>
             new SlideBgImage(sdkSlidePart));
         this.sdkCustomXmlPart = new Lazy<CustomXmlPart?>(this.GetSldCustomXmlPart);
         this.SlideLayout = slideLayout;
-        this.Shapes = new SlideShapes(this.sdkSlidePart, new ShapeCollection.Shapes(sdkSlidePart));
+        this.Shapes = new SlideShapes(this.SDKSlidePart, new ShapeCollection.Shapes(sdkSlidePart));
     }
 
     public ISlideLayout SlideLayout { get; }
+    
+    public SlidePart SDKSlidePart { get; }
 
     public ISlideShapes Shapes { get; }
 
@@ -55,18 +56,18 @@ internal sealed class Slide : ISlide
         set => this.SetCustomData(value);
     }
 
-    public bool Hidden() => this.sdkSlidePart.Slide.Show is not null && this.sdkSlidePart.Slide.Show.Value == false;
+    public bool Hidden() => this.SDKSlidePart.Slide.Show is not null && this.SDKSlidePart.Slide.Show.Value == false;
 
     public void Hide()
     {
-        if (this.sdkSlidePart.Slide.Show is null)
+        if (this.SDKSlidePart.Slide.Show is null)
         {
             var showAttribute = new OpenXmlAttribute("show", string.Empty, "0");
-            this.sdkSlidePart.Slide.SetAttribute(showAttribute);
+            this.SDKSlidePart.Slide.SetAttribute(showAttribute);
         }
         else
         {
-            this.sdkSlidePart.Slide.Show = false;
+            this.SDKSlidePart.Slide.Show = false;
         }
     }
 
@@ -123,7 +124,7 @@ internal sealed class Slide : ISlide
         return returnList;
     }
     
-    internal PresentationDocument SDKPresentationDocument() => (PresentationDocument)this.sdkSlidePart.OpenXmlPackage;
+    internal PresentationDocument SDKPresentationDocument() => (PresentationDocument)this.SDKSlidePart.OpenXmlPackage;
 
     /// <summary>
     ///     Iterates group recursively and add all text boxes in the list.
@@ -150,9 +151,9 @@ internal sealed class Slide : ISlide
 
     private int ParseNumber()
     {
-        var sdkPresentationDocument = (PresentationDocument)this.sdkSlidePart.OpenXmlPackage;
+        var sdkPresentationDocument = (PresentationDocument)this.SDKSlidePart.OpenXmlPackage;
         var presentationPart = sdkPresentationDocument.PresentationPart!;
-        var currentSlidePartId = presentationPart.GetIdOfPart(this.sdkSlidePart);
+        var currentSlidePartId = presentationPart.GetIdOfPart(this.SDKSlidePart);
         var slideIdList =
             presentationPart.Presentation.SlideIdList!.ChildElements.OfType<SlideId>().ToList();
         for (int i = 0; i < slideIdList.Count; i++)
@@ -175,7 +176,7 @@ internal sealed class Slide : ISlide
 
         var currentIndex = this.Number - 1;
         var destIndex = newSlideNumber - 1;
-        var sdkPresentationDocument = (PresentationDocument)this.sdkSlidePart.OpenXmlPackage;
+        var sdkPresentationDocument = (PresentationDocument)this.SDKSlidePart.OpenXmlPackage;
         if (destIndex < 0 || currentIndex >= sdkPresentationDocument.PresentationPart!.SlideParts.Count() ||
             destIndex == currentIndex)
         {
@@ -238,7 +239,7 @@ internal sealed class Slide : ISlide
         Stream customXmlPartStream;
         if (this.sdkCustomXmlPart.Value == null)
         {
-            CustomXmlPart newSlideCustomXmlPart = this.sdkSlidePart.AddCustomXmlPart(CustomXmlPartType.CustomXml);
+            CustomXmlPart newSlideCustomXmlPart = this.SDKSlidePart.AddCustomXmlPart(CustomXmlPartType.CustomXml);
             customXmlPartStream = newSlideCustomXmlPart.GetStream();
             this.sdkCustomXmlPart = new Lazy<CustomXmlPart?>(() => newSlideCustomXmlPart);
         }
@@ -253,7 +254,7 @@ internal sealed class Slide : ISlide
 
     private CustomXmlPart? GetSldCustomXmlPart()
     {
-        foreach (CustomXmlPart customXmlPart in this.sdkSlidePart.CustomXmlParts)
+        foreach (CustomXmlPart customXmlPart in this.SDKSlidePart.CustomXmlParts)
         {
             using var customXmlPartStream = new StreamReader(customXmlPart.GetStream());
             string customXmlPartText = customXmlPartStream.ReadToEnd();


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The PR focuses on adding SDK-related properties to `ISlide` and `IChart` interfaces and updating their implementations in `Slide` and `Chart` classes.

### Detailed summary
- Added `SDKSlidePart` property to `ISlide` interface.
- Added `SDKGraphicFrame`, `SDKChartPart`, and `SDKPlotArea` properties to `IChart` interface.
- Updated implementations to use SDK-related properties in `Slide` and `Chart` classes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->