### PR TITLE
Fix typo in CHANGELOG.md and README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Version 0.53.0 - 2024-06-20
 🍀Added `ISlide.Notes` and `ISlide.AddNotes()` for Slide Notes expirience [#684](https://github.com/ShapeCrawler/ShapeCrawler/issues/684)    
-🐞Fixed appllying "No Outline" [#649](https://github.com/ShapeCrawler/ShapeCrawler/issues/649)  
+🐞Fixed applying "No Outline" [#649](https://github.com/ShapeCrawler/ShapeCrawler/issues/649)  
 
 ## Version 0.52.0 - 2024-05-28
 🍀Added support for the SVG format for the method `ISlideShapes.AddPicture()` [#350](https://github.com/ShapeCrawler/ShapeCrawler/issues/350)  

--- a/README.md
+++ b/README.md
@@ -91,6 +91,6 @@ Pull Requests are welcome! Please read the [Contribution Guide](https://github.c
 
 ### Version 0.53.0 - 2024-06-20
 🍀Added `ISlide.Notes` and `ISlide.AddNotes()` for Slide Notes expirience [#684](https://github.com/ShapeCrawler/ShapeCrawler/issues/684)    
-🐞Fixed appllying "No Outline" [#649](https://github.com/ShapeCrawler/ShapeCrawler/issues/649)  
+🐞Fixed applying "No Outline" [#649](https://github.com/ShapeCrawler/ShapeCrawler/issues/649)  
 
 Visit [CHANGELOG.md](https://github.com/ShapeCrawler/ShapeCrawler/blob/master/CHANGELOG.md) to see the full log.


### PR DESCRIPTION
A typo in the word "applying" in both CHANGELOG.md and README.md was corrected. This change was made in the description of issue [#649](https://github.com/ShapeCrawler/ShapeCrawler/issues/649) under the release notes for Version 0.53.0.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces new features and bug fixes in version 0.53.0 of ShapeCrawler library.

### Detailed summary
- Added `ISlide.Notes` and `ISlide.AddNotes()` for Slide Notes experience
- Fixed a bug with applying "No Outline" in shapes

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->