### PR TITLE
Fix AddPicture so correct height is set

### DIFF
--- a/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
@@ -124,7 +124,7 @@ internal sealed class SlideShapes : ISlideShapes
         var xEmu = UnitConverter.HorizontalPixelToEmu(100);
         var yEmu = UnitConverter.VerticalPixelToEmu(100);
         var cxEmu = UnitConverter.HorizontalPixelToEmu(skBitmap.Width);
-        var cyEmu = UnitConverter.VerticalEmuToPixel(skBitmap.Height);
+        var cyEmu = UnitConverter.VerticalPixelToEmu(skBitmap.Height);
 
         var pPicture = this.CreatePPicture(imageStream, "Picture");
 

--- a/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
@@ -367,6 +367,24 @@ public class ShapeCollectionTests : SCTest
     }
 
     [Test]
+    public void AddPicture_sets_dimensions()
+    {
+        // Arrange
+        var pres = new Presentation();
+        var shapes = pres.Slides[0].Shapes;
+        var image = TestHelper.GetStream("test-image-1.png");
+
+        // Act
+        shapes.AddPicture(image);
+
+        // Assert
+        var picture = (IPicture)shapes.Last();
+        picture.Width.Should().Be(300);
+        picture.Height.Should().Be(300);
+    }
+
+
+    [Test]
     public void AddRectangle_adds_rectangle_with_valid_id_and_name()
     {
         // Arrange


### PR DESCRIPTION
`AddPicture()` mistakenly used `VerticalEmuToPixel`, when in fact the opposite was needed.

Also includes previously-failing test used to isolate the bug.

Fixes #671

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a test for setting dimensions when adding a picture to a slide in ShapeCrawler.

### Detailed summary
- Updated `SlideShapes.cs` to correctly convert vertical pixel to emu
- Added a test `AddPicture_sets_dimensions` in `ShapeCollectionTests.cs` to ensure correct dimensions are set when adding a picture

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->