### PR TITLE
Convert position and size properties into decimal type

### DIFF
--- a/src/ShapeCrawler/Drawing/IShapeOutline.cs
+++ b/src/ShapeCrawler/Drawing/IShapeOutline.cs
@@ -11,7 +11,7 @@ public interface IShapeOutline
     /// <summary>
     ///     Gets or sets outline weight in points.
     /// </summary>
-    double Weight { get; set; }
+    decimal Weight { get; set; }
 
     /// <summary>
     ///     Gets or sets color in hexadecimal format. Returns <see langword="null"/> if outline is not filled.

--- a/src/ShapeCrawler/Positions/IPosition.cs
+++ b/src/ShapeCrawler/Positions/IPosition.cs
@@ -9,10 +9,10 @@ public interface IPosition
     /// <summary>
     ///     Gets or sets x-coordinate of the upper-left corner of the shape.
     /// </summary>
-    int X { get; set; }
+    decimal X { get; set; }
 
     /// <summary>
     ///     Gets or sets y-coordinate of the upper-left corner of the shape in pixels.
     /// </summary>
-    int Y { get; set; }
+    decimal Y { get; set; }
 }

--- a/src/ShapeCrawler/Positions/Point.cs
+++ b/src/ShapeCrawler/Positions/Point.cs
@@ -11,7 +11,13 @@ public readonly ref struct Point
         this.X = x;
         this.Y = y;
     }
-    
+
+    internal Point(decimal x, decimal y)
+    {
+        this.X = (int)x;
+        this.Y = (int)y;
+    }
+
     /// <summary>
     ///     Gets the X coordinate.
     /// </summary>

--- a/src/ShapeCrawler/Positions/Position.cs
+++ b/src/ShapeCrawler/Positions/Position.cs
@@ -18,17 +18,17 @@ internal sealed class Position
         this.pShapeTreeElement = pShapeTreeElement;
     }
 
-    internal int X() => new Emus(this.AOffset().X!.Value).AsHorizontalPixels();
+    internal decimal X() => new Emus(this.AOffset().X!.Value).AsHorizontalPixels();
    
-    internal void UpdateX(int pixels)
+    internal void UpdateX(decimal pixels)
     {
         var emus = new Pixels(pixels).AsHorizontalEmus();
         this.AOffset().X = new Int64Value(emus);
     }
     
-    internal int Y() => new Emus(this.AOffset().Y!.Value).AsVerticalPixels();
+    internal decimal Y() => new Emus(this.AOffset().Y!.Value).AsVerticalPixels();
 
-    internal void UpdateY(int pixels)
+    internal void UpdateY(decimal pixels)
     {
         var emus = new Pixels(pixels).AsVerticalEmus();
         this.AOffset().Y = new Int64Value(emus);

--- a/src/ShapeCrawler/Presentations/IPresentationProperties.cs
+++ b/src/ShapeCrawler/Presentations/IPresentationProperties.cs
@@ -13,12 +13,12 @@ public interface IPresentationProperties
     /// <summary>
     ///     Gets or sets presentation slides width in pixels.
     /// </summary>
-    int SlideWidth { get; set; }
+    decimal SlideWidth { get; set; }
 
     /// <summary>
     ///     Gets or sets the presentation slides height.
     /// </summary>
-    int SlideHeight { get; set; }
+    decimal SlideHeight { get; set; }
 
     /// <summary>
     ///     Gets collection of the slide masters.

--- a/src/ShapeCrawler/Presentations/PathPresentation.cs
+++ b/src/ShapeCrawler/Presentations/PathPresentation.cs
@@ -25,13 +25,13 @@ internal sealed record PathPresentation : IValidateable
     public void CopyTo(Stream stream) => this.presentationCore.CopyTo(stream);
     public ISlides Slides => this.presentationCore.Slides;
 
-    public int SlideWidth
+    public decimal SlideWidth
     {
         get => this.presentationCore.SlideWidth;
         set => this.presentationCore.SlideWidth = value;
     }
 
-    public int SlideHeight
+    public decimal SlideHeight
     {
         get => this.presentationCore.SlideHeight;
         set => this.presentationCore.SlideHeight = value;

--- a/src/ShapeCrawler/Presentations/Presentation.cs
+++ b/src/ShapeCrawler/Presentations/Presentation.cs
@@ -39,14 +39,14 @@ public sealed class Presentation : IPresentation
     public ISlides Slides => this.validateable.Slides;
 
     /// <inheritdoc />
-    public int SlideWidth
+    public decimal SlideWidth
     {
         get => this.validateable.SlideWidth; 
         set => this.validateable.SlideWidth = value;
     }
     
     /// <inheritdoc />
-    public int SlideHeight
+    public decimal SlideHeight
     {
         get => this.validateable.SlideHeight;
         set => this.validateable.SlideHeight = value;

--- a/src/ShapeCrawler/Presentations/PresentationCore.cs
+++ b/src/ShapeCrawler/Presentations/PresentationCore.cs
@@ -45,13 +45,13 @@ internal sealed class PresentationCore
 
     internal ISlides Slides { get; }
 
-    internal int SlideHeight
+    internal decimal SlideHeight
     {
         get => this.slideSize.Height();
         set => this.slideSize.UpdateHeight(value);
     }
 
-    internal int SlideWidth
+    internal decimal SlideWidth
     {
         get => this.slideSize.Width();
         set => this.slideSize.UpdateWidth(value);

--- a/src/ShapeCrawler/Presentations/Slide.cs
+++ b/src/ShapeCrawler/Presentations/Slide.cs
@@ -77,7 +77,7 @@ internal sealed class Slide : ISlide
     
     public void SaveAsPng(Stream stream)
     {
-        var imageInfo = new SKImageInfo(this.slideSize.Width(), this.slideSize.Height());
+        var imageInfo = new SKImageInfo((int)this.slideSize.Width(), (int)this.slideSize.Height());
         var surface = SKSurface.Create(imageInfo);
         var canvas = surface.Canvas;
         canvas.Clear(SKColors.White); // TODO: #344 get real

--- a/src/ShapeCrawler/Presentations/SlideSize.cs
+++ b/src/ShapeCrawler/Presentations/SlideSize.cs
@@ -13,17 +13,17 @@ internal sealed class SlideSize
         this.pSlideSize = pSlideSize;
     }
 
-    internal int Width() => UnitConverter.HorizontalEmuToPixel(this.pSlideSize.Cx!.Value);
+    internal decimal Width() => UnitConverter.HorizontalEmuToPixel(this.pSlideSize.Cx!.Value);
 
-    internal int Height() => UnitConverter.HorizontalEmuToPixel(this.pSlideSize.Cy!.Value);
+    internal decimal Height() => UnitConverter.HorizontalEmuToPixel(this.pSlideSize.Cy!.Value);
 
-    internal void UpdateWidth(int pixels)
+    internal void UpdateWidth(decimal pixels)
     {
         var emu = UnitConverter.HorizontalPixelToEmu(pixels);
         this.pSlideSize.Cx = new Int32Value((int)emu);
     }
     
-    internal void UpdateHeight(int pixels)
+    internal void UpdateHeight(decimal pixels)
     {
         var emu = UnitConverter.VerticalPixelToEmu(pixels);
         this.pSlideSize.Cy = new Int32Value((int)emu);

--- a/src/ShapeCrawler/Presentations/StreamPresentation.cs
+++ b/src/ShapeCrawler/Presentations/StreamPresentation.cs
@@ -18,13 +18,13 @@ internal sealed class StreamPresentation : IValidateable
 
     public ISlides Slides => this.presentationCore.Slides;
     
-    public int SlideWidth
+    public decimal SlideWidth
     {
         get => this.presentationCore.SlideWidth;
         set => this.presentationCore.SlideWidth = value;
     }
     
-    public int SlideHeight
+    public decimal SlideHeight
     {
         get => this.presentationCore.SlideHeight;
         set => this.presentationCore.SlideHeight = value;

--- a/src/ShapeCrawler/ShapeCollection/AutoShape.cs
+++ b/src/ShapeCrawler/ShapeCollection/AutoShape.cs
@@ -98,14 +98,14 @@ internal sealed class AutoShape : CopyableShape
 
         if (this.GeometryType == Geometry.Rectangle)
         {
-            float left = this.X;
-            float top = this.Y;
-            float right = this.X + this.Width;
-            float bottom = this.Y + this.Height;
+            float left = (float)this.X;
+            float top = (float)this.Y;
+            float right = (float)(this.X + this.Width);
+            float bottom = (float)(this.Y + this.Height);
             var rect = new SKRect(left, top, right, bottom);
             slideCanvas.DrawRect(rect, paint);
             var textFrame = (TextFrame)this.TextFrame!;
-            textFrame.Draw(slideCanvas, left, this.Y);
+            textFrame.Draw(slideCanvas, left, top);
         }
     }
 }

--- a/src/ShapeCrawler/ShapeCollection/AutoShape.cs
+++ b/src/ShapeCrawler/ShapeCollection/AutoShape.cs
@@ -92,7 +92,7 @@ internal sealed class AutoShape : CopyableShape
         {
             Color = skColorOutline,
             IsAntialias = true,
-            StrokeWidth = UnitConverter.PointToPixel(this.Outline.Weight),
+            StrokeWidth = (float)UnitConverter.PointToPixel(this.Outline.Weight),
             Style = SKPaintStyle.Stroke
         };
 

--- a/src/ShapeCrawler/ShapeCollection/GroupedShape.cs
+++ b/src/ShapeCrawler/ShapeCollection/GroupedShape.cs
@@ -19,7 +19,7 @@ internal sealed class GroupedShape : IShape
         this.decoratedShape = decoratedShape;
     }
 
-    public int X
+    public decimal X
     {
         get
         {
@@ -69,7 +69,7 @@ internal sealed class GroupedShape : IShape
         }
     }
 
-    public int Y
+    public decimal Y
     {
         get => this.decoratedShape.Y;
         set
@@ -107,13 +107,13 @@ internal sealed class GroupedShape : IShape
 
     #region Decorated Shape
 
-    public int Width
+    public decimal Width
     {
         get => this.decoratedShape.Width;
         set => this.decoratedShape.Width = value;
     }
 
-    public int Height
+    public decimal Height
     {
         get => this.decoratedShape.Height;
         set => this.decoratedShape.Height = value;

--- a/src/ShapeCrawler/ShapeCollection/IShape.cs
+++ b/src/ShapeCrawler/ShapeCollection/IShape.cs
@@ -16,12 +16,12 @@ public interface IShape : IPosition
     /// <summary>
     ///     Gets or sets width of the shape in pixels.
     /// </summary>
-    int Width { get; set; }
+    decimal Width { get; set; }
 
     /// <summary>
     ///     Gets or sets height of the shape in pixels.
     /// </summary>
-    int Height { get; set; }
+    decimal Height { get; set; }
 
     /// <summary>
     ///     Gets identifier of the shape.

--- a/src/ShapeCrawler/ShapeCollection/RootShape.cs
+++ b/src/ShapeCrawler/ShapeCollection/RootShape.cs
@@ -64,7 +64,7 @@ internal sealed class RootShape : CopyableShape, IRootShape
         {
             Color = skColorOutline,
             IsAntialias = true,
-            StrokeWidth = UnitConverter.PointToPixel(this.Outline.Weight),
+            StrokeWidth = (float)UnitConverter.PointToPixel(this.Outline.Weight),
             Style = SKPaintStyle.Stroke
         };
 

--- a/src/ShapeCrawler/ShapeCollection/RootShape.cs
+++ b/src/ShapeCrawler/ShapeCollection/RootShape.cs
@@ -41,7 +41,7 @@ internal sealed class RootShape : CopyableShape, IRootShape
     
     public override Geometry GeometryType => this.decoratedShape.GeometryType;
 
-    public override int X
+    public override decimal X
     {
         get => this.decoratedShape.X; 
         set => this.decoratedShape.X = value;
@@ -70,14 +70,14 @@ internal sealed class RootShape : CopyableShape, IRootShape
 
         if (this.GeometryType == Geometry.Rectangle)
         {
-            float left = this.X;
-            float top = this.Y;
-            float right = this.X + this.Width;
-            float bottom = this.Y + this.Height;
+            float left = (float)(this.X);
+            float top = (float)(this.Y);
+            float right = (float)(this.X + this.Width);
+            float bottom = (float)(this.Y + this.Height);
             var rect = new SKRect(left, top, right, bottom);
             slideCanvas.DrawRect(rect, paint);
             var textFrame = (TextFrame)this.TextFrame!;
-            textFrame.Draw(slideCanvas, left, this.Y);
+            textFrame.Draw(slideCanvas, left, top);
         }
     }
 }

--- a/src/ShapeCrawler/ShapeCollection/Shape.cs
+++ b/src/ShapeCrawler/ShapeCollection/Shape.cs
@@ -31,25 +31,25 @@ internal abstract class Shape : IShape
         this.shapeId = new ShapeId(pShapeTreeElement);
     }
 
-    public virtual int X
+    public virtual decimal X
     {
         get => this.position.X();
         set => this.position.UpdateX(value);
     }
 
-    public virtual int Y
+    public virtual decimal Y
     {
         get => this.position.Y();
         set => this.position.UpdateY(value);
     }
 
-    public int Width
+    public decimal Width
     {
         get => this.size.Width();
         set => this.size.UpdateWidth(value);
     }
 
-    public int Height
+    public decimal Height
     {
         get => this.size.Height();
         set => this.size.UpdateHeight(value);

--- a/src/ShapeCrawler/ShapeCollection/ShapeSize.cs
+++ b/src/ShapeCrawler/ShapeCollection/ShapeSize.cs
@@ -17,13 +17,13 @@ internal sealed class ShapeSize
         this.sdkPShapeTreeElement = sdkPShapeTreeElement;
     }
 
-    internal int Height() => UnitConverter.VerticalEmuToPixel(this.AExtents().Cy!);
+    internal decimal Height() => UnitConverter.VerticalEmuToPixel(this.AExtents().Cy!);
    
-    internal void UpdateHeight(int heightPixels) => this.AExtents().Cy = UnitConverter.VerticalPixelToEmu(heightPixels);
+    internal void UpdateHeight(decimal heightPixels) => this.AExtents().Cy = UnitConverter.VerticalPixelToEmu(heightPixels);
     
-    internal int Width() => UnitConverter.HorizontalEmuToPixel(this.AExtents().Cx!);
+    internal decimal Width() => UnitConverter.HorizontalEmuToPixel(this.AExtents().Cx!);
     
-    internal void UpdateWidth(int widthPixels) => this.AExtents().Cx = UnitConverter.HorizontalPixelToEmu(widthPixels);
+    internal void UpdateWidth(decimal widthPixels) => this.AExtents().Cx = UnitConverter.HorizontalPixelToEmu(widthPixels);
 
     private A.Extents AExtents()
     {

--- a/src/ShapeCrawler/ShapeCollection/SlideShapeOutline.cs
+++ b/src/ShapeCrawler/ShapeCollection/SlideShapeOutline.cs
@@ -1,4 +1,5 @@
-﻿using DocumentFormat.OpenXml;
+﻿using System;
+using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using ShapeCrawler.Drawing;
 using ShapeCrawler.Extensions;
@@ -18,7 +19,7 @@ internal sealed class SlideShapeOutline : IShapeOutline
         this.sdkTypedOpenXmlCompositeElement = sdkTypedOpenXmlCompositeElement;
     }
 
-    public double Weight
+    public decimal Weight
     {
         get => this.ParseWeight();
         set => this.UpdateWeight(value);
@@ -30,7 +31,7 @@ internal sealed class SlideShapeOutline : IShapeOutline
         set => this.UpdateHexColor(value);
     }
 
-    private void UpdateWeight(double points)
+    private void UpdateWeight(decimal points)
     {
         var aOutline = this.sdkTypedOpenXmlCompositeElement.GetFirstChild<A.Outline>();
         var aNoFill = aOutline?.GetFirstChild<A.NoFill>();
@@ -40,7 +41,7 @@ internal sealed class SlideShapeOutline : IShapeOutline
             aOutline = this.sdkTypedOpenXmlCompositeElement.AddAOutline();
         }
 
-        aOutline.Width = new Int32Value(UnitConverter.PointToEmu(points));
+        aOutline.Width = new Int32Value((Int32)UnitConverter.PointToEmu(points));
     }
     
     private void UpdateHexColor(string? hex)
@@ -62,7 +63,7 @@ internal sealed class SlideShapeOutline : IShapeOutline
         aOutline.Append(aSolidFill);
     }
 
-    private double ParseWeight()
+    private decimal ParseWeight()
     {
         var width = this.sdkTypedOpenXmlCompositeElement.GetFirstChild<A.Outline>()?.Width;
         if (width is null)

--- a/src/ShapeCrawler/Shared/Constants.cs
+++ b/src/ShapeCrawler/Shared/Constants.cs
@@ -8,9 +8,9 @@ internal static class Constants
 
     internal static int DefaultFontSize => 18; // https://bit.ly/37Tjjlo
 
-    internal static double DefaultLeftAndRightMargin => 0.25;
+    internal static decimal DefaultLeftAndRightMargin => 0.25m; // cm
 
-    internal static double DefaultTopAndBottomMargin => 0.13;
+    internal static decimal DefaultTopAndBottomMargin => 0.13m; // cm
     
     internal static long DefaultRowHeightEmu => 370840L;
 }

--- a/src/ShapeCrawler/Shared/Pixels.cs
+++ b/src/ShapeCrawler/Shared/Pixels.cs
@@ -4,14 +4,15 @@ internal readonly ref struct Pixels
 {
     private const int HorizontalResolutionDpi = 96;
     private const int VerticalResolutionDpi = 96;
-    private readonly int pixels;
+    private const int EmusPerInch = 914400;
+    private readonly decimal pixels;
 
-    internal Pixels(int pixels)
+    internal Pixels(decimal pixels)
     {
         this.pixels = pixels;
     }
 
-    internal long AsHorizontalEmus() => this.pixels * 914400 / HorizontalResolutionDpi;
+    internal long AsHorizontalEmus() => (long)(this.pixels * EmusPerInch / HorizontalResolutionDpi);
    
-    internal long AsVerticalEmus() => this.pixels * 914400 / VerticalResolutionDpi;
+    internal long AsVerticalEmus() => (long)(this.pixels * EmusPerInch / VerticalResolutionDpi);
 }

--- a/src/ShapeCrawler/Shared/UnitConverter.cs
+++ b/src/ShapeCrawler/Shared/UnitConverter.cs
@@ -8,6 +8,8 @@ internal static class UnitConverter
     private const int VerticalResolutionDpi = 96;
     private const double AngleToDegrees = 1 / 60000d;
     private const int EmusPerInch = 914400;
+    private const int EmusPerCentimeter = 360000;
+    private const int EmusPerPoint = 12700;
 
     internal static decimal HorizontalEmuToPixel(long horizontalEmus)
     {
@@ -21,42 +23,42 @@ internal static class UnitConverter
 
     internal static long HorizontalPixelToEmu(decimal horizontalPixels)
     {
-        return (long)(horizontalPixels * EmusPerInch / HorizontalResolutionDpi);
+        return (long)Math.Round(horizontalPixels * EmusPerInch / (decimal)HorizontalResolutionDpi);
     }
 
     internal static long VerticalPixelToEmu(decimal verticalPixels)
     {
-        return (long)(verticalPixels * EmusPerInch / VerticalResolutionDpi);
+        return (long)Math.Round(verticalPixels * EmusPerInch / (decimal)VerticalResolutionDpi);
     }
 
-    internal static double EmuToCentimeter(long emu)
+    internal static decimal EmuToCentimeter(long emu)
     {
-        return Math.Round(emu * 0.000002734, 2);
+        return emu / (decimal)EmusPerCentimeter;
     }
 
-    internal static decimal CentimeterToEmu(double centimeter)
+    internal static long CentimeterToEmu(decimal centimeter)
     {
-        return (decimal)(centimeter / 0.000002734);
+        return (long)Math.Round(centimeter * EmusPerCentimeter);
     }
 
-    internal static decimal CentimeterToPixel(double centimeter)
+    internal static decimal CentimeterToPixel(decimal centimeter)
     {
-        return (decimal)(centimeter * 96 / 2.54);
+        return HorizontalEmuToPixel(CentimeterToEmu(centimeter));
     }
 
-    internal static double EmuToPoint(long emu)
+    internal static decimal EmuToPoint(long emu)
     {
-        return emu * 1.0 / 12700; // 1pt = 12700 EMUs (http://officeopenxml.com/drwSp-outline.php)
+        return emu / (decimal)EmusPerPoint; // 1pt = 12700 EMUs (http://officeopenxml.com/drwSp-outline.php)
     }
 
-    internal static int PointToEmu(double point)
+    internal static long PointToEmu(decimal point)
     {
-        return (int)(point * 12700); // 1pt = 12700 EMUs (http://officeopenxml.com/drwSp-outline.php)
+        return (long)Math.Round(point * EmusPerPoint); // 1pt = 12700 EMUs (http://officeopenxml.com/drwSp-outline.php)
     }
 
-    internal static float PointToPixel(double points)
+    internal static decimal PointToPixel(decimal point)
     {
-        return (float)(points * 96 / 72);
+        return HorizontalEmuToPixel(PointToEmu(point));
     }
 
     internal static double AngleValueToDegrees(int angle)

--- a/src/ShapeCrawler/Shared/UnitConverter.cs
+++ b/src/ShapeCrawler/Shared/UnitConverter.cs
@@ -4,46 +4,47 @@ namespace ShapeCrawler.Shared;
 
 internal static class UnitConverter
 {
-    private const float HorizontalResolutionDpi = 96;
-    private const float VerticalResolutionDpi = 96;
+    private const int HorizontalResolutionDpi = 96;
+    private const int VerticalResolutionDpi = 96;
     private const double AngleToDegrees = 1 / 60000d;
+    private const int EmusPerInch = 914400;
 
-    internal static int HorizontalEmuToPixel(long horizontalEmus)
+    internal static decimal HorizontalEmuToPixel(long horizontalEmus)
     {
-        return (int)(horizontalEmus * HorizontalResolutionDpi / 914400);
+        return horizontalEmus * HorizontalResolutionDpi / (decimal)EmusPerInch;
     }
 
-    internal static int VerticalEmuToPixel(long verticalEmus)
+    internal static decimal VerticalEmuToPixel(long verticalEmus)
     {
-        return (int)(verticalEmus * VerticalResolutionDpi / 914400);
+        return verticalEmus * VerticalResolutionDpi / (decimal)EmusPerInch;
     }
 
-    internal static long HorizontalPixelToEmu(int horizontalPixels)
+    internal static long HorizontalPixelToEmu(decimal horizontalPixels)
     {
-        return (long)(horizontalPixels * 914400 / HorizontalResolutionDpi);
+        return (long)(horizontalPixels * EmusPerInch / HorizontalResolutionDpi);
     }
 
-    internal static long VerticalPixelToEmu(long verticalPixels)
+    internal static long VerticalPixelToEmu(decimal verticalPixels)
     {
-        return (long)(verticalPixels * 914400 / VerticalResolutionDpi);
+        return (long)(verticalPixels * EmusPerInch / VerticalResolutionDpi);
     }
 
-    internal static double EmuToCentimeter(int emu)
+    internal static double EmuToCentimeter(long emu)
     {
         return Math.Round(emu * 0.000002734, 2);
     }
 
-    internal static long CentimeterToEmu(double centimeter)
+    internal static decimal CentimeterToEmu(double centimeter)
     {
-        return (long)(centimeter / 0.000002734);
+        return (decimal)(centimeter / 0.000002734);
     }
 
-    internal static int CentimeterToPixel(double centimeter)
+    internal static decimal CentimeterToPixel(double centimeter)
     {
-        return (int)(centimeter * 96 / 2.54);
+        return (decimal)(centimeter * 96 / 2.54);
     }
 
-    internal static double EmuToPoint(int emu)
+    internal static double EmuToPoint(long emu)
     {
         return emu * 1.0 / 12700; // 1pt = 12700 EMUs (http://officeopenxml.com/drwSp-outline.php)
     }

--- a/src/ShapeCrawler/SlideMasters/IMasterSlideNumber.cs
+++ b/src/ShapeCrawler/SlideMasters/IMasterSlideNumber.cs
@@ -36,13 +36,13 @@ internal sealed class MasterSlideNumber : IMasterSlideNumber
 
     public ISlideNumberFont Font { get; }
 
-    public int X
+    public decimal X
     {
         get => this.position.X();
         set => this.position.UpdateX(value);
     }
 
-    public int Y
+    public decimal Y
     {
         get => this.position.Y();
         set => this.position.UpdateY(value);

--- a/src/ShapeCrawler/Texts/ITextFrame.cs
+++ b/src/ShapeCrawler/Texts/ITextFrame.cs
@@ -24,22 +24,22 @@ public interface ITextFrame
     /// <summary>
     ///     Gets or sets left margin of text frame in centimeters.
     /// </summary>
-    double LeftMargin { get; set; }
+    decimal LeftMargin { get; set; }
 
     /// <summary>
     ///     Gets or sets right margin of text frame in centimeters.
     /// </summary>
-    double RightMargin { get; set; }
+    decimal RightMargin { get; set; }
 
     /// <summary>
     ///     Gets or sets top margin of text frame in centimeters.
     /// </summary>
-    double TopMargin { get; set; }
+    decimal TopMargin { get; set; }
 
     /// <summary>
     ///     Gets or sets bottom margin of text frame in centimeters.
     /// </summary>
-    double BottomMargin { get; set; }
+    decimal BottomMargin { get; set; }
 
     /// <summary>
     ///     Gets a value indicating whether text is wrapped in shape.

--- a/src/ShapeCrawler/Texts/NullTextFrame.cs
+++ b/src/ShapeCrawler/Texts/NullTextFrame.cs
@@ -20,25 +20,25 @@ internal class NullTextFrame : ITextFrame
         set => throw new Exception(error);
     }
     
-    public double LeftMargin 
+    public decimal LeftMargin 
     { 
         get => throw new Exception(error); 
         set => throw new Exception(error);
     }
 
-    public double RightMargin
+    public decimal RightMargin
     {
         get => throw new Exception(error); 
         set => throw new Exception(error);
     }
 
-    public double TopMargin
+    public decimal TopMargin
     {
         get => throw new Exception(error); 
         set => throw new Exception(error);
     }
 
-    public double BottomMargin
+    public decimal BottomMargin
     {
         get => throw new Exception(error); 
         set => throw new Exception(error);

--- a/src/ShapeCrawler/Texts/TextFrame.cs
+++ b/src/ShapeCrawler/Texts/TextFrame.cs
@@ -192,8 +192,8 @@ internal sealed class TextFrame : ITextFrame
         var textRect = default(SKRect);
         var text = this.Text;
         paint.MeasureText(text, ref textRect);
-        var textWidth = textRect.Width;
-        var textHeight = paint.TextSize;
+        var textWidth = (decimal)textRect.Width;
+        var textHeight = (decimal)paint.TextSize;
         var shapeSize = new ShapeSize(this.sdkTypedOpenXmlPart, this.sdkTextBody.Ancestors<P.Shape>().First());
         var currentBlockWidth = shapeSize.Width() - lMarginPixel - rMarginPixel;
         var currentBlockHeight = shapeSize.Height() - tMarginPixel - bMarginPixel;
@@ -210,8 +210,8 @@ internal sealed class TextFrame : ITextFrame
         paint.TextSize = firstPortion.Font.Size;
         var typeFace = SKTypeface.FromFamilyName(firstPortion.Font.LatinName);
         paint.Typeface = typeFace;
-        float leftMarginPx = UnitConverter.CentimeterToPixel(this.LeftMargin);
-        float topMarginPx = UnitConverter.CentimeterToPixel(this.TopMargin);
+        float leftMarginPx = (float)UnitConverter.CentimeterToPixel(this.LeftMargin);
+        float topMarginPx = (float)UnitConverter.CentimeterToPixel(this.TopMargin);
         float fontHeightPx = UnitConverter.PointToPixel(16);
         float x = shapeX + leftMarginPx;
         float y = shapeY + topMarginPx + fontHeightPx;
@@ -295,7 +295,7 @@ internal sealed class TextFrame : ITextFrame
 
         var parent = this.sdkTextBody.Parent!;
         var shapeSize = new ShapeSize(this.sdkTypedOpenXmlPart, parent);
-        var fontSize = FontService.GetAdjustedFontSize(newText, font, shapeSize.Width(), shapeSize.Height());
+        var fontSize = FontService.GetAdjustedFontSize(newText, font, (int)shapeSize.Width(), (int)shapeSize.Height());
 
         var paragraphInternal = (Paragraph)baseParagraph;
         paragraphInternal.SetFontSize(fontSize);
@@ -303,8 +303,8 @@ internal sealed class TextFrame : ITextFrame
 
     private void UpdateShapeWidthIfNeeded(
         SKPaint paint, 
-        int lMarginPixel, 
-        int rMarginPixel, 
+        decimal lMarginPixel, 
+        decimal rMarginPixel, 
         TextFrame textFrame,
         OpenXmlElement parent)
     {
@@ -326,12 +326,12 @@ internal sealed class TextFrame : ITextFrame
     }
 
     private void UpdateShapeHeight(
-        float textWidth,
-        int currentBlockWidth,
-        float textHeight,
-        int tMarginPixel,
-        int bMarginPixel,
-        int currentBlockHeight,
+        decimal textWidth,
+        decimal currentBlockWidth,
+        decimal textHeight,
+        decimal tMarginPixel,
+        decimal bMarginPixel,
+        decimal currentBlockHeight,
         OpenXmlElement parent)
     {
         var requiredRowsCount = textWidth / currentBlockWidth;
@@ -351,6 +351,6 @@ internal sealed class TextFrame : ITextFrame
         // We should raise the shape up by the amount which is half of the increased offset.
         // PowerPoint does the same thing.
         var yOffset = (requiredHeight - currentBlockHeight) / 2;
-        position.UpdateY((int)(position.Y() - yOffset));
+        position.UpdateY(position.Y() - yOffset);
     }
 }

--- a/src/ShapeCrawler/Texts/TextFrame.cs
+++ b/src/ShapeCrawler/Texts/TextFrame.cs
@@ -137,25 +137,25 @@ internal sealed class TextFrame : ITextFrame
         }
     }
 
-    public double LeftMargin
+    public decimal LeftMargin
     {
         get => this.GetLeftMargin();
         set => this.SetLeftMargin(value);
     }
 
-    public double RightMargin
+    public decimal RightMargin
     {
         get => this.GetRightMargin();
         set => this.SetRightMargin(value);
     }
 
-    public double TopMargin
+    public decimal TopMargin
     {
         get => this.GetTopMargin();
         set => this.SetTopMargin(value);
     }
 
-    public double BottomMargin
+    public decimal BottomMargin
     {
         get => this.GetBottomMargin();
         set => this.SetBottomMargin(value);
@@ -212,48 +212,48 @@ internal sealed class TextFrame : ITextFrame
         paint.Typeface = typeFace;
         float leftMarginPx = (float)UnitConverter.CentimeterToPixel(this.LeftMargin);
         float topMarginPx = (float)UnitConverter.CentimeterToPixel(this.TopMargin);
-        float fontHeightPx = UnitConverter.PointToPixel(16);
+        float fontHeightPx = (float)UnitConverter.PointToPixel(16);
         float x = shapeX + leftMarginPx;
         float y = shapeY + topMarginPx + fontHeightPx;
         slideCanvas.DrawText(this.Text, x, y, paint);
     }
 
-    private double GetLeftMargin()
+    private decimal GetLeftMargin()
     {
         var bodyProperties = this.sdkTextBody.GetFirstChild<A.BodyProperties>() !;
         var ins = bodyProperties.LeftInset;
         return ins is null ? Constants.DefaultLeftAndRightMargin : UnitConverter.EmuToCentimeter(ins.Value);
     }
 
-    private double GetRightMargin()
+    private decimal GetRightMargin()
     {
         var bodyProperties = this.sdkTextBody.GetFirstChild<A.BodyProperties>() !;
         var ins = bodyProperties.RightInset;
         return ins is null ? Constants.DefaultLeftAndRightMargin : UnitConverter.EmuToCentimeter(ins.Value);
     }
 
-    private void SetLeftMargin(double centimetre)
+    private void SetLeftMargin(decimal centimetre)
     {
         var bodyProperties = this.sdkTextBody.GetFirstChild<A.BodyProperties>() !;
         var emu = UnitConverter.CentimeterToEmu(centimetre);
         bodyProperties.LeftInset = new Int32Value((int)emu);
     }
 
-    private void SetRightMargin(double centimetre)
+    private void SetRightMargin(decimal centimetre)
     {
         var bodyProperties = this.sdkTextBody.GetFirstChild<A.BodyProperties>() !;
         var emu = UnitConverter.CentimeterToEmu(centimetre);
         bodyProperties.RightInset = new Int32Value((int)emu);
     }
 
-    private void SetTopMargin(double centimetre)
+    private void SetTopMargin(decimal centimetre)
     {
         var bodyProperties = this.sdkTextBody.GetFirstChild<A.BodyProperties>() !;
         var emu = UnitConverter.CentimeterToEmu(centimetre);
         bodyProperties.TopInset = new Int32Value((int)emu);
     }
 
-    private void SetBottomMargin(double centimetre)
+    private void SetBottomMargin(decimal centimetre)
     {
         var bodyProperties = this.sdkTextBody.GetFirstChild<A.BodyProperties>() !;
         var emu = UnitConverter.CentimeterToEmu(centimetre);
@@ -273,14 +273,14 @@ internal sealed class TextFrame : ITextFrame
         return true;
     }
 
-    private double GetTopMargin()
+    private decimal GetTopMargin()
     {
         var bodyProperties = this.sdkTextBody.GetFirstChild<A.BodyProperties>() !;
         var ins = bodyProperties.TopInset;
         return ins is null ? Constants.DefaultTopAndBottomMargin : UnitConverter.EmuToCentimeter(ins.Value);
     }
 
-    private double GetBottomMargin()
+    private decimal GetBottomMargin()
     {
         var bodyProperties = this.sdkTextBody.GetFirstChild<A.BodyProperties>() !;
         var ins = bodyProperties.BottomInset;
@@ -343,7 +343,7 @@ internal sealed class TextFrame : ITextFrame
         }
 
         var requiredHeight = (integerPart * textHeight) + tMarginPixel + bMarginPixel;
-        var newHeight = (int)requiredHeight + tMarginPixel + bMarginPixel + tMarginPixel + bMarginPixel;
+        var newHeight = requiredHeight + tMarginPixel + bMarginPixel + tMarginPixel + bMarginPixel;
         var position = new Position(this.sdkTypedOpenXmlPart, parent);
         var size = new ShapeSize(this.sdkTypedOpenXmlPart, parent);
         size.UpdateHeight(newHeight);

--- a/test/ShapeCrawler.Tests.Unit.xUnit/Helpers/TestHelper.cs
+++ b/test/ShapeCrawler.Tests.Unit.xUnit/Helpers/TestHelper.cs
@@ -23,7 +23,7 @@ public static class TestHelper
         return mStream;
     }
 
-    public static readonly float HorizontalResolution;
+    public static readonly int HorizontalResolution;
 
-    public static readonly float VerticalResolution;
+    public static readonly int VerticalResolution;
 }

--- a/test/ShapeCrawler.Tests.Unit/ParagraphTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ParagraphTests.cs
@@ -144,8 +144,10 @@ public class ParagraphTests : SCTest
 
         // Assert
         // TODO: Investigate! This is a pretty big approximation delta
-        shape.Height.Should().BeApproximately(46,5m);
-        shape.Y.Should().BeApproximately(147,2m);
+        // NOTE: Doing this operation in Excel results in 45.12, so about what we had before.
+        // In ShapeCrawler now, it's 50.88
+        shape.Height.Should().BeApproximately(51.48m,0.01m);
+        shape.Y.Should().Be(145m);
     }
 
     [Test]

--- a/test/ShapeCrawler.Tests.Unit/ParagraphTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ParagraphTests.cs
@@ -143,8 +143,9 @@ public class ParagraphTests : SCTest
         paragraph.Text = "AutoShape 4 some text";
 
         // Assert
-        shape.Height.Should().Be(46);
-        shape.Y.Should().Be(147);
+        // TODO: Investigate! This is a pretty big approximation delta
+        shape.Height.Should().BeApproximately(46,5m);
+        shape.Y.Should().BeApproximately(147,2m);
     }
 
     [Test]

--- a/test/ShapeCrawler.Tests.Unit/ShapeOutlineTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeOutlineTests.cs
@@ -12,7 +12,7 @@ public class ShapeOutlineTests : SCTest
     [SlideShapeData("autoshape-grouping.pptx", 1, "TextBox 4", 0)]
     [SlideShapeData("autoshape-grouping.pptx", 1, "TextBox 6", 0.25)]
     [SlideShapeData("020.pptx", 1, "Shape 1", 0)]
-    public void Weight_Getter_returns_outline_weight_in_points(IShape shape, double expectedWeight)
+    public void Weight_Getter_returns_outline_weight_in_points(IShape shape, decimal expectedWeight)
     {
         // Arrange
         var autoShape = (IShape)shape;
@@ -36,10 +36,10 @@ public class ShapeOutlineTests : SCTest
         var outline = shape.Outline;
         
         // Act
-        outline.Weight = 0.25;
+        outline.Weight = 0.25m;
 
         // Assert
-        outline.Weight.Should().Be(0.25);
+        outline.Weight.Should().Be(0.25m);
         pres.Validate();
     }
 

--- a/test/ShapeCrawler.Tests.Unit/ShapeTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeTests.cs
@@ -105,9 +105,9 @@ public class ShapeTests : SCTest
         float verticalResoulution = Helpers.TestHelper.VerticalResolution;
 
         // Act
-        int yCoordinate1 = shapeCase1.Y;
-        int yCoordinate2 = shapeCase2.Y;
-        int yCoordinate3 = shapeCase3.Y;
+        decimal yCoordinate1 = shapeCase1.Y;
+        decimal yCoordinate2 = shapeCase2.Y;
+        decimal yCoordinate3 = shapeCase3.Y;
 
         // Assert
         yCoordinate1.Should().Be((int)(1122363 * verticalResoulution / 914400));
@@ -144,7 +144,7 @@ public class ShapeTests : SCTest
         // Assert
         groupedShape.Y.Should().Be(359);
         parentGroupShape.Y.Should().Be(359, "because the moved grouped shape was on the up-hand side");
-        parentGroupShape.Height.Should().Be(172);
+        parentGroupShape.Height.Should().BeApproximately(172,1m);
     }
 
     [Test]
@@ -160,7 +160,7 @@ public class ShapeTests : SCTest
 
         // Assert
         groupedShape.Y.Should().Be(555);
-        groupShape.Height.Should().Be(178, "because it was 108 and the down-hand grouped shape got down on 71 pixels");
+        groupShape.Height.Should().BeApproximately(178, 2m, "because it was 108 and the down-hand grouped shape got down on 71 pixels");
     }
 
     [Test]
@@ -177,7 +177,7 @@ public class ShapeTests : SCTest
         // Assert
         groupedShape.X.Should().Be(67);
         groupShape.X.Should().Be(67, "because the moved grouped shape was on the left-hand side");
-        groupShape.Width.Should().Be(117);
+        groupShape.Width.Should().BeApproximately(117,1m);
     }
 
     [Test]
@@ -195,7 +195,7 @@ public class ShapeTests : SCTest
         groupedShape.X.Should().Be(91);
         groupShape.X.Should().Be(79,
             "because the X-coordinate of parent group shouldn't be changed when a grouped shape is moved to the right side");
-        groupShape.Width.Should().Be(115);
+        groupShape.Width.Should().BeApproximately(115,1m);
     }
 
     [Test]
@@ -208,14 +208,14 @@ public class ShapeTests : SCTest
         IShape shapeCase3 = new Presentation(StreamOf("009_table.pptx")).Slides[1].Shapes.First(sp => sp.Id == 9);
 
         // Act
-        int width1 = shapeCase1.Width;
-        int width2 = shapeCase2.Width;
-        int width3 = shapeCase3.Width;
+        decimal width1 = shapeCase1.Width;
+        decimal width2 = shapeCase2.Width;
+        decimal width3 = shapeCase3.Width;
 
         // Assert
-        (width1 * 914400 / TestHelper.HorizontalResolution).Should().Be(9144000);
-        (width2 * 914400 / TestHelper.HorizontalResolution).Should().Be(1181100);
-        (width3 * 914400 / TestHelper.HorizontalResolution).Should().Be(485775);
+        (width1 * 914400 / TestHelper.HorizontalResolution).Should().Be(9144000m);
+        (width2 * 914400 / TestHelper.HorizontalResolution).Should().BeApproximately(1181100m,1000m);
+        (width3 * 914400 / TestHelper.HorizontalResolution).Should().Be(485775m);
     }
 
     [Test]
@@ -231,7 +231,7 @@ public class ShapeTests : SCTest
         var height = groupedShape.Height;
 
         // Assert
-        height.Should().Be(68);
+        height.Should().BeApproximately(68,1m);
     }
 
     [TestCase(2, Geometry.Rectangle)]
@@ -494,7 +494,7 @@ public class ShapeTests : SCTest
     public void X_Getter_returns_x_coordinate_in_pixels(IShape shape, int expectedX)
     {
         // Act
-        int x = shape.X;
+        decimal x = shape.X;
 
         // Assert
         x.Should().Be(expectedX);
@@ -508,10 +508,10 @@ public class ShapeTests : SCTest
         var shape = pres.Slides[1].Shapes.GetByName<IGroupShape>("Group 1").Shapes.GetByName<IShape>("Shape 1");
         
         // Act
-        int x = shape.X;
+        decimal x = shape.X;
         
         // Assert
-        x.Should().Be(53);
+        x.Should().BeApproximately(53,1m);
     }
     
     [Test]
@@ -531,7 +531,7 @@ public class ShapeTests : SCTest
         var shapeWidth = shape.Width;
 
         // Assert
-        shapeWidth.Should().Be(expectedWidth);
+        shapeWidth.Should().BeApproximately(expectedWidth,1m);
     }
     
     [Test]
@@ -544,7 +544,7 @@ public class ShapeTests : SCTest
         var height = shape.Height;
 
         // Assert
-        height.Should().Be(expectedHeight);
+        height.Should().BeApproximately(expectedHeight,1m);
     }
     
     [Test]

--- a/test/ShapeCrawler.Tests.Unit/ShapeTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeTests.cs
@@ -144,7 +144,7 @@ public class ShapeTests : SCTest
         // Assert
         groupedShape.Y.Should().Be(359);
         parentGroupShape.Y.Should().Be(359, "because the moved grouped shape was on the up-hand side");
-        parentGroupShape.Height.Should().BeApproximately(172,1m);
+        parentGroupShape.Height.Should().BeApproximately(172.84m,0.01m);
     }
 
     [Test]
@@ -160,7 +160,7 @@ public class ShapeTests : SCTest
 
         // Assert
         groupedShape.Y.Should().Be(555);
-        groupShape.Height.Should().BeApproximately(178, 2m, "because it was 108 and the down-hand grouped shape got down on 71 pixels");
+        groupShape.Height.Should().BeApproximately(179.11m, 0.01m, "because it was 108 and the down-hand grouped shape got down on 71 pixels");
     }
 
     [Test]
@@ -177,7 +177,7 @@ public class ShapeTests : SCTest
         // Assert
         groupedShape.X.Should().Be(67);
         groupShape.X.Should().Be(67, "because the moved grouped shape was on the left-hand side");
-        groupShape.Width.Should().BeApproximately(117,1m);
+        groupShape.Width.Should().BeApproximately(117.25m,0.01m);
     }
 
     [Test]
@@ -195,7 +195,7 @@ public class ShapeTests : SCTest
         groupedShape.X.Should().Be(91);
         groupShape.X.Should().Be(79,
             "because the X-coordinate of parent group shouldn't be changed when a grouped shape is moved to the right side");
-        groupShape.Width.Should().BeApproximately(115,1m);
+        groupShape.Width.Should().BeApproximately(115.97m,0.01m);
     }
 
     [Test]
@@ -214,7 +214,7 @@ public class ShapeTests : SCTest
 
         // Assert
         (width1 * 914400 / TestHelper.HorizontalResolution).Should().Be(9144000m);
-        (width2 * 914400 / TestHelper.HorizontalResolution).Should().BeApproximately(1181100m,1000m);
+        (width2 * 914400 / TestHelper.HorizontalResolution).Should().Be(1181377m);
         (width3 * 914400 / TestHelper.HorizontalResolution).Should().Be(485775m);
     }
 
@@ -231,7 +231,7 @@ public class ShapeTests : SCTest
         var height = groupedShape.Height;
 
         // Assert
-        height.Should().BeApproximately(68,1m);
+        height.Should().BeApproximately(68.67m,0.01m);
     }
 
     [TestCase(2, Geometry.Rectangle)]
@@ -316,10 +316,10 @@ public class ShapeTests : SCTest
         shape.Hidden.Should().Be(expectedHidden);
     }
 
-    [TestCase("autoshape-case018_rotation.pptx", 1, "RotationTextBox", 325)]
-    [TestCase("autoshape-case018_rotation.pptx", 2, "VerticalTextPH", 282)]
+    [TestCase("autoshape-case018_rotation.pptx", 1, "RotationTextBox", 325.40)]
+    [TestCase("autoshape-case018_rotation.pptx", 2, "VerticalTextPH", 281.97)]
     [TestCase("autoshape-case018_rotation.pptx", 2, "NoRotationGroup", 0)]
-    [TestCase("autoshape-case018_rotation.pptx", 2, "RotationGroup", 56)]
+    [TestCase("autoshape-case018_rotation.pptx", 2, "RotationGroup", 55.60)]
     public void Rotation_returns_shape_rotation_in_degrees(string presentationName, int slideNumber, string shapeName, double expectedAngle)
     {
         // Arrange
@@ -330,7 +330,7 @@ public class ShapeTests : SCTest
         var rotation = shape.Rotation;
 
         // Assert
-        rotation.Should().BeApproximately(expectedAngle, 1);
+        rotation.Should().BeApproximately(expectedAngle, 0.01);
     }
     
     [Test]
@@ -511,17 +511,17 @@ public class ShapeTests : SCTest
         decimal x = shape.X;
         
         // Assert
-        x.Should().BeApproximately(53,1m);
+        x.Should().BeApproximately(53.05m,0.01m);
     }
     
     [Test]
-    [TestCase("050_title-placeholder.pptx", 1, 2, 777)]
-    [TestCase("051_title-placeholder.pptx", 1, 3074, 864)]
+    [TestCase("050_title-placeholder.pptx", 1, 2, 777.6)]
+    [TestCase("051_title-placeholder.pptx", 1, 3074, 864.0)]
     public void Width_returns_width_of_Title_placeholder(
         string filename, 
         int slideNumber, 
         int shapeId,
-        int expectedWidth)
+        decimal expectedWidth)
     {
         // Arrange
         var pres = new Presentation(StreamOf(filename));
@@ -531,20 +531,20 @@ public class ShapeTests : SCTest
         var shapeWidth = shape.Width;
 
         // Assert
-        shapeWidth.Should().BeApproximately(expectedWidth,1m);
+        shapeWidth.Should().Be(expectedWidth);
     }
     
     [Test]
-    [SlideShape("006_1 slides.pptx", 1, "Shape 2", 149)]
-    [SlideShape( "009_table.pptx", 2, "Object 3", 39)]
-    [SlideShape( "autoshape-grouping.pptx", 1, "Group 2", 108)]
-    public void Height_returns_shape_height_in_pixels(IShape shape, int expectedHeight)
+    [SlideShape("006_1 slides.pptx", 1, "Shape 2", 149.66)]
+    [SlideShape( "009_table.pptx", 2, "Object 3", 39.17)]
+    [SlideShape( "autoshape-grouping.pptx", 1, "Group 2", 108.02)]
+    public void Height_returns_shape_height_in_pixels(IShape shape, double expectedHeight)
     {
         // Act
         var height = shape.Height;
 
         // Assert
-        height.Should().BeApproximately(expectedHeight,1m);
+        height.Should().BeApproximately((decimal)expectedHeight,0.01m);
     }
     
     [Test]

--- a/test/ShapeCrawler.Tests.Unit/SlideMasterTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/SlideMasterTests.cs
@@ -52,8 +52,8 @@ public class SlideMasterTests : SCTest
        IShape shape = slideMaster.Shapes.First(sp => sp.Id == 2);
 
         // Act
-        int shapeXCoordinate = shape.X;
-        int shapeYCoordinate = shape.Y;
+        decimal shapeXCoordinate = shape.X;
+        decimal shapeYCoordinate = shape.Y;
 
         // Assert
         shapeXCoordinate.Should().Be((int)(838200 * Helpers.TestHelper.HorizontalResolution / 914400));
@@ -72,12 +72,12 @@ public class SlideMasterTests : SCTest
         float verticalResolution = Helpers.TestHelper.VerticalResolution;
 
         // Act
-        int shapeWidth = shape.Width;
-        int shapeHeight = shape.Height;
+        decimal shapeWidth = shape.Width;
+        decimal shapeHeight = shape.Height;
 
         // Assert
         shapeWidth.Should().Be((int)(10515600 * horizontalResolution / 914400));
-        shapeHeight.Should().Be((int)(1325563 * verticalResolution / 914400));
+        shapeHeight.Should().BeApproximately((int)(1325563 * verticalResolution / 914400),1m);
     }
 
     [Test]

--- a/test/ShapeCrawler.Tests.Unit/SlideMasterTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/SlideMasterTests.cs
@@ -68,16 +68,16 @@ public class SlideMasterTests : SCTest
         var pres = new Presentation(pptx);
         ISlideMaster slideMaster = pres.SlideMasters[0];
         IShape shape = slideMaster.Shapes.First(sp => sp.Id == 2);
-        float horizontalResolution = Helpers.TestHelper.HorizontalResolution;
-        float verticalResolution = Helpers.TestHelper.VerticalResolution;
+        var horizontalResolution = Helpers.TestHelper.HorizontalResolution;
+        var verticalResolution = Helpers.TestHelper.VerticalResolution;
 
         // Act
         decimal shapeWidth = shape.Width;
         decimal shapeHeight = shape.Height;
 
         // Assert
-        shapeWidth.Should().Be((int)(10515600 * horizontalResolution / 914400));
-        shapeHeight.Should().BeApproximately((int)(1325563 * verticalResolution / 914400),1m);
+        shapeWidth.Should().Be(10515600m * horizontalResolution / 914400m);
+        shapeHeight.Should().Be(1325563m * verticalResolution / 914400m);
     }
 
     [Test]

--- a/test/ShapeCrawler.Tests.Unit/TableTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/TableTests.cs
@@ -199,7 +199,7 @@ public class TableTests : SCTest
 
         // Assert
         row.Height.Should().Be(58);
-        table.Height.Should().BeApproximately(76, 1m, "because table height was 38px.");
+        table.Height.Should().BeApproximately(76.93m, 0.01m, "because table height was 38px.");
     }
 
     [Test(Description = "MergeCells #1")]

--- a/test/ShapeCrawler.Tests.Unit/TableTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/TableTests.cs
@@ -199,7 +199,7 @@ public class TableTests : SCTest
 
         // Assert
         row.Height.Should().Be(58);
-        table.Height.Should().Be(76, "because table height was 38px.");
+        table.Height.Should().BeApproximately(76, 1m, "because table height was 38px.");
     }
 
     [Test(Description = "MergeCells #1")]

--- a/test/ShapeCrawler.Tests.Unit/TextFrameTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/TextFrameTests.cs
@@ -114,8 +114,8 @@ namespace ShapeCrawler.Tests.Unit.xUnit
 
             // Assert
             // TODO: Investigate this wide range
-            shape.Height.Should().BeApproximately(46,5m);
-            shape.Y.Should().BeApproximately(151,2m);
+            shape.Height.Should().BeApproximately(51.48m,0.01m);
+            shape.Y.Should().Be(149m);
             pres.Validate();
         }
 
@@ -148,7 +148,7 @@ namespace ShapeCrawler.Tests.Unit.xUnit
             textFrame.AutofitType = AutofitType.Resize;
 
             // Assert
-            shape.Width.Should().BeApproximately(107,1m);
+            shape.Width.Should().BeApproximately(107.90m,0.01m);
             pres.Validate();
         }
 
@@ -166,7 +166,10 @@ namespace ShapeCrawler.Tests.Unit.xUnit
 
             // Assert
             // TODO: Investigate wide approximation range 
-            shape.Height.Should().BeApproximately(35, 5m);
+            // NOTE: When performing this operation in Powerpoint, the resulting shape is 0.29 inches. (27.84)
+            // In current ShapeCrawler code, it's 0.41 inches, (39.36). 
+            // Oddly the original value isn't right either.
+            shape.Height.Should().BeApproximately(40.48m, 0.01m);
             pres.Validate();
         }
 
@@ -301,7 +304,7 @@ namespace ShapeCrawler.Tests.Unit.xUnit
 
             // Assert
             // TODO: Investigate wide approximation range
-            shape.Height.Should().BeApproximately(88,5m);
+            shape.Height.Should().BeApproximately(93.48m,0.01m);
         }
         
         [Test]
@@ -445,7 +448,7 @@ namespace ShapeCrawler.Tests.Unit.xUnit
             var leftMargin = textFrame.LeftMargin;
             
             // Assert
-            leftMargin.Should().Be(expectedMargin);
+            leftMargin.Should().Be((decimal)expectedMargin);
         }
         
         [Test]
@@ -457,10 +460,10 @@ namespace ShapeCrawler.Tests.Unit.xUnit
             var textFrame = autoShape.TextFrame;
             
             // Act
-            textFrame.LeftMargin = 0.5;
+            textFrame.LeftMargin = 0.5m;
             
             // Assert
-            textFrame.LeftMargin.Should().Be(0.5);
+            textFrame.LeftMargin.Should().Be(0.5m);
         }
         
         [Test]
@@ -475,7 +478,7 @@ namespace ShapeCrawler.Tests.Unit.xUnit
             var rightMargin = textFrame.RightMargin;
             
             // Assert
-            rightMargin.Should().Be(expectedMargin);
+            rightMargin.Should().Be((decimal)expectedMargin);
         }
         
         [Test]
@@ -491,7 +494,7 @@ namespace ShapeCrawler.Tests.Unit.xUnit
             var topMargin = textFrame.TopMargin;
             
             // Assert
-            topMargin.Should().Be(expectedMargin);
+            topMargin.Should().Be((decimal)expectedMargin);
         }
         
         [Test]
@@ -506,7 +509,7 @@ namespace ShapeCrawler.Tests.Unit.xUnit
             var bottomMargin = textFrame.BottomMargin;
             
             // Assert
-            bottomMargin.Should().Be(expectedMargin);
+            bottomMargin.Should().Be((decimal)expectedMargin);
         }
     }
 }

--- a/test/ShapeCrawler.Tests.Unit/TextFrameTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/TextFrameTests.cs
@@ -113,8 +113,9 @@ namespace ShapeCrawler.Tests.Unit.xUnit
             textFrame.Text = "AutoShape 4 some text";
 
             // Assert
-            shape.Height.Should().Be(46);
-            shape.Y.Should().Be(151);
+            // TODO: Investigate this wide range
+            shape.Height.Should().BeApproximately(46,5m);
+            shape.Y.Should().BeApproximately(151,2m);
             pres.Validate();
         }
 
@@ -147,7 +148,7 @@ namespace ShapeCrawler.Tests.Unit.xUnit
             textFrame.AutofitType = AutofitType.Resize;
 
             // Assert
-            shape.Width.Should().Be(107);
+            shape.Width.Should().BeApproximately(107,1m);
             pres.Validate();
         }
 
@@ -164,7 +165,8 @@ namespace ShapeCrawler.Tests.Unit.xUnit
             textFrame.AutofitType = AutofitType.Resize;
 
             // Assert
-            shape.Height.Should().Be(35);
+            // TODO: Investigate wide approximation range 
+            shape.Height.Should().BeApproximately(35, 5m);
             pres.Validate();
         }
 
@@ -298,7 +300,8 @@ namespace ShapeCrawler.Tests.Unit.xUnit
             textFrame.Text = "Some sentence. Some sentence";
 
             // Assert
-            shape.Height.Should().Be(88);
+            // TODO: Investigate wide approximation range
+            shape.Height.Should().BeApproximately(88,5m);
         }
         
         [Test]


### PR DESCRIPTION
As discussed in #686. This is a wide-reaching change.

Of note, there were a handful of unit tests which required fairly large (+/- 5) approximation margins, which seems odd and worthy of further study.

This did work fine for my fairly limited use cases.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates various properties and methods across the codebase to use `decimal` instead of `int` or `double` for more precise calculations and measurements.

### Detailed summary
- Changed properties `X`, `Y`, `Width`, `Height`, `LeftMargin`, `RightMargin`, `TopMargin`, `BottomMargin` to `decimal`
- Updated methods to use `decimal` parameters for more accurate calculations

> The following files were skipped due to too many changes: `src/ShapeCrawler/ShapeCollection/ShapeSize.cs`, `src/ShapeCrawler/ShapeCollection/RootShape.cs`, `test/ShapeCrawler.Tests.Unit/SlideMasterTests.cs`, `src/ShapeCrawler/ShapeCollection/SlideShapeOutline.cs`, `test/ShapeCrawler.Tests.Unit/TextFrameTests.cs`, `src/ShapeCrawler/Shared/UnitConverter.cs`, `test/ShapeCrawler.Tests.Unit/ShapeTests.cs`, `src/ShapeCrawler/Texts/TextFrame.cs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->