### PR TITLE
Add support for table cell borders

### DIFF
--- a/src/ShapeCrawler/Tables/BottomBorder.cs
+++ b/src/ShapeCrawler/Tables/BottomBorder.cs
@@ -1,0 +1,49 @@
+﻿using DocumentFormat.OpenXml;
+using ShapeCrawler.Units;
+using A = DocumentFormat.OpenXml.Drawing;
+
+namespace ShapeCrawler.Tables;
+
+internal class BottomBorder : IBorder
+{
+    private readonly A.TableCellProperties aTableCellProperties;
+
+    internal BottomBorder(A.TableCellProperties aTableCellProperties)
+    {
+        this.aTableCellProperties = aTableCellProperties;
+    }
+
+    public float Width
+    {
+        get => this.GetWidth();
+        set => this.UpdateWidth(value);
+    }
+
+    private void UpdateWidth(float points)
+    {
+        if (this.aTableCellProperties.BottomBorderLineProperties is null)
+        {
+            var aSolidFill = new A.SolidFill
+            {
+                SchemeColor = new A.SchemeColor { Val = A.SchemeColorValues.Text1 }
+            };
+            this.aTableCellProperties.BottomBorderLineProperties = new A.BottomBorderLineProperties();
+            this.aTableCellProperties.BottomBorderLineProperties.AppendChild(aSolidFill);
+        }
+        
+        var emus = new Points(points).AsEmus();
+        this.aTableCellProperties.BottomBorderLineProperties!.Width = new Int32Value((int)emus);
+    }
+
+    private float GetWidth()
+    {
+        if (this.aTableCellProperties.BottomBorderLineProperties is null)
+        {
+            return 1; // default value
+        }
+
+        var emus = this.aTableCellProperties.BottomBorderLineProperties!.Width!.Value;
+        
+        return new Emus(emus).AsPoints();
+    }
+}

--- a/src/ShapeCrawler/Tables/IBorder.cs
+++ b/src/ShapeCrawler/Tables/IBorder.cs
@@ -1,0 +1,15 @@
+﻿
+
+// ReSharper disable once CheckNamespace
+namespace ShapeCrawler;
+
+/// <summary>
+///     Represents a top border of a table cell.
+/// </summary>
+public interface IBorder
+{
+    /// <summary>
+    ///     Gets or sets border width in points.
+    /// </summary>
+    float Width { get; set; }
+}

--- a/src/ShapeCrawler/Tables/ITableCell.cs
+++ b/src/ShapeCrawler/Tables/ITableCell.cs
@@ -1,5 +1,6 @@
 ﻿using DocumentFormat.OpenXml.Packaging;
 using ShapeCrawler.Drawing;
+using ShapeCrawler.Tables;
 using ShapeCrawler.Texts;
 using A = DocumentFormat.OpenXml.Drawing;
 
@@ -27,9 +28,24 @@ public interface ITableCell
     IShapeFill Fill { get; }
 
     /// <summary>
-    ///     Gets the top border.
+    ///     Gets the Top Border.
     /// </summary>
-    ITopBorder TopBorder { get; }
+    IBorder TopBorder { get; }
+    
+    /// <summary>
+    ///     Gets the Bottom Border.
+    /// </summary>
+    IBorder BottomBorder { get; }
+    
+    /// <summary>
+    ///     Gets the Left Border.
+    /// </summary>
+    IBorder LeftBorder { get; }
+    
+    /// <summary>
+    ///     Gets the Right Border.
+    /// </summary>
+    IBorder RightBorder { get; }
 }
 
 internal sealed class TableCell : ITableCell
@@ -43,6 +59,9 @@ internal sealed class TableCell : ITableCell
         var aTcPr = aTableCell.TableCellProperties!;
         this.Fill = new TableCellFill(sdkTypedOpenXmlPart, aTcPr);
         this.TopBorder = new TopBorder(aTableCell.TableCellProperties!);
+        this.BottomBorder = new BottomBorder(aTableCell.TableCellProperties!);
+        this.LeftBorder = new LeftBorder(aTableCell.TableCellProperties!);
+        this.RightBorder = new RightBorder(aTableCell.TableCellProperties!);
     }
 
     public bool IsMergedCell => this.ATableCell.GridSpan is not null ||
@@ -52,7 +71,11 @@ internal sealed class TableCell : ITableCell
 
     public IShapeFill Fill { get; }
 
-    public ITopBorder TopBorder { get; }
+    public IBorder TopBorder { get; }
+    
+    public IBorder BottomBorder { get; }
+    public IBorder LeftBorder { get; }
+    public IBorder RightBorder { get; }
 
     public ITextFrame TextFrame { get; }
 

--- a/src/ShapeCrawler/Tables/ITableCell.cs
+++ b/src/ShapeCrawler/Tables/ITableCell.cs
@@ -74,7 +74,9 @@ internal sealed class TableCell : ITableCell
     public IBorder TopBorder { get; }
     
     public IBorder BottomBorder { get; }
+
     public IBorder LeftBorder { get; }
+
     public IBorder RightBorder { get; }
 
     public ITextFrame TextFrame { get; }

--- a/src/ShapeCrawler/Tables/LeftBorder.cs
+++ b/src/ShapeCrawler/Tables/LeftBorder.cs
@@ -1,0 +1,49 @@
+﻿using DocumentFormat.OpenXml;
+using ShapeCrawler.Units;
+using A = DocumentFormat.OpenXml.Drawing;
+
+namespace ShapeCrawler.Tables;
+
+internal class LeftBorder : IBorder
+{
+    private readonly A.TableCellProperties aTableCellProperties;
+
+    internal LeftBorder(A.TableCellProperties aTableCellProperties)
+    {
+        this.aTableCellProperties = aTableCellProperties;
+    }
+
+    public float Width
+    {
+        get => this.GetWidth();
+        set => this.UpdateWidth(value);
+    }
+
+    private void UpdateWidth(float points)
+    {
+        if (this.aTableCellProperties.LeftBorderLineProperties is null)
+        {
+            var aSolidFill = new A.SolidFill
+            {
+                SchemeColor = new A.SchemeColor { Val = A.SchemeColorValues.Text1 }
+            };
+            this.aTableCellProperties.LeftBorderLineProperties = new A.LeftBorderLineProperties();
+            this.aTableCellProperties.LeftBorderLineProperties.AppendChild(aSolidFill);
+        }
+        
+        var emus = new Points(points).AsEmus();
+        this.aTableCellProperties.LeftBorderLineProperties!.Width = new Int32Value((int)emus);
+    }
+
+    private float GetWidth()
+    {
+        if (this.aTableCellProperties.LeftBorderLineProperties is null)
+        {
+            return 1; // default value
+        }
+
+        var emus = this.aTableCellProperties.LeftBorderLineProperties!.Width!.Value;
+        
+        return new Emus(emus).AsPoints();
+    }
+}

--- a/src/ShapeCrawler/Tables/RightBorder.cs
+++ b/src/ShapeCrawler/Tables/RightBorder.cs
@@ -1,0 +1,49 @@
+﻿using DocumentFormat.OpenXml;
+using ShapeCrawler.Units;
+using A = DocumentFormat.OpenXml.Drawing;
+
+namespace ShapeCrawler.Tables;
+
+internal class RightBorder : IBorder
+{
+    private readonly A.TableCellProperties aTableCellProperties;
+
+    internal RightBorder(A.TableCellProperties aTableCellProperties)
+    {
+        this.aTableCellProperties = aTableCellProperties;
+    }
+
+    public float Width
+    {
+        get => this.GetWidth();
+        set => this.UpdateWidth(value);
+    }
+
+    private void UpdateWidth(float points)
+    {
+        if (this.aTableCellProperties.RightBorderLineProperties is null)
+        {
+            var aSolidFill = new A.SolidFill
+            {
+                SchemeColor = new A.SchemeColor { Val = A.SchemeColorValues.Text1 }
+            };
+            this.aTableCellProperties.RightBorderLineProperties = new A.RightBorderLineProperties();
+            this.aTableCellProperties.RightBorderLineProperties.AppendChild(aSolidFill);
+        }
+        
+        var emus = new Points(points).AsEmus();
+        this.aTableCellProperties.RightBorderLineProperties!.Width = new Int32Value((int)emus);
+    }
+
+    private float GetWidth()
+    {
+        if (this.aTableCellProperties.RightBorderLineProperties is null)
+        {
+            return 1; // default value
+        }
+
+        var emus = this.aTableCellProperties.RightBorderLineProperties!.Width!.Value;
+        
+        return new Emus(emus).AsPoints();
+    }
+}

--- a/src/ShapeCrawler/Tables/TopBorder.cs
+++ b/src/ShapeCrawler/Tables/TopBorder.cs
@@ -1,21 +1,9 @@
 ﻿using DocumentFormat.OpenXml;
 using ShapeCrawler.Units;
 
-// ReSharper disable once CheckNamespace
-namespace ShapeCrawler;
+namespace ShapeCrawler.Tables;
 
-/// <summary>
-///     Represents a top border of a table cell.
-/// </summary>
-public interface ITopBorder
-{
-    /// <summary>
-    ///     Gets or sets border width in points.
-    /// </summary>
-    float Width { get; set; }
-}
-
-internal class TopBorder : ITopBorder
+internal class TopBorder : IBorder
 {
     private readonly DocumentFormat.OpenXml.Drawing.TableCellProperties aTableCellProperties;
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to refactor border classes in the `ShapeCrawler.Tables` namespace to implement a shared `IBorder` interface for table cell borders.

### Detailed summary
- Refactored `TopBorder`, `LeftBorder`, `RightBorder`, and `BottomBorder` to implement `IBorder` interface.
- Updated `ITableCell` interface to use `IBorder` for all border properties.
- Added `Width` property and methods for updating and retrieving border width in points.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->