### PR TITLE
Remove extraneous TODO comments

### DIFF
--- a/test/ShapeCrawler.Tests.Unit/ParagraphTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ParagraphTests.cs
@@ -143,9 +143,6 @@ public class ParagraphTests : SCTest
         paragraph.Text = "AutoShape 4 some text";
 
         // Assert
-        // TODO: Investigate! This is a pretty big approximation delta
-        // NOTE: Doing this operation in Excel results in 45.12, so about what we had before.
-        // In ShapeCrawler now, it's 50.88
         shape.Height.Should().BeApproximately(51.48m,0.01m);
         shape.Y.Should().Be(145m);
     }

--- a/test/ShapeCrawler.Tests.Unit/TextFrameTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/TextFrameTests.cs
@@ -113,7 +113,6 @@ namespace ShapeCrawler.Tests.Unit.xUnit
             textFrame.Text = "AutoShape 4 some text";
 
             // Assert
-            // TODO: Investigate this wide range
             shape.Height.Should().BeApproximately(51.48m,0.01m);
             shape.Y.Should().Be(149m);
             pres.Validate();
@@ -165,10 +164,6 @@ namespace ShapeCrawler.Tests.Unit.xUnit
             textFrame.AutofitType = AutofitType.Resize;
 
             // Assert
-            // TODO: Investigate wide approximation range 
-            // NOTE: When performing this operation in Powerpoint, the resulting shape is 0.29 inches. (27.84)
-            // In current ShapeCrawler code, it's 0.41 inches, (39.36). 
-            // Oddly the original value isn't right either.
             shape.Height.Should().BeApproximately(40.48m, 0.01m);
             pres.Validate();
         }
@@ -303,7 +298,6 @@ namespace ShapeCrawler.Tests.Unit.xUnit
             textFrame.Text = "Some sentence. Some sentence";
 
             // Assert
-            // TODO: Investigate wide approximation range
             shape.Height.Should().BeApproximately(93.48m,0.01m);
         }
         


### PR DESCRIPTION
I already did them, just neglected to remove them.

Related to #686

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates assertion values in unit tests for ShapeCrawler. 

### Detailed summary
- Updated assertion values in `ParagraphTests.cs` and `TextFrameTests.cs`
- Removed TODO comments related to investigation of wide approximation ranges

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->