### PR TITLE
Add SVG Picture

### DIFF
--- a/src/ShapeCrawler/ShapeCollection/ISlideShapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/ISlideShapes.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using ShapeCrawler.Shared;
+using Svg;
 
 // ReSharper disable once CheckNamespace
 namespace ShapeCrawler;
@@ -71,6 +72,20 @@ public interface ISlideShapes : IShapes
     ///     Adds picture.
     /// </summary>
     void AddPicture(Stream imageStream);
+
+    /// <summary>
+    ///     Adds an SVG picture
+    /// </summary>
+    /// <remarks>
+    ///     Note that an SVG picture is inserted into the document as BOTH a
+    ///     vector image AND a rasterized image. The rasterized image is what
+    ///     the user sees. The vector image is used by the application to re-
+    ///     rasterize at a different size later.
+    /// </remarks>
+    /// <param name="image">The image to be loaded</param>
+    /// <param name="rasterWidth">Width of rasterized image in pixels.</param>
+    /// <param name="rasterHeight">Height of rasterized image in pixels.</param>
+    void AddPictureSvg(SvgDocument image, int rasterWidth, int rasterHeight);
 
     /// <summary>
     ///     Adds Bar chart.

--- a/src/ShapeCrawler/ShapeCollection/ISlideShapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/ISlideShapes.cs
@@ -1,6 +1,5 @@
 ﻿using System.IO;
 using ShapeCrawler.Shared;
-using Svg;
 
 // ReSharper disable once CheckNamespace
 namespace ShapeCrawler;

--- a/src/ShapeCrawler/ShapeCollection/ISlideShapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/ISlideShapes.cs
@@ -74,20 +74,6 @@ public interface ISlideShapes : IShapes
     void AddPicture(Stream imageStream);
 
     /// <summary>
-    ///     Adds an SVG picture
-    /// </summary>
-    /// <remarks>
-    ///     Note that an SVG picture is inserted into the document as BOTH a
-    ///     vector image AND a rasterized image. The rasterized image is what
-    ///     the user sees. The vector image is used by the application to re-
-    ///     rasterize at a different size later.
-    /// </remarks>
-    /// <param name="image">The image to be loaded</param>
-    /// <param name="rasterWidth">Width of rasterized image in pixels.</param>
-    /// <param name="rasterHeight">Height of rasterized image in pixels.</param>
-    void AddPictureSvg(SvgDocument image, int rasterWidth, int rasterHeight);
-
-    /// <summary>
     ///     Adds Bar chart.
     /// </summary>
     void AddBarChart(BarChartType barChartType);

--- a/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -13,7 +14,6 @@ using ShapeCrawler.Services;
 using ShapeCrawler.Shared;
 using SkiaSharp;
 using Svg;
-using System.Drawing.Imaging;
 using A = DocumentFormat.OpenXml.Drawing;
 using A14 = DocumentFormat.OpenXml.Office2010.Drawing;
 using A16 = DocumentFormat.OpenXml.Office2016.Drawing;

--- a/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
@@ -621,7 +621,9 @@ internal sealed class SlideShapes : ISlideShapes
 
         A16.CreationId a16CreationId = new A16.CreationId();
 
-        a16CreationId.AddNamespaceDeclaration("a16", "http://schemas.microsoft.com/office/drawing/2014/main");
+        // "http://schemas.microsoft.com/office/drawing/2014/main"
+        var a16 = DocumentFormat.OpenXml.Linq.A16.a16;
+        a16CreationId.AddNamespaceDeclaration(nameof(a16), a16.NamespaceName);
 
         a16CreationId.Id = "{2BEA8DB4-11C1-B7BA-06ED-DC504E2BBEBE}";
 
@@ -645,7 +647,10 @@ internal sealed class SlideShapes : ISlideShapes
 
         A14.UseLocalDpi a14UseLocalDpi = new A14.UseLocalDpi();
 
-        a14UseLocalDpi.AddNamespaceDeclaration("a14", "http://schemas.microsoft.com/office/drawing/2010/main");
+        // "http://schemas.microsoft.com/office/drawing/2010/main"
+        var a14 = DocumentFormat.OpenXml.Linq.A14.a14;
+
+        a14UseLocalDpi.AddNamespaceDeclaration(nameof(a14), a14.NamespaceName);
 
         a14UseLocalDpi.Val = false;
 
@@ -658,7 +663,10 @@ internal sealed class SlideShapes : ISlideShapes
 
         var sVGBlip = new DocumentFormat.OpenXml.Office2019.Drawing.SVG.SVGBlip() { Embed = svgPartRId };
 
-        sVGBlip.AddNamespaceDeclaration("asvg", "http://schemas.microsoft.com/office/drawing/2016/SVG/main");
+        // "http://schemas.microsoft.com/office/drawing/2016/SVG/main"
+        var asvg = DocumentFormat.OpenXml.Linq.ASVG.asvg;
+
+        sVGBlip.AddNamespaceDeclaration(nameof(asvg), asvg.NamespaceName);
 
         aBlipExtension.Append(sVGBlip);
 

--- a/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
@@ -156,7 +156,7 @@ internal sealed class SlideShapes : ISlideShapes
             }
 
             // Add it
-            AddPictureSvg(doc);
+            this.AddPictureSvg(doc);
         }
     }
 

--- a/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
@@ -627,14 +627,14 @@ internal sealed class SlideShapes : ISlideShapes
 
         a16CreationId.Id = "{2BEA8DB4-11C1-B7BA-06ED-DC504E2BBEBE}";
 
-        aNonVisualDrawingPropertiesExtension.Append(a16CreationId);
+        aNonVisualDrawingPropertiesExtension.AppendChild(a16CreationId);
 
-        aNonVisualDrawingPropertiesExtensionList.Append(aNonVisualDrawingPropertiesExtension);
+        aNonVisualDrawingPropertiesExtensionList.AppendChild(aNonVisualDrawingPropertiesExtension);
 
-        nonVisualDrawingProperties.Append(aNonVisualDrawingPropertiesExtensionList);
-        nonVisualPictureProperties.Append(nonVisualDrawingProperties);
-        nonVisualPictureProperties.Append(nonVisualPictureDrawingProperties);
-        nonVisualPictureProperties.Append(appNonVisualDrawingProperties);
+        nonVisualDrawingProperties.AppendChild(aNonVisualDrawingPropertiesExtensionList);
+        nonVisualPictureProperties.AppendChild(nonVisualDrawingProperties);
+        nonVisualPictureProperties.AppendChild(nonVisualPictureDrawingProperties);
+        nonVisualPictureProperties.AppendChild(appNonVisualDrawingProperties);
 
         var blipFill = new P.BlipFill();
 
@@ -654,9 +654,9 @@ internal sealed class SlideShapes : ISlideShapes
 
         a14UseLocalDpi.Val = false;
 
-        aBlipExtension.Append(a14UseLocalDpi);
+        aBlipExtension.AppendChild(a14UseLocalDpi);
 
-        aBlipExtensionList.Append(aBlipExtension);
+        aBlipExtensionList.AppendChild(aBlipExtension);
 
         aBlipExtension = new A.BlipExtension();
         aBlipExtension.Uri = "{96DAC541-7B7A-43D3-8B79-37D633B846F1}";
@@ -668,21 +668,21 @@ internal sealed class SlideShapes : ISlideShapes
 
         sVGBlip.AddNamespaceDeclaration(nameof(asvg), asvg.NamespaceName);
 
-        aBlipExtension.Append(sVGBlip);
+        aBlipExtension.AppendChild(sVGBlip);
 
-        aBlipExtensionList.Append(aBlipExtension);
+        aBlipExtensionList.AppendChild(aBlipExtension);
 
-        aBlip.Append(aBlipExtensionList);
+        aBlip.AppendChild(aBlipExtensionList);
 
-        blipFill.Append(aBlip);
+        blipFill.AppendChild(aBlip);
 
         A.Stretch aStretch = new A.Stretch();
 
         A.FillRectangle aFillRectangle = new A.FillRectangle();
 
-        aStretch.Append(aFillRectangle);
+        aStretch.AppendChild(aFillRectangle);
 
-        blipFill.Append(aStretch);
+        blipFill.AppendChild(aStretch);
 
         var transform2D = new A.Transform2D(
             new A.Offset { X = 0, Y = 0 },
@@ -693,18 +693,18 @@ internal sealed class SlideShapes : ISlideShapes
 
         A.AdjustValueList aAdjustValueList = new A.AdjustValueList();
 
-        presetGeometry.Append(aAdjustValueList);
+        presetGeometry.AppendChild(aAdjustValueList);
 
         var shapeProperties = new P.ShapeProperties();
-        shapeProperties.Append(transform2D);
-        shapeProperties.Append(presetGeometry);
+        shapeProperties.AppendChild(transform2D);
+        shapeProperties.AppendChild(presetGeometry);
 
         var pPicture = new P.Picture();
-        pPicture.Append(nonVisualPictureProperties);
-        pPicture.Append(blipFill);
-        pPicture.Append(shapeProperties);
+        pPicture.AppendChild(nonVisualPictureProperties);
+        pPicture.AppendChild(blipFill);
+        pPicture.AppendChild(shapeProperties);
 
-        this.sdkSlidePart.Slide.CommonSlideData!.ShapeTree!.Append(pPicture);
+        this.sdkSlidePart.Slide.CommonSlideData!.ShapeTree!.AppendChild(pPicture);
 
         return pPicture;
     }

--- a/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
@@ -15,6 +15,10 @@ using SkiaSharp;
 using A = DocumentFormat.OpenXml.Drawing;
 using P = DocumentFormat.OpenXml.Presentation;
 using Position = ShapeCrawler.Positions.Position;
+using A16 = DocumentFormat.OpenXml.Office2016.Drawing;
+using A14 = DocumentFormat.OpenXml.Office2010.Drawing;
+using Svg;
+using System.Drawing.Imaging;
 
 namespace ShapeCrawler.ShapeCollection;
 
@@ -121,6 +125,10 @@ internal sealed class SlideShapes : ISlideShapes
         imageCopy.Position = 0;
         imageStream.Position = 0;
         using var skBitmap = SKBitmap.Decode(imageCopy);
+
+        if (skBitmap == null)
+            throw new ArgumentException("Unable to decode bitmap from supplied stream", nameof(imageStream));
+
         var xEmu = UnitConverter.HorizontalPixelToEmu(100);
         var yEmu = UnitConverter.VerticalPixelToEmu(100);
         var cxEmu = UnitConverter.HorizontalPixelToEmu(skBitmap.Width);
@@ -128,6 +136,33 @@ internal sealed class SlideShapes : ISlideShapes
 
         var pPicture = this.CreatePPicture(imageStream, "Picture");
 
+        var transform2D = pPicture.ShapeProperties!.Transform2D!;
+        transform2D.Offset!.X = xEmu;
+        transform2D.Offset!.Y = yEmu;
+        transform2D.Extents!.Cx = cxEmu;
+        transform2D.Extents!.Cy = cyEmu;
+    }
+
+    public void AddPictureSvg(SvgDocument image, int rasterWidth, int rasterHeight)
+    {
+        // Rasterize image
+        var bitmap = image.Draw(rasterWidth, rasterHeight);
+        var rasterStream = new MemoryStream();
+        bitmap.Save(rasterStream, ImageFormat.Png);
+        rasterStream.Position = 0;
+
+        // Extract svg
+        var svgStream = new MemoryStream();
+        image.Write(svgStream);
+        svgStream.Position = 0;
+
+        // Create the picture
+        var pPicture = this.CreatePPictureSvg(rasterStream, svgStream, "Picture");
+
+        var xEmu = UnitConverter.HorizontalPixelToEmu(100);
+        var yEmu = UnitConverter.VerticalPixelToEmu(100);
+        var cxEmu = UnitConverter.HorizontalPixelToEmu(rasterWidth);
+        var cyEmu = UnitConverter.VerticalPixelToEmu(rasterHeight);
         var transform2D = pPicture.ShapeProperties!.Transform2D!;
         transform2D.Offset!.X = xEmu;
         transform2D.Offset!.Y = yEmu;
@@ -519,6 +554,121 @@ internal sealed class SlideShapes : ISlideShapes
 
         var presetGeometry = new A.PresetGeometry
             { Preset = A.ShapeTypeValues.Rectangle };
+        var shapeProperties = new P.ShapeProperties();
+        shapeProperties.Append(transform2D);
+        shapeProperties.Append(presetGeometry);
+
+        var pPicture = new P.Picture();
+        pPicture.Append(nonVisualPictureProperties);
+        pPicture.Append(blipFill);
+        pPicture.Append(shapeProperties);
+
+        this.sdkSlidePart.Slide.CommonSlideData!.ShapeTree!.Append(pPicture);
+
+        return pPicture;
+    }
+    private P.Picture CreatePPictureSvg(Stream rasterStream, Stream svgStream, string shapeName)
+    {
+        // The A.Blip contains a raster representation of the vector image
+        //
+        // This should be rendered to the size of the rectangle (or higher), else user will have to resize the image
+        // first to get the app to re-render it.
+
+        var imgPartRId = this.sdkSlidePart.NextRelationshipId();
+        var imagePart = this.sdkSlidePart.AddNewPart<ImagePart>("image/png", imgPartRId);
+        rasterStream.Position = 0;
+        imagePart.FeedData(rasterStream);
+
+        // The SVG Blip contains the vector data
+
+        var imgPartRId2 = this.sdkSlidePart.NextRelationshipId();
+        var imagePart2 = this.sdkSlidePart.AddNewPart<ImagePart>("image/svg+xml", imgPartRId2);
+        rasterStream.Position = 0;
+        imagePart2.FeedData(svgStream);
+
+        var nonVisualPictureProperties = new P.NonVisualPictureProperties();
+        var shapeId = (uint)this.NextShapeId();
+        var nonVisualDrawingProperties = new P.NonVisualDrawingProperties
+        {
+            Id = shapeId, Name = $"{shapeName} {shapeId}"
+        };
+        var nonVisualPictureDrawingProperties = new P.NonVisualPictureDrawingProperties();
+        var appNonVisualDrawingProperties = new P.ApplicationNonVisualDrawingProperties();
+
+        A.NonVisualDrawingPropertiesExtensionList aNonVisualDrawingPropertiesExtensionList = new A.NonVisualDrawingPropertiesExtensionList();
+
+        A.NonVisualDrawingPropertiesExtension aNonVisualDrawingPropertiesExtension = new A.NonVisualDrawingPropertiesExtension();
+        aNonVisualDrawingPropertiesExtension.Uri = "{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}";
+
+        A16.CreationId a16CreationId = new A16.CreationId();
+
+        a16CreationId.AddNamespaceDeclaration("a16", "http://schemas.microsoft.com/office/drawing/2014/main");
+
+        a16CreationId.Id = "{2BEA8DB4-11C1-B7BA-06ED-DC504E2BBEBE}";
+
+        aNonVisualDrawingPropertiesExtension.Append(a16CreationId);
+
+        aNonVisualDrawingPropertiesExtensionList.Append(aNonVisualDrawingPropertiesExtension);
+
+        nonVisualDrawingProperties.Append(aNonVisualDrawingPropertiesExtensionList);
+
+        nonVisualPictureProperties.Append(nonVisualDrawingProperties);
+        nonVisualPictureProperties.Append(nonVisualPictureDrawingProperties);
+        nonVisualPictureProperties.Append(appNonVisualDrawingProperties);
+
+        var blipFill = new P.BlipFill();
+
+        A.Blip aBlip = new A.Blip() { Embed = imgPartRId };
+
+        A.BlipExtensionList aBlipExtensionList = new A.BlipExtensionList();
+
+        A.BlipExtension aBlipExtension = new A.BlipExtension();
+        aBlipExtension.Uri = "{28A0092B-C50C-407E-A947-70E740481C1C}";
+
+        A14.UseLocalDpi a14UseLocalDpi = new A14.UseLocalDpi();
+
+        a14UseLocalDpi.AddNamespaceDeclaration("a14", "http://schemas.microsoft.com/office/drawing/2010/main");
+
+        a14UseLocalDpi.Val = false;
+
+        aBlipExtension.Append(a14UseLocalDpi);
+
+        aBlipExtensionList.Append(aBlipExtension);
+
+        aBlipExtension = new A.BlipExtension();
+        aBlipExtension.Uri = "{96DAC541-7B7A-43D3-8B79-37D633B846F1}";
+
+        var sVGBlip = new DocumentFormat.OpenXml.Office2019.Drawing.SVG.SVGBlip() { Embed = imgPartRId2 };
+
+        sVGBlip.AddNamespaceDeclaration("asvg", "http://schemas.microsoft.com/office/drawing/2016/SVG/main");
+
+        aBlipExtension.Append(sVGBlip);
+
+        aBlipExtensionList.Append(aBlipExtension);
+
+        aBlip.Append(aBlipExtensionList);
+
+        blipFill.Append(aBlip);
+
+        A.Stretch aStretch = new A.Stretch();
+
+        A.FillRectangle aFillRectangle = new A.FillRectangle();
+
+        aStretch.Append(aFillRectangle);
+
+        blipFill.Append(aStretch);
+
+        var transform2D = new A.Transform2D(
+            new A.Offset { X = 0, Y = 0 },
+            new A.Extents { Cx = 0, Cy = 0 });
+
+        var presetGeometry = new A.PresetGeometry
+            { Preset = A.ShapeTypeValues.Rectangle };
+
+        A.AdjustValueList aAdjustValueList = new A.AdjustValueList();
+
+        presetGeometry.Append(aAdjustValueList);
+
         var shapeProperties = new P.ShapeProperties();
         shapeProperties.Append(transform2D);
         shapeProperties.Append(presetGeometry);

--- a/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
@@ -152,7 +152,7 @@ internal sealed class SlideShapes : ISlideShapes
             catch
             {
                 // Neither bitmap nor svg can load this, so that's an error.
-                throw new ArgumentException("Unable to decode image from supplied stream", nameof(imageStream));
+                throw new SCException("Unable to decode image from supplied stream");
             }
 
             // Add it

--- a/src/ShapeCrawler/ShapeCrawler.csproj
+++ b/src/ShapeCrawler/ShapeCrawler.csproj
@@ -76,6 +76,7 @@ This library provides a simplified object model on top of the Open XML SDK for m
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Svg" Version="3.4.7" />
     <PackageReference Include="System.Resources.Extensions" Version="5.0.0" />
     <PackageReference Include="System.Text.Json" Version="7.0.2" />
   </ItemGroup>

--- a/src/ShapeCrawler/ShapeCrawler.csproj
+++ b/src/ShapeCrawler/ShapeCrawler.csproj
@@ -70,6 +70,7 @@ This library provides a simplified object model on top of the Open XML SDK for m
 
   <ItemGroup>
     <PackageReference Include="DocumentFormat.OpenXml" Version="3.0.2" />
+    <PackageReference Include="DocumentFormat.OpenXml.Linq" Version="3.0.2" />
     <PackageReference Include="SkiaSharp" Version="2.88.6" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.6" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/test/ShapeCrawler.Tests.Unit.xUnit/Resource/test-vector-image-1.svg
+++ b/test/ShapeCrawler.Tests.Unit.xUnit/Resource/test-vector-image-1.svg
@@ -1,0 +1,3 @@
+<svg height="100" width="100" xmlns="http://www.w3.org/2000/svg">
+  <circle r="45" cx="50" cy="50" fill="red" />
+</svg> 

--- a/test/ShapeCrawler.Tests.Unit.xUnit/ShapeCrawler.Tests.Unit.xUnit.csproj
+++ b/test/ShapeCrawler.Tests.Unit.xUnit/ShapeCrawler.Tests.Unit.xUnit.csproj
@@ -216,6 +216,8 @@
     <EmbeddedResource Include="Resource\test-wav.wav" />
     <None Remove="Resource\054_get_shape_xpath.pptx" />
     <EmbeddedResource Include="Resource\054_get_shape_xpath.pptx" />
+    <None Remove="Resource\test-vector-image-1.svg" />
+    <EmbeddedResource Include="Resource\test-vector-image-1.svg" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
@@ -350,37 +350,37 @@ public class ShapeCollectionTests : SCTest
     }
 
     [Test]
-    public void AddPictureSvg_adds_picture()
+    public void AddPicture_adds_svg_picture()
     {
         // Arrange
         var pres = new Presentation();
         var shapes = pres.Slides[0].Shapes;
         var image = TestHelper.GetStream("test-vector-image-1.svg");
         image.Position = 0;
-        var doc = Svg.SvgDocument.Open<Svg.SvgDocument>(image);
 
         // Act
-        shapes.AddPictureSvg(doc, 200, 200);
+        shapes.AddPicture(image);
 
         // Assert
         shapes.Should().HaveCount(1);
         var picture = (IPicture)shapes.Last();
         picture.ShapeType.Should().Be(ShapeType.Picture);
-        picture.Height.Should().Be(200);
-        picture.Width.Should().Be(200);
+
+        // These values are the intrinsic size of the test image
+        picture.Height.Should().Be(100);
+        picture.Width.Should().Be(100);
         pres.Validate();
     }
 
     [Test]
-    public void AddPictureSvg_sets_valid_svg_content()
+    public void AddPicture_sets_valid_svg_content()
     {
         // Arrange
         var pres = new Presentation();
         var shapes = pres.Slides[0].Shapes;
         var image = TestHelper.GetStream("test-vector-image-1.svg");
         image.Position = 0;
-        var doc = Svg.SvgDocument.Open<Svg.SvgDocument>(image);
-        shapes.AddPictureSvg(doc, 200, 200);
+        shapes.AddPicture(image);
         var picture = (IPicture)shapes.Last();
 
         // Act

--- a/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using FluentAssertions;
 using NUnit.Framework;
+using ShapeCrawler.Exceptions;
 using ShapeCrawler.Shapes;
 using ShapeCrawler.Shared;
 using ShapeCrawler.Tests.Shared;
@@ -419,7 +420,7 @@ public class ShapeCollectionTests : SCTest
         var act = () => shapes.AddPicture(notAnImage);
 
         // Assert
-        act.Should().Throw<ArgumentException>();
+        act.Should().Throw<SCException>();
     }
 
     [Test]

--- a/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
@@ -1,7 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Drawing.Imaging;
 using System.Linq;
-using System.Linq.Expressions;
 using FluentAssertions;
 using NUnit.Framework;
 using ShapeCrawler.Shapes;

--- a/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Drawing.Imaging;
 using System.Linq;
 using FluentAssertions;
 using NUnit.Framework;
@@ -349,42 +350,44 @@ public class ShapeCollectionTests : SCTest
     }
 
     [Test]
-    [Explicit]
-    public void AddPicture_adds_picture_svg()
+    public void AddPictureSvg_adds_picture()
     {
         // Arrange
         var pres = new Presentation();
         var shapes = pres.Slides[0].Shapes;
         var image = TestHelper.GetStream("test-vector-image-1.svg");
+        image.Position = 0;
+        var doc = Svg.SvgDocument.Open<Svg.SvgDocument>(image);
 
         // Act
-        shapes.AddPicture(image);
+        shapes.AddPictureSvg(doc, 200, 200);
 
         // Assert
         shapes.Should().HaveCount(1);
         var picture = (IPicture)shapes.Last();
         picture.ShapeType.Should().Be(ShapeType.Picture);
-        picture.Height.Should().Be(100);
-        picture.Width.Should().Be(100);
+        picture.Height.Should().Be(200);
+        picture.Width.Should().Be(200);
         pres.Validate();
     }
 
     [Test]
-    [Explicit]
-    public void AddPicture_returns_svg_content()
+    public void AddPictureSvg_sets_valid_svg_content()
     {
         // Arrange
         var pres = new Presentation();
         var shapes = pres.Slides[0].Shapes;
         var image = TestHelper.GetStream("test-vector-image-1.svg");
-        shapes.AddPicture(image);
+        image.Position = 0;
+        var doc = Svg.SvgDocument.Open<Svg.SvgDocument>(image);
+        shapes.AddPictureSvg(doc, 200, 200);
         var picture = (IPicture)shapes.Last();
 
         // Act
         var svgContent = picture.SvgContent;
         
         // Assert
-        svgContent.Should().NotBeEmpty();
+        svgContent.Should().Contain("<svg");
     }
 
     [Test]

--- a/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
@@ -349,6 +349,45 @@ public class ShapeCollectionTests : SCTest
     }
 
     [Test]
+    [Explicit]
+    public void AddPicture_adds_picture_svg()
+    {
+        // Arrange
+        var pres = new Presentation();
+        var shapes = pres.Slides[0].Shapes;
+        var image = TestHelper.GetStream("test-vector-image-1.svg");
+
+        // Act
+        shapes.AddPicture(image);
+
+        // Assert
+        shapes.Should().HaveCount(1);
+        var picture = (IPicture)shapes.Last();
+        picture.ShapeType.Should().Be(ShapeType.Picture);
+        picture.Height.Should().Be(100);
+        picture.Width.Should().Be(100);
+        pres.Validate();
+    }
+
+    [Test]
+    [Explicit]
+    public void AddPicture_returns_svg_content()
+    {
+        // Arrange
+        var pres = new Presentation();
+        var shapes = pres.Slides[0].Shapes;
+        var image = TestHelper.GetStream("test-vector-image-1.svg");
+        shapes.AddPicture(image);
+        var picture = (IPicture)shapes.Last();
+
+        // Act
+        var svgContent = picture.SvgContent;
+        
+        // Assert
+        svgContent.Should().NotBeEmpty();
+    }
+
+    [Test]
     public void AddPicture_adds_picture()
     {
         // Arrange

--- a/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing.Imaging;
 using System.Linq;
+using System.Linq.Expressions;
 using FluentAssertions;
 using NUnit.Framework;
 using ShapeCrawler.Shapes;
@@ -407,7 +408,22 @@ public class ShapeCollectionTests : SCTest
         picture.ShapeType.Should().Be(ShapeType.Picture);
         pres.Validate();
     }
-    
+
+    [Test]
+    public void AddPicture_with_not_an_image_throws_exception()
+    {
+        // Arrange
+        var pres = new Presentation();
+        var shapes = pres.Slides[0].Shapes;
+        var notAnImage = TestHelper.GetStream("autoshape-case011_save-as-png.pptx");
+
+        // Act
+        var act = () => shapes.AddPicture(notAnImage);
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+
     [Test]
     public void AddPicture_adds_picture_with_correct_Height()
     {


### PR DESCRIPTION
This extends `SlideShapes.AddPicture()` to allow adding SVG pictures.

It does not seem to matter what size the A.Blip gets rasterized at. I've experimented with very small resolutions, but when I load the file in PowerPoint, a proper-looking image is always shown. Ergo, it seems to be fine to simply for the user to add the svg picture and then resize in the usual way by changing the `Height` and `Width` properties. Perhaps a dedicated "resize" API is not needed.

In addition to the included unit tests, I have done some lightweight use-case testing. On Monday, I'll put this into my at-work workflow, which loads hundreds of images from many sources, and we'll see how it does there.

Fixes #350

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for adding SVG images to PowerPoint slides and ensures proper handling of SVG content.

### Detailed summary
- Added support for adding SVG images to PowerPoint slides
- Implemented methods to handle SVG content in PowerPoint slides
- Updated project dependencies for SVG support

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->