### PR TITLE
Add status badges for GitHub issues to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,13 @@
 
 <h3 align="center"> 
 
-[![NuGet](https://img.shields.io/nuget/v/ShapeCrawler?color=orange)](https://www.nuget.org/packages/ShapeCrawler) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?color=orange)](https://makeapullrequest.com) ![Nuget](https://img.shields.io/nuget/dt/ShapeCrawler?color=orange) [![License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) 
+[![NuGet](https://img.shields.io/nuget/v/ShapeCrawler?color=orange)](https://www.nuget.org/packages/ShapeCrawler)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?color=orange)](https://makeapullrequest.com)
+![Nuget](https://img.shields.io/nuget/dt/ShapeCrawler?color=orange)
+[![License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) 
+[![GitHub repo Good Issues for newbies](https://img.shields.io/github/issues/ShapeCrawler/ShapeCrawler/good%20first%20issue?style=flat&logo=github&logoColor=green&label=Good%20First%20issues)](https://github.com/ShapeCrawler/ShapeCrawler/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
+[![GitHub Help Wanted issues](https://img.shields.io/github/issues/ShapeCrawler/ShapeCrawler/help%20wanted?style=flat&logo=github&logoColor=b545d1&label=%22Help%20Wanted%22%20issues)](https://github.com/ShapeCrawler/ShapeCrawler/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)
+[![GitHub repo Issues](https://img.shields.io/github/issues/ShapeCrawler/ShapeCrawler?style=flat&logo=github&logoColor=red&label=Issues)](https://github.com/ShapeCrawler/ShapeCrawler/issues?q=is%3Aopen)
 
 </h3>
 


### PR DESCRIPTION
Separated existing badges for better readability and added new badges to highlight "Good First Issues", "Help Wanted" issues, and general GitHub issues. This improves the visibility of contribution opportunities for potential contributors.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds additional badges to the README.md file, including badges for good first issues, help wanted issues, and general issues.

### Detailed summary
- Added badge for good first issues
- Added badge for help wanted issues
- Added badge for general issues

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->