### PR TITLE
Allow IParagraphPortion.Font to be null

### DIFF
--- a/src/ShapeCrawler/Texts/IParagraph.cs
+++ b/src/ShapeCrawler/Texts/IParagraph.cs
@@ -188,7 +188,7 @@ internal sealed class Paragraph : IParagraph
     {
         foreach (var portion in this.Portions.Where(s => s.Font != null))
         {
-            portion.Font.Size = fontSize;
+            portion.Font!.Size = fontSize;
         }
     }
 

--- a/src/ShapeCrawler/Texts/IParagraph.cs
+++ b/src/ShapeCrawler/Texts/IParagraph.cs
@@ -186,7 +186,7 @@ internal sealed class Paragraph : IParagraph
 
     public void SetFontSize(int fontSize)
     {
-        foreach (var portion in this.Portions)
+        foreach (var portion in this.Portions.Where(s => s.Font != null))
         {
             portion.Font.Size = fontSize;
         }

--- a/src/ShapeCrawler/Texts/IParagraphPortion.cs
+++ b/src/ShapeCrawler/Texts/IParagraphPortion.cs
@@ -14,7 +14,7 @@ public interface IParagraphPortion
     /// <summary>
     ///     Gets font.
     /// </summary>
-    ITextPortionFont Font { get; }
+    ITextPortionFont? Font { get; }
 
     /// <summary>
     ///     Gets or sets hypelink.

--- a/src/ShapeCrawler/Texts/TextFrame.cs
+++ b/src/ShapeCrawler/Texts/TextFrame.cs
@@ -289,11 +289,12 @@ internal sealed class TextFrame : ITextFrame
 
     private void ShrinkText(string newText, IParagraph baseParagraph)
     {
-        var popularPortion = baseParagraph.Portions.GroupBy(p => p.Font!.Size).OrderByDescending(x => x.Count())
+        var parent = this.sdkTextBody.Parent!;
+        var groups = baseParagraph.Portions.Where(s => s.Font != null).GroupBy(p => p.Font.Size);
+        var popularPortion = groups.OrderByDescending(x => x.Count())
             .First().First();
         var font = popularPortion.Font;
 
-        var parent = this.sdkTextBody.Parent!;
         var shapeSize = new ShapeSize(this.sdkTypedOpenXmlPart, parent);
         var fontSize = FontService.GetAdjustedFontSize(newText, font, (int)shapeSize.Width(), (int)shapeSize.Height());
 

--- a/src/ShapeCrawler/Texts/TextFrame.cs
+++ b/src/ShapeCrawler/Texts/TextFrame.cs
@@ -207,8 +207,8 @@ internal sealed class TextFrame : ITextFrame
         using var paint = new SKPaint();
         paint.Color = SKColors.Black;
         var firstPortion = this.Paragraphs.First().Portions.First();
-        paint.TextSize = (float)firstPortion.Font.Size;
-        var typeFace = SKTypeface.FromFamilyName(firstPortion.Font.LatinName);
+        paint.TextSize = (float)(firstPortion.Font?.Size ?? 11);
+        var typeFace = SKTypeface.FromFamilyName(firstPortion.Font?.LatinName ?? "Arial");
         paint.Typeface = typeFace;
         float leftMarginPx = (float)UnitConverter.CentimeterToPixel(this.LeftMargin);
         float topMarginPx = (float)UnitConverter.CentimeterToPixel(this.TopMargin);
@@ -290,10 +290,9 @@ internal sealed class TextFrame : ITextFrame
     private void ShrinkText(string newText, IParagraph baseParagraph)
     {
         var parent = this.sdkTextBody.Parent!;
-        var groups = baseParagraph.Portions.Where(s => s.Font != null).GroupBy(p => p.Font.Size);
-        var popularPortion = groups.OrderByDescending(x => x.Count())
+        var popularPortion = baseParagraph.Portions.Where(s => s.Font != null).GroupBy(p => p.Font!.Size).OrderByDescending(x => x.Count())
             .First().First();
-        var font = popularPortion.Font;
+        var font = popularPortion.Font!;
 
         var shapeSize = new ShapeSize(this.sdkTypedOpenXmlPart, parent);
         var fontSize = FontService.GetAdjustedFontSize(newText, font, (int)shapeSize.Width(), (int)shapeSize.Height());


### PR DESCRIPTION
In our usage, we found instances where TextFrame.ShrinkText would throw a null reference exception due to ContentFrames not having font's for every portion. Changed IParagraphPortion to be nullable and cleaned up code so that it can skip null fonts

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates nullable references in text handling classes for font properties. 

### Detailed summary
- Made `Font` property nullable in `IParagraphPortion.cs`.
- Updated font property access to handle nullability in `IParagraph.cs`.
- Adjusted font property access to handle nullability in `TextFrame.cs`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->