### PR TITLE
Added SVG support to ISlideShapes.AddPicture()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog  
 
+## Version 0.52.0 - Unreleased
+🍀Added support for the SVG format for the `ISlideShapes.AddPicture()` method [#350](https://github.com/ShapeCrawler/ShapeCrawler/issues/350)
+
 ## Version 0.51.0 - 2024-05-11
 🍀Added `IShapeFill.SetNoFill()` to remove shape filling [#667](https://github.com/ShapeCrawler/ShapeCrawler/issues/667)
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds support for the SVG format in the `ISlideShapes.AddPicture()` method.

### Detailed summary
- Added support for the SVG format in `ISlideShapes.AddPicture()` method
- Issue #350 on GitHub was addressed

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->