### PR TITLE
Handle no-fill shape outlines

### DIFF
--- a/src/ShapeCrawler/Drawing/IShapeOutline.cs
+++ b/src/ShapeCrawler/Drawing/IShapeOutline.cs
@@ -14,7 +14,17 @@ public interface IShapeOutline
     decimal Weight { get; set; }
 
     /// <summary>
-    ///     Gets or sets color in hexadecimal format. Returns <see langword="null"/> if outline is not filled.
+    ///     Gets color in 6-digit hexadecimal format. Returns <see langword="null"/> if outline is not filled.
     /// </summary>
-    string? HexColor { get; set; }
+    string? HexColor { get; }
+
+    /// <summary>
+    ///     Sets color in 6-digit hexadecimal format.
+    /// </summary>
+    void SetHexColor(string value);
+
+    /// <summary>
+    ///     Sets shape outline to "No outline".
+    /// </summary>
+    void SetNoOutline();
 }

--- a/src/ShapeCrawler/ShapeCollection/SlideShapeOutline.cs
+++ b/src/ShapeCrawler/ShapeCollection/SlideShapeOutline.cs
@@ -75,7 +75,22 @@ internal sealed class SlideShapeOutline : IShapeOutline
 
     private void Remove()
     {
-        this.sdkTypedOpenXmlCompositeElement.RemoveAllChildren<A.Outline>();
+        // Removing an outline really means ensuring that the shape has a 
+        // 'NoFill' outline. If we just REMOVE the outline, then the style
+        // will take over and give it the default outline, which is not
+        // what we want
+        A.Outline? outline = this.sdkTypedOpenXmlCompositeElement.GetFirstChild<A.Outline>();
+        if (outline is null)
+        {
+            outline = new A.Outline();
+            this.sdkTypedOpenXmlCompositeElement.AppendChild(outline);
+        }
+
+        // Remove any explicit existing kinds of outline
+        outline.RemoveAllChildren();
+
+        // Add a nofill outline
+        outline.AppendChild(new A.NoFill());
     }
 
     private decimal ParseWeight()

--- a/src/ShapeCrawler/ShapeCollection/SlideShapeOutline.cs
+++ b/src/ShapeCrawler/ShapeCollection/SlideShapeOutline.cs
@@ -83,8 +83,7 @@ internal sealed class SlideShapeOutline : IShapeOutline
             .GetFirstChild<A.SolidFill>();
         if (aSolidFill is null)
         {
-            var defaultBlackHex = "000000";
-            return defaultBlackHex;
+            return null;
         }
 
         var pSlideMaster = this.sdkTypedOpenXmlPart switch

--- a/src/ShapeCrawler/ShapeCollection/SlideShapeOutline.cs
+++ b/src/ShapeCrawler/ShapeCollection/SlideShapeOutline.cs
@@ -28,7 +28,17 @@ internal sealed class SlideShapeOutline : IShapeOutline
     public string? HexColor
     {
         get => this.ParseHexColor();
-        set => this.UpdateHexColor(value);
+        set 
+        {
+            if (value == null)
+            {
+                this.Remove();                
+            }
+            else
+            {
+                this.UpdateHexColor(value);
+            }
+        }
     }
 
     private void UpdateWeight(decimal points)
@@ -44,11 +54,11 @@ internal sealed class SlideShapeOutline : IShapeOutline
         aOutline.Width = new Int32Value((Int32)UnitConverter.PointToEmu(points));
     }
     
-    private void UpdateHexColor(string? hex)
+    private void UpdateHexColor(string hex)
     {
         var aOutline = this.sdkTypedOpenXmlCompositeElement.GetFirstChild<A.Outline>();
-        var aNoFill = aOutline?.GetFirstChild<A.NoFill>();
 
+        var aNoFill = aOutline?.GetFirstChild<A.NoFill>();
         if (aOutline == null || aNoFill != null)
         {
             aOutline = this.sdkTypedOpenXmlCompositeElement.AddAOutline();
@@ -61,6 +71,11 @@ internal sealed class SlideShapeOutline : IShapeOutline
         var aSrgbColor = new A.RgbColorModelHex { Val = hex };
         aSolidFill = new A.SolidFill(aSrgbColor);
         aOutline.Append(aSolidFill);
+    }
+
+    private void Remove()
+    {
+        this.sdkTypedOpenXmlCompositeElement.RemoveAllChildren<A.Outline>();
     }
 
     private decimal ParseWeight()

--- a/src/ShapeCrawler/ShapeCollection/SlideShapeOutline.cs
+++ b/src/ShapeCrawler/ShapeCollection/SlideShapeOutline.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using ShapeCrawler.Drawing;
@@ -26,10 +25,22 @@ internal sealed class SlideShapeOutline : IShapeOutline
         set => this.UpdateWeight(value);
     }
 
+    /// <inheritdoc/>
     public string? HexColor
     {
         get => this.ParseHexColor();
-        set => this.UpdateHexColor(value);
+    }
+
+    /// <inheritdoc/>
+    public void SetHexColor(string value)
+    {
+        this.UpdateFill(new A.SolidFill(new A.RgbColorModelHex { Val = value }));
+    }
+
+    /// <inheritdoc/>
+    public void SetNoOutline()
+    {
+        this.UpdateFill(new A.NoFill());
     }
 
     private void UpdateWeight(decimal points)
@@ -45,7 +56,7 @@ internal sealed class SlideShapeOutline : IShapeOutline
         aOutline.Width = new Int32Value((Int32)UnitConverter.PointToEmu(points));
     }
     
-    private void UpdateHexColor(string? hex)
+    private void UpdateFill(OpenXmlElement child)
     {
         // Ensure there is an outline
         var aOutline = this.sdkTypedOpenXmlCompositeElement.GetFirstChild<A.Outline>();
@@ -58,17 +69,8 @@ internal sealed class SlideShapeOutline : IShapeOutline
         // Remove any explicit existing kinds of outline
         aOutline.RemoveAllChildren();
 
-        if (hex is null)
-        {
-            // Add a no fill outline
-            aOutline.AppendChild(new A.NoFill());
-        }
-        else
-        {
-            // Add a solid fill outline
-            IEnumerable<OpenXmlElement> solidFillParams = [ new A.RgbColorModelHex { Val = hex } ];
-            aOutline.AppendChild(new A.SolidFill(solidFillParams));
-        }
+        // Set the new child value
+        aOutline.AppendChild(child);
     }
 
     private decimal ParseWeight()

--- a/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
@@ -597,7 +597,7 @@ public class ShapeCollectionTests : SCTest
         rectangle.Width.Should().Be(100);
         rectangle.Height.Should().Be(70);
         rectangle.TextFrame!.Paragraphs.Count.Should().Be(1);
-        rectangle.Outline.HexColor.Should().Be("000000");
+        rectangle.Outline.HexColor.Should().BeNull();
         pres.Validate();
     }
 
@@ -615,7 +615,7 @@ public class ShapeCollectionTests : SCTest
         var roundedRectangle = shapes.Last();
         roundedRectangle.GeometryType.Should().Be(Geometry.RoundRectangle);
         roundedRectangle.Name.Should().Be("Rectangle: Rounded Corners");
-        roundedRectangle.Outline.HexColor.Should().Be("000000");
+        roundedRectangle.Outline.HexColor.Should().BeNull();
         pres.Validate();
     }
 

--- a/test/ShapeCrawler.Tests.Unit/ShapeOutlineTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeOutlineTests.cs
@@ -60,7 +60,7 @@ public class ShapeOutlineTests : SCTest
     
     [Test]
     [TestCase("autoshape-grouping.pptx", 1, "TextBox 6")]
-    public void Color_Setter_sets_outline_color(string file, int slideNumber, string shapeName)
+    public void SetHexColor_sets_outline_color(string file, int slideNumber, string shapeName)
     {
         // Arrange
         var pres = new Presentation(StreamOf(file));
@@ -68,7 +68,7 @@ public class ShapeOutlineTests : SCTest
         var outline = shape.Outline;
         
         // Act
-        outline.HexColor = "be3455";
+        outline.SetHexColor("be3455");
 
         // Assert
         outline.HexColor.Should().Be("be3455");
@@ -77,7 +77,7 @@ public class ShapeOutlineTests : SCTest
 
     [Test]
     [TestCase("autoshape-grouping.pptx", 1, "TextBox 6")]
-    public void Color_Setter_null_removes_outline_color(string file, int slideNumber, string shapeName)
+    public void SetNoOutline_removes_outline_color(string file, int slideNumber, string shapeName)
     {
         // Arrange
         var pres = new Presentation(StreamOf(file));
@@ -85,7 +85,7 @@ public class ShapeOutlineTests : SCTest
         var outline = shape.Outline;
         
         // Act
-        outline.HexColor = null;
+        outline.SetNoOutline();
 
         // Assert
         outline.HexColor.Should().BeNull();

--- a/test/ShapeCrawler.Tests.Unit/ShapeOutlineTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeOutlineTests.cs
@@ -92,4 +92,21 @@ public class ShapeOutlineTests : SCTest
         outline.HexColor.Should().BeNull();
         pres.Validate();
     }
+
+    [Test]
+    [SlideShape("autoshape-grouping.pptx", 1, "TextBox 4")]
+    [Explicit("Failing test for issue #703")]
+    public void Color_Getter_returns_no_outline_color_as_null(IShape shape)
+    {
+        // Arrange
+        var autoShape = (IShape)shape;
+        var outline = autoShape.Outline;
+        
+        // Act
+        var outlineColor = outline.HexColor;
+        
+        // Assert
+        outlineColor.Should().BeNull();
+    }
+    
 }

--- a/test/ShapeCrawler.Tests.Unit/ShapeOutlineTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeOutlineTests.cs
@@ -74,4 +74,22 @@ public class ShapeOutlineTests : SCTest
         outline.HexColor.Should().Be("be3455");
         pres.Validate();
     }
+
+    [Test]
+    [TestCase("autoshape-grouping.pptx", 1, "TextBox 6")]
+    [Explicit("Failing test for issue #703")]
+    public void Color_Setter_null_removes_outline_color(string file, int slideNumber, string shapeName)
+    {
+        // Arrange
+        var pres = new Presentation(StreamOf(file));
+        var shape = pres.Slides[slideNumber - 1].Shapes.GetByName(shapeName);
+        var outline = shape.Outline;
+        
+        // Act
+        outline.HexColor = null;
+
+        // Assert
+        outline.HexColor.Should().BeNull();
+        pres.Validate();
+    }
 }

--- a/test/ShapeCrawler.Tests.Unit/ShapeOutlineTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeOutlineTests.cs
@@ -77,7 +77,6 @@ public class ShapeOutlineTests : SCTest
 
     [Test]
     [TestCase("autoshape-grouping.pptx", 1, "TextBox 6")]
-    [Explicit("Failing test for issue #703")]
     public void Color_Setter_null_removes_outline_color(string file, int slideNumber, string shapeName)
     {
         // Arrange
@@ -95,18 +94,15 @@ public class ShapeOutlineTests : SCTest
 
     [Test]
     [SlideShape("autoshape-grouping.pptx", 1, "TextBox 4")]
-    [Explicit("Failing test for issue #703")]
     public void Color_Getter_returns_no_outline_color_as_null(IShape shape)
     {
         // Arrange
-        var autoShape = (IShape)shape;
-        var outline = autoShape.Outline;
+        var outline = shape.Outline;
         
         // Act
         var outlineColor = outline.HexColor;
         
         // Assert
         outlineColor.Should().BeNull();
-    }
-    
+    }    
 }

--- a/test/ShapeCrawler.Tests.Unit/ShapeOutlineTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeOutlineTests.cs
@@ -104,5 +104,5 @@ public class ShapeOutlineTests : SCTest
         
         // Assert
         outlineColor.Should().BeNull();
-    }    
+    }
 }


### PR DESCRIPTION
This PR fixes 2 related issues.

First, shapes with no outline (including newly-created shapes) were erroneously reported as having outlines of color "000000", when they definitely were not solid black.

Second, attempting to set outline color to the *valid* value of `null`, led to presentation validation error. This is documented in the below-mentioned issue.

To fix the second part, I also implemented ability to set existing outline to no-fill.

Fixes #703

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance shape outline manipulation in ShapeCrawler by adding methods to set hex color and remove outline.

### Detailed summary
- Added `SetHexColor` and `SetNoOutline` methods to `IShapeOutline` interface.
- Implemented `SetHexColor` and `SetNoOutline` methods in `SlideShapeOutline` class.
- Updated tests to reflect changes in outline color manipulation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->