### PR TITLE
Change font sizes to decimal type

### DIFF
--- a/src/ShapeCrawler/Fonts/IFont.cs
+++ b/src/ShapeCrawler/Fonts/IFont.cs
@@ -9,5 +9,5 @@ public interface IFont
     /// <summary>
     ///     Gets or sets font size in points.
     /// </summary>
-    int Size { get; set; }
+    decimal Size { get; set; }
 }

--- a/src/ShapeCrawler/Fonts/IFontSize.cs
+++ b/src/ShapeCrawler/Fonts/IFontSize.cs
@@ -8,10 +8,10 @@ internal interface IFontSize
     /// <summary>
     ///     Font size in points.
     /// </summary>
-    int Size();
+    decimal Size();
     
     /// <summary>
     ///     Updates font size in points.
     /// </summary>
-    void Update(int points);
+    void Update(decimal points);
 }

--- a/src/ShapeCrawler/Fonts/PortionFontSize.cs
+++ b/src/ShapeCrawler/Fonts/PortionFontSize.cs
@@ -12,6 +12,7 @@ namespace ShapeCrawler.Fonts;
 
 internal class PortionFontSize : IFontSize
 {
+    private const decimal HalfPointsInPoint = 100m;
     private readonly OpenXmlPart sdkTypedOpenXmlPart;
     private readonly A.Text aText;
 
@@ -21,19 +22,19 @@ internal class PortionFontSize : IFontSize
         this.aText = aText;
     }
 
-    int IFontSize.Size()
+    decimal IFontSize.Size()
     {
         var fontSize = this.aText.Parent!.GetFirstChild<A.RunProperties>()?.FontSize
             ?.Value;
         if (fontSize != null)
         {
-            return fontSize.Value / 100;
+            return fontSize.Value / HalfPointsInPoint;
         }
  
         var size = new ReferencedIndent(this.sdkTypedOpenXmlPart, this.aText).FontSizeOrNull();
         if (size != null)
         {
-            return size.Value / 100;
+            return size.Value / HalfPointsInPoint;
         }
 
         var indentLevel = new AParagraphWrap(this.aText.Ancestors<A.Paragraph>().First()).IndentLevel();
@@ -60,7 +61,7 @@ internal class PortionFontSize : IFontSize
             {
                 var titleFontSize = sdkSlideMasterPart.SlideMaster.TextStyles!.TitleStyle!.Level1ParagraphProperties!
                     .GetFirstChild<A.DefaultRunProperties>() !.FontSize!.Value;
-                return titleFontSize / 100;
+                return titleFontSize / HalfPointsInPoint;
             }
             
             var indentFonts =
@@ -68,7 +69,7 @@ internal class PortionFontSize : IFontSize
             var indentFont = indentFonts.FontOrNull(indentLevel);
             if (indentFont != null)
             {
-                return indentFont.Value.Size!.Value / 100;
+                return indentFont.Value.Size!.Value / HalfPointsInPoint;
             }    
         }
         
@@ -80,7 +81,7 @@ internal class PortionFontSize : IFontSize
             var defaultTextStyleFont = defaultTextStyleFonts.FontOrNull(indentLevel);
             if (defaultTextStyleFont.HasValue && defaultTextStyleFont.Value.Size != null)
             {
-                return defaultTextStyleFont.Value.Size!.Value / 100;
+                return defaultTextStyleFont.Value.Size!.Value / HalfPointsInPoint;
             }
 
             var aTextDefault2 = pPresentation.PresentationPart!.ThemePart!.Theme.ObjectDefaults!.TextDefault;
@@ -91,7 +92,7 @@ internal class PortionFontSize : IFontSize
                 var listStyleFontsFont = listStyleFonts.FontOrNull(indentLevel);
                 if (listStyleFontsFont.HasValue && listStyleFontsFont.Value.Size != null)
                 {
-                    return listStyleFontsFont.Value.Size!.Value / 100;
+                    return listStyleFontsFont.Value.Size!.Value / HalfPointsInPoint;
                 }
             }
         }
@@ -103,7 +104,7 @@ internal class PortionFontSize : IFontSize
             var indentFont2 = indentFonts2.FontOrNull(indentLevel);
             if (indentFont2 != null && indentFont2.Value.Size != null)
             {
-                return indentFont2.Value.Size!.Value / 100;
+                return indentFont2.Value.Size!.Value / HalfPointsInPoint;
             }
         }
 
@@ -114,14 +115,14 @@ internal class PortionFontSize : IFontSize
             var listStyleFont = listStyleFonts.FontOrNull(indentLevel);
             if (listStyleFont.HasValue && listStyleFont.Value.Size != null)
             {
-                return listStyleFont.Value.Size!.Value / 100;
+                return listStyleFont.Value.Size!.Value / HalfPointsInPoint;
             }
         }
 
         return Constants.DefaultFontSize;
     }
 
-    void IFontSize.Update(int points)
+    void IFontSize.Update(decimal points)
     {
         var parent = this.aText.Parent!;
         var aRunPr = parent.GetFirstChild<A.RunProperties>();
@@ -132,6 +133,6 @@ internal class PortionFontSize : IFontSize
             parent.InsertAt(aRunPr, 0);
         }
 
-        aRunPr.FontSize = points * 100;
+        aRunPr.FontSize = (int)(points * HalfPointsInPoint);
     }
 }

--- a/src/ShapeCrawler/Fonts/TextPortionFont.cs
+++ b/src/ShapeCrawler/Fonts/TextPortionFont.cs
@@ -45,7 +45,7 @@ internal sealed class TextPortionFont : ITextPortionFont
 
     #region Public APIs
 
-    public int Size
+    public decimal Size
     {
         get => this.size.Size();
         set => this.size.Update(value);

--- a/src/ShapeCrawler/Services/FontService.cs
+++ b/src/ShapeCrawler/Services/FontService.cs
@@ -14,7 +14,7 @@ internal static class FontService
 
         var paint = new SKPaint();
         var fontSize = font.Size;
-        paint.TextSize = fontSize;
+        paint.TextSize = (float)fontSize;
         paint.Typeface = SKTypeface.FromFamilyName(font.LatinName);
         paint.IsAntialias = true;
         const int defaultPaddingSize = 10;

--- a/src/ShapeCrawler/SlideMasters/ISlideNumberFont.cs
+++ b/src/ShapeCrawler/SlideMasters/ISlideNumberFont.cs
@@ -32,7 +32,7 @@ internal sealed class SlideNumberFont : ISlideNumberFont
         set => this.UpdateColor(value);
     }
 
-    public int Size
+    public decimal Size
     {
         get => this.masterSlideNumberSize.Size();
         set => this.masterSlideNumberSize.Update(value);

--- a/src/ShapeCrawler/Texts/LayoutSlideNumberSize.cs
+++ b/src/ShapeCrawler/Texts/LayoutSlideNumberSize.cs
@@ -10,7 +10,7 @@ internal record LayoutSlideNumberSize : IFontSize
 {
     private readonly P.TextBody pTextBody;
     private readonly ISlideNumberFont masterSlideNumberFont;
-    private const int HalfPointsInPoint = 100;
+    private const decimal HalfPointsInPoint = 100m;
 
     internal LayoutSlideNumberSize(P.TextBody pTextBody, ISlideNumberFont masterSlideNumberFont)
     {
@@ -18,7 +18,7 @@ internal record LayoutSlideNumberSize : IFontSize
         this.masterSlideNumberFont = masterSlideNumberFont;
     }
 
-    public int Size()
+    public decimal Size()
     {
         var halfPoints = this.pTextBody.Descendants<A.Field>().First().RunProperties?.FontSize?.Value;
         if (halfPoints == null)
@@ -31,7 +31,7 @@ internal record LayoutSlideNumberSize : IFontSize
         return points;
     }
 
-    public void Update(int points)
+    public void Update(decimal points)
     {
         var aListStyle = this.pTextBody.ListStyle!;
         var aLvl1pPr = aListStyle.Level1ParagraphProperties;
@@ -40,6 +40,6 @@ internal record LayoutSlideNumberSize : IFontSize
         var halfPoints = points * HalfPointsInPoint;
         aListStyle.AppendChild(
             new A.Level1ParagraphProperties(
-                new A.DefaultRunProperties { FontSize = new Int32Value(halfPoints) }));
+                new A.DefaultRunProperties { FontSize = new Int32Value((int)halfPoints) }));
     }
 }

--- a/src/ShapeCrawler/Texts/MasterSlideNumberSize.cs
+++ b/src/ShapeCrawler/Texts/MasterSlideNumberSize.cs
@@ -6,22 +6,22 @@ namespace ShapeCrawler.Texts;
 internal record MasterSlideNumberSize : IFontSize
 {
     private readonly A.DefaultRunProperties aDefaultRunProperties;
-    private const int HalfPointsInPoint = 100;
+    private const decimal HalfPointsInPoint = 100m;
 
     internal MasterSlideNumberSize(A.DefaultRunProperties aDefaultRunProperties)
     {
         this.aDefaultRunProperties = aDefaultRunProperties;
     }
 
-    public int Size()
+    public decimal Size()
     {
         var halfPoints = this.aDefaultRunProperties.FontSize!.Value;
         return halfPoints / HalfPointsInPoint;
     }
 
-    public void Update(int points)
+    public void Update(decimal points)
     {
         var halfPoints = points * HalfPointsInPoint;
-        this.aDefaultRunProperties.FontSize!.Value = halfPoints;
+        this.aDefaultRunProperties.FontSize!.Value = (int)halfPoints;
     }
 }

--- a/src/ShapeCrawler/Texts/TextFrame.cs
+++ b/src/ShapeCrawler/Texts/TextFrame.cs
@@ -180,7 +180,7 @@ internal sealed class TextFrame : ITextFrame
 
         var paint = new SKPaint();
         var fontSize = font.Size;
-        paint.TextSize = fontSize;
+        paint.TextSize = (float)fontSize;
         paint.Typeface = SKTypeface.FromFamilyName(font.LatinName);
         paint.IsAntialias = true;
 
@@ -207,7 +207,7 @@ internal sealed class TextFrame : ITextFrame
         using var paint = new SKPaint();
         paint.Color = SKColors.Black;
         var firstPortion = this.Paragraphs.First().Portions.First();
-        paint.TextSize = firstPortion.Font.Size;
+        paint.TextSize = (float)firstPortion.Font.Size;
         var typeFace = SKTypeface.FromFamilyName(firstPortion.Font.LatinName);
         paint.Typeface = typeFace;
         float leftMarginPx = (float)UnitConverter.CentimeterToPixel(this.LeftMargin);

--- a/test/ShapeCrawler.Tests.Unit/FontTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/FontTests.cs
@@ -347,7 +347,7 @@ public class FontTests : SCTest
         var font = pres.Slides[slideNumber - 1].Shapes.GetByName(shapeName).TextFrame!.Paragraphs[0].Portions[0].Font;
         var mStream = new MemoryStream();
         var oldSize = font.Size;
-        var newSize = oldSize + 2;
+        var newSize = oldSize + 2.4m;
 
         // Act
         font.Size = newSize;

--- a/test/ShapeCrawler.Tests.Unit/FontTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/FontTests.cs
@@ -295,20 +295,20 @@ public class FontTests : SCTest
     [Test]
     [MasterShape("001.pptx", "Freeform: Shape 7", 18)]
     [SlideShape("020.pptx", 1, 3, 18)]
-    [SlideShape("015.pptx", 2, 61, 18)]
+    [SlideShape("015.pptx", 2, 61, 18.67)]
     [SlideShape("009_table.pptx", 3, 2, 18)]
     [SlideShape("009_table.pptx", 4, 2, 44)]
     [SlideShape("009_table.pptx", 4, 3, 32)]
     [SlideShape("019.pptx", 1, 4103, 18)]
     [SlideShape("019.pptx", 1, 2, 12)]
-    [SlideShape("014.pptx", 2, 5, 21)]
+    [SlideShape("014.pptx", 2, 5, 21.77)]
     [SlideShape("012_title-placeholder.pptx", 1, "Title 1", 20)]
-    [SlideShape("010.pptx", 1, 2, 15)]
+    [SlideShape("010.pptx", 1, 2, 15.39)]
     [SlideShape("014.pptx", 4, 5, 12)]
     [SlideShape("014.pptx", 5, 4, 12)]
     [SlideShape("014.pptx", 6, 52, 27)]
     [SlideShape("autoshape-case016.pptx", 1, "Text Placeholder 1", 28)]
-    public void Size_Getter_returns_font_size(IShape shape, int expectedSize)
+    public void Size_Getter_returns_font_size(IShape shape, double expectedSize)
     {
         // Arrange
         var autoShape =  shape;
@@ -318,7 +318,7 @@ public class FontTests : SCTest
         var fontSize = font.Size;
         
         // Assert
-        fontSize.Should().Be(expectedSize);
+        fontSize.Should().Be((decimal)expectedSize);
     }
     
     [Test]


### PR DESCRIPTION
Using decimal type to match recent changes to other size values.

Note that existing font size getter tests already had static test assets with fractional point text, so just needed to update tests to account for those. Modified setter tests to set decimal values.

Fixes #653


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates font size properties across multiple classes from `int` to `decimal` for more precise calculations and consistency.

### Detailed summary
- Updated font size properties from `int` to `decimal` for precision and consistency.
- Updated font size calculations and updates to use `decimal` data type.
- Updated tests to reflect changes in font size data type.
- Adjusted font size calculations for better accuracy in various classes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->