### PR TITLE
Update year in the license copyright notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2023 Adam Shakhabov
+Copyright (c) 2019-2024 Adam Shakhabov
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the year in the copyright notice from 2023 to 2024.

### Detailed summary
- Updated the copyright year from 2023 to 2024 in the LICENSE file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->