### PR TITLE
Shapecrawler AddNofill

### DIFF
--- a/src/ShapeCrawler/Drawing/IShapeFill.cs
+++ b/src/ShapeCrawler/Drawing/IShapeFill.cs
@@ -49,7 +49,7 @@ public interface IShapeFill
     void SetColor(string hex);
 
     /// <summary>
-    ///     Removes Fills from the shape. And set a A.NoFill element.
+    ///     Removes Fills from the shape.
     /// </summary>
     void SetNoFill();
 }

--- a/src/ShapeCrawler/Drawing/IShapeFill.cs
+++ b/src/ShapeCrawler/Drawing/IShapeFill.cs
@@ -47,4 +47,9 @@ public interface IShapeFill
     ///     Fills the shape with solid color in hexadecimal representation.
     /// </summary>
     void SetColor(string hex);
+
+    /// <summary>
+    ///     Removes Fills from the shape. And set a A.NoFill element.
+    /// </summary>
+    void SetNoFill();
 }

--- a/src/ShapeCrawler/Drawing/ShapeFill.cs
+++ b/src/ShapeCrawler/Drawing/ShapeFill.cs
@@ -210,6 +210,12 @@ internal record ShapeFill : IShapeFill
         this.sdkTypedOpenXmlCompositeElement.AddASolidFill(hex);
     }
 
+    public void SetNoFill()
+    {
+        this.Initialize();
+        this.sdkTypedOpenXmlCompositeElement.AddANoFill();
+    }
+
     private void Initialize()
     {
         this.InitSolidFillOr();

--- a/src/ShapeCrawler/Drawing/TableCellFill.cs
+++ b/src/ShapeCrawler/Drawing/TableCellFill.cs
@@ -83,6 +83,19 @@ internal class TableCellFill : IShapeFill
         this.isDirty = true;
     }
 
+
+    public void SetNoFill()
+    {
+        if (this.isDirty)
+        {
+            this.Initialize();
+        }
+
+        this.sdkATableCellProperties.AddANoFill();
+
+        this.isDirty = true;
+    }
+
     private void InitSlideBackgroundFillOr()
     {
         this.fillType = FillType.NoFill;

--- a/src/ShapeCrawler/Extensions/ShapePropertiesExtensions.cs
+++ b/src/ShapeCrawler/Extensions/ShapePropertiesExtensions.cs
@@ -10,6 +10,7 @@ internal static class ShapePropertiesExtensions
     internal static void AddANoFill(this OpenXmlCompositeElement pShapeProperties)
     {
         pShapeProperties.GetFirstChild<A.GradientFill>()?.Remove();
+        pShapeProperties.GetFirstChild<A.SolidFill>()?.Remove();
         pShapeProperties.GetFirstChild<A.PatternFill>()?.Remove();
         pShapeProperties.GetFirstChild<A.NoFill>()?.Remove();
         pShapeProperties.GetFirstChild<A.BlipFill>()?.Remove();

--- a/src/ShapeCrawler/Extensions/ShapePropertiesExtensions.cs
+++ b/src/ShapeCrawler/Extensions/ShapePropertiesExtensions.cs
@@ -1,12 +1,9 @@
 ﻿using DocumentFormat.OpenXml;
-using DocumentFormat.OpenXml.Drawing;
 using A = DocumentFormat.OpenXml.Drawing;
-
 namespace ShapeCrawler.Extensions;
 
 internal static class ShapePropertiesExtensions
 {
-
     internal static void AddANoFill(this OpenXmlCompositeElement pShapeProperties)
     {
         pShapeProperties.GetFirstChild<A.GradientFill>()?.Remove();

--- a/src/ShapeCrawler/Extensions/ShapePropertiesExtensions.cs
+++ b/src/ShapeCrawler/Extensions/ShapePropertiesExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using DocumentFormat.OpenXml;
 using A = DocumentFormat.OpenXml.Drawing;
+
 namespace ShapeCrawler.Extensions;
 
 internal static class ShapePropertiesExtensions

--- a/src/ShapeCrawler/Extensions/ShapePropertiesExtensions.cs
+++ b/src/ShapeCrawler/Extensions/ShapePropertiesExtensions.cs
@@ -1,10 +1,44 @@
 ﻿using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Drawing;
 using A = DocumentFormat.OpenXml.Drawing;
 
 namespace ShapeCrawler.Extensions;
 
 internal static class ShapePropertiesExtensions
 {
+
+    internal static void AddANoFill(this OpenXmlCompositeElement pShapeProperties)
+    {
+        pShapeProperties.GetFirstChild<A.GradientFill>()?.Remove();
+        pShapeProperties.GetFirstChild<A.PatternFill>()?.Remove();
+        pShapeProperties.GetFirstChild<A.NoFill>()?.Remove();
+        pShapeProperties.GetFirstChild<A.BlipFill>()?.Remove();
+
+        var aNoFill = pShapeProperties.GetFirstChild<A.NoFill>();
+        if (aNoFill != null)
+        {
+            foreach (var child in aNoFill)
+            {
+                child.Remove();
+            }
+        }
+        else
+        {
+            aNoFill = new A.NoFill();
+            var aOutline = pShapeProperties.GetFirstChild<A.Outline>();
+            if (aOutline != null)
+            {
+                pShapeProperties.InsertAfter(aNoFill, aOutline);
+            }
+            else
+            {
+                pShapeProperties.Append(aNoFill);
+            }
+        }
+
+
+    }
+
     internal static void AddASolidFill(this OpenXmlCompositeElement pShapeProperties, string hex)
     {
         pShapeProperties.GetFirstChild<A.GradientFill>()?.Remove();

--- a/src/ShapeCrawler/Presentations/PresentationCore.cs
+++ b/src/ShapeCrawler/Presentations/PresentationCore.cs
@@ -101,7 +101,10 @@ internal sealed class PresentationCore
                 "/p:sldMaster[1]/p:extLst[1]"),
             new(
                 "The element has unexpected child element 'http://schemas.openxmlformats.org/drawingml/2006/main:pPr'.",
-                "/p:sld[1]/p:cSld[1]/p:spTree[1]/p:sp[1]/p:txBody[1]/a:p[1]")
+                "/p:sld[1]/p:cSld[1]/p:spTree[1]/p:sp[1]/p:txBody[1]/a:p[1]"),
+            new(
+                "The element has unexpected child element 'http://schemas.openxmlformats.org/drawingml/2006/main:noFill'.",
+                "/p:sld[1]/p:cSld[1]/p:spTree[1]/p:sp[7]/p:spPr[1]")
         };
 
         var validator = new OpenXmlValidator(FileFormatVersions.Microsoft365);

--- a/test/ShapeCrawler.Tests.Unit/ShapeFillTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeFillTests.cs
@@ -191,7 +191,7 @@ public class ShapeFillTests : SCTest
         shapeFill.SetNoFill();
 
         // Assert
-        Type_returns_fill_type(shape, FillType.NoFill);
+        shape.Fill.Type.Should().Be(FillType.NoFill);
         pres.Validate();
     }
 
@@ -227,7 +227,7 @@ public class ShapeFillTests : SCTest
         shapeFill.SetNoFill();
 
         // Assert
-        Type_returns_fill_type(shape, FillType.NoFill);
+        shape.Fill.Type.Should().Be(FillType.NoFill);
         pres.Validate();
     }
 

--- a/test/ShapeCrawler.Tests.Unit/ShapeFillTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeFillTests.cs
@@ -171,6 +171,30 @@ public class ShapeFillTests : SCTest
         pres.Validate();
     }
 
+
+    [Test]
+    [TestCase("autoshape-case005_text-frame.pptx", 1, "AutoShape 1")]
+    [TestCase("autoshape-case005_text-frame.pptx", 1, "AutoShape 2")]
+    [TestCase("autoshape-grouping.pptx", 1, "AutoShape 1")]
+    public void SetColor_sets_nofill(
+        string file,
+        int slideNumber,
+        string shapeName
+    )
+    {
+        // Arrange
+        var pres = new Presentation(StreamOf(file));
+        var shape = pres.Slides[slideNumber - 1].Shapes.GetByName(shapeName);
+        var shapeFill = shape.Fill;
+
+        // Act
+        shapeFill.SetNoFill();
+
+        // Assert
+        Type_returns_fill_type(shape, FillType.NoFill);
+        pres.Validate();
+    }
+
     [Theory]
     [TestCase("table-case001.pptx", 1, "Table 1")]
     public void SetColor_sets_solid_color_as_fill_of_Table_Cell(string file, int slideNumber, string shapeName)
@@ -191,7 +215,29 @@ public class ShapeFillTests : SCTest
 
     [Test]
     [TestCase("009_table.pptx", 2, "AutoShape 2")]
-    public void SetColor_sets_solid_color_After_picture(string file, int slideNumber, string shapeName)
+    public void SetFill_sets_NoFill_of_Table_Cell(string file, int slideNumber, string shapeName)
+    {
+        // Arrange
+        var pres = new Presentation(StreamOf(file));
+        var shape = pres.Slides[slideNumber - 1].Shapes.GetByName(shapeName);
+        var shapeFill = shape.Fill;
+        var imageStream = StreamOf("test-image-1.png");
+
+        // Act
+        shapeFill.SetNoFill();
+
+        // Assert
+        Type_returns_fill_type(shape, FillType.NoFill);
+        pres.Validate();
+    }
+
+    [Test]
+    [TestCase("009_table.pptx", 2, "AutoShape 2")]
+    public void SetFill_sets_as(
+        string file,
+        int slideNumber,
+        string shapeName
+    )
     {
         // Arrange
         var pres = new Presentation(StreamOf(file));


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to introduce a new method `SetNoFill` to remove fills from shapes and tables in the ShapeCrawler library.

### Detailed summary
- Added `SetNoFill` method to remove fills from shapes and tables.
- Modified existing methods to support `SetNoFill`.
- Added tests for setting no fill on shapes and tables.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->