### PR TITLE
Bump release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog  
 
+## Version 0.51.0 - 2024-05-11
+🍀Added `IShapeFill.SetNoFill()` to remove shape filling [#667](https://github.com/ShapeCrawler/ShapeCrawler/issues/667)
+
 ## Version 0.50.4 - 2024-05-10
 🐞Fixed `ISlideShapes.AddPicture()` [#671](https://github.com/ShapeCrawler/ShapeCrawler/issues/671)
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Pull Requests are welcome! Please read the [Contribution Guide](https://github.c
 
 ## Changelog  
 
-### Version 0.50.4 - 2024-05-10
-🐞Fixed `ISlideShapes.AddPicture()` [#671](https://github.com/ShapeCrawler/ShapeCrawler/issues/671)
+### Version 0.51.0 - 2024-05-11
+🍀Added `IShapeFill.SetNoFill()` to remove shape filling [#667](https://github.com/ShapeCrawler/ShapeCrawler/issues/667)
 
 Visit [CHANGELOG.md](https://github.com/ShapeCrawler/ShapeCrawler/blob/master/CHANGELOG.md) to see the full log.

--- a/src/ShapeCrawler/Presentations/PresentationCore.cs
+++ b/src/ShapeCrawler/Presentations/PresentationCore.cs
@@ -98,13 +98,7 @@ internal sealed class PresentationCore
                 "/p:sldLayout[1]/p:extLst[1]"),
             new(
                 "The 'mod' attribute is not declared.",
-                "/p:sldMaster[1]/p:extLst[1]"),
-            new(
-                "The element has unexpected child element 'http://schemas.openxmlformats.org/drawingml/2006/main:pPr'.",
-                "/p:sld[1]/p:cSld[1]/p:spTree[1]/p:sp[1]/p:txBody[1]/a:p[1]"),
-            new(
-                "The element has unexpected child element 'http://schemas.openxmlformats.org/drawingml/2006/main:noFill'.",
-                "/p:sld[1]/p:cSld[1]/p:spTree[1]/p:sp[7]/p:spPr[1]")
+                "/p:sldMaster[1]/p:extLst[1]")
         };
 
         var validator = new OpenXmlValidator(FileFormatVersions.Microsoft365);

--- a/src/ShapeCrawler/Presentations/PresentationCore.cs
+++ b/src/ShapeCrawler/Presentations/PresentationCore.cs
@@ -98,7 +98,10 @@ internal sealed class PresentationCore
                 "/p:sldLayout[1]/p:extLst[1]"),
             new(
                 "The 'mod' attribute is not declared.",
-                "/p:sldMaster[1]/p:extLst[1]")
+                "/p:sldMaster[1]/p:extLst[1]"),
+            new(
+                "The element has unexpected child element 'http://schemas.openxmlformats.org/drawingml/2006/main:noFill'.",
+                "/p:sld[1]/p:cSld[1]/p:spTree[1]/p:sp[7]/p:spPr[1]")
         };
 
         var validator = new OpenXmlValidator(FileFormatVersions.Microsoft365);

--- a/src/ShapeCrawler/ShapeCrawler.csproj
+++ b/src/ShapeCrawler/ShapeCrawler.csproj
@@ -10,7 +10,7 @@ This library provides a simplified object model on top of the Open XML SDK for m
     <PackageTags>ShapeCrawler Presentation PPTX  PowerPoint Slides OpenXml OOXML</PackageTags>
     <NeutralLanguage>en</NeutralLanguage>
     <LangVersion>default</LangVersion>
-    <PackageReleaseNotes>Fixed ISlideShapes.AddPicture()</PackageReleaseNotes>
+    <PackageReleaseNotes>Added IShapeFill.SetNoFill() to remove shape filling</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/ShapeCrawler/ShapeCrawler</PackageProjectUrl>
     <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
     <RepositoryType>Git</RepositoryType>

--- a/test/ShapeCrawler.Tests.Unit/ShapeFillTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeFillTests.cs
@@ -171,27 +171,21 @@ public class ShapeFillTests : SCTest
         pres.Validate();
     }
 
-
     [Test]
     [TestCase("autoshape-case005_text-frame.pptx", 1, "AutoShape 1")]
     [TestCase("autoshape-case005_text-frame.pptx", 1, "AutoShape 2")]
-    [TestCase("autoshape-grouping.pptx", 1, "AutoShape 1")]
-    public void SetColor_sets_nofill(
-        string file,
-        int slideNumber,
-        string shapeName
+    public void SetColor_sets_NoFill(string file, int slideNumber, string shapeName
     )
     {
         // Arrange
         var pres = new Presentation(StreamOf(file));
-        var shape = pres.Slides[slideNumber - 1].Shapes.GetByName(shapeName);
-        var shapeFill = shape.Fill;
+        var shapeFill = pres.Slides[slideNumber - 1].Shapes.GetByName(shapeName).Fill;
 
         // Act
         shapeFill.SetNoFill();
 
         // Assert
-        shape.Fill.Type.Should().Be(FillType.NoFill);
+        shapeFill.Type.Should().Be(FillType.NoFill);
         pres.Validate();
     }
 

--- a/test/ShapeCrawler.Tests.Unit/ShapeFillTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeFillTests.cs
@@ -175,7 +175,7 @@ public class ShapeFillTests : SCTest
     [TestCase("autoshape-case005_text-frame.pptx", 1, "AutoShape 1")]
     [TestCase("autoshape-case005_text-frame.pptx", 1, "AutoShape 2")]
     [TestCase("autoshape-grouping.pptx", 1, "AutoShape 1")]
-    public void SetColor_sets_NoFill(string file, int slideNumber, string shapeName)
+    public void SetColor_sets_No_Fill(string file, int slideNumber, string shapeName)
     {
         // Arrange
         var pres = new Presentation(StreamOf(file));

--- a/test/ShapeCrawler.Tests.Unit/ShapeFillTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeFillTests.cs
@@ -172,8 +172,8 @@ public class ShapeFillTests : SCTest
     }
 
     [Test]
-    // [TestCase("autoshape-case005_text-frame.pptx", 1, "AutoShape 1")]
-    // [TestCase("autoshape-case005_text-frame.pptx", 1, "AutoShape 2")]
+    [TestCase("autoshape-case005_text-frame.pptx", 1, "AutoShape 1")]
+    [TestCase("autoshape-case005_text-frame.pptx", 1, "AutoShape 2")]
     [TestCase("autoshape-grouping.pptx", 1, "AutoShape 1")]
     public void SetColor_sets_NoFill(string file, int slideNumber, string shapeName)
     {
@@ -183,7 +183,6 @@ public class ShapeFillTests : SCTest
 
         // Act
         shapeFill.SetNoFill();
-        pres.SaveAs(@"C:\temp\test.pptx");
 
         // Assert
         shapeFill.Type.Should().Be(FillType.NoFill);

--- a/test/ShapeCrawler.Tests.Unit/ShapeFillTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeFillTests.cs
@@ -172,10 +172,10 @@ public class ShapeFillTests : SCTest
     }
 
     [Test]
-    [TestCase("autoshape-case005_text-frame.pptx", 1, "AutoShape 1")]
-    [TestCase("autoshape-case005_text-frame.pptx", 1, "AutoShape 2")]
-    public void SetColor_sets_NoFill(string file, int slideNumber, string shapeName
-    )
+    // [TestCase("autoshape-case005_text-frame.pptx", 1, "AutoShape 1")]
+    // [TestCase("autoshape-case005_text-frame.pptx", 1, "AutoShape 2")]
+    [TestCase("autoshape-grouping.pptx", 1, "AutoShape 1")]
+    public void SetColor_sets_NoFill(string file, int slideNumber, string shapeName)
     {
         // Arrange
         var pres = new Presentation(StreamOf(file));
@@ -183,6 +183,7 @@ public class ShapeFillTests : SCTest
 
         // Act
         shapeFill.SetNoFill();
+        pres.SaveAs(@"C:\temp\test.pptx");
 
         // Assert
         shapeFill.Type.Should().Be(FillType.NoFill);


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new method `IShapeFill.SetNoFill()` to remove shape filling. It updates the changelog, README, and project notes accordingly.

### Detailed summary
- Added `IShapeFill.SetNoFill()` method to remove shape filling
- Updated changelog, README, and project notes with relevant information

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->