### PR TITLE
Add System.Drawing.Common package to ShapeCrawler.Tests.Unit project

### DIFF
--- a/test/ShapeCrawler.Tests.Unit/ShapeCrawler.Tests.Unit.csproj
+++ b/test/ShapeCrawler.Tests.Unit/ShapeCrawler.Tests.Unit.csproj
@@ -26,7 +26,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="coverlet.collector" Version="3.2.0" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.6" />
+    <PackageReference Include="System.Drawing.Common" Version="5.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/ShapeCrawler.Tests.Unit/ShapeCrawler.Tests.Unit.csproj
+++ b/test/ShapeCrawler.Tests.Unit/ShapeCrawler.Tests.Unit.csproj
@@ -26,6 +26,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="coverlet.collector" Version="3.2.0" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.6" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a reference to `System.Drawing.Common` in the `ShapeCrawler.Tests.Unit.csproj` file.

### Detailed summary
- Added reference to `System.Drawing.Common` in `ShapeCrawler.Tests.Unit.csproj`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->