### PR TITLE
Update OpenXML packages and add test for cell left border

### DIFF
--- a/src/ShapeCrawler/ShapeCrawler.csproj
+++ b/src/ShapeCrawler/ShapeCrawler.csproj
@@ -69,8 +69,8 @@ This library provides a simplified object model on top of the Open XML SDK for m
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DocumentFormat.OpenXml" Version="3.1.0" />
-    <PackageReference Include="DocumentFormat.OpenXml.Linq" Version="3.1.0" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="3.0.2" />
+    <PackageReference Include="DocumentFormat.OpenXml.Linq" Version="3.0.2" />
     <PackageReference Include="SkiaSharp" Version="2.88.6" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.6" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/src/ShapeCrawler/ShapeCrawler.csproj
+++ b/src/ShapeCrawler/ShapeCrawler.csproj
@@ -69,8 +69,8 @@ This library provides a simplified object model on top of the Open XML SDK for m
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DocumentFormat.OpenXml" Version="3.0.2" />
-    <PackageReference Include="DocumentFormat.OpenXml.Linq" Version="3.0.2" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="3.1.0" />
+    <PackageReference Include="DocumentFormat.OpenXml.Linq" Version="3.1.0" />
     <PackageReference Include="SkiaSharp" Version="2.88.6" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.6" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/test/ShapeCrawler.Tests.Unit/TableTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/TableTests.cs
@@ -186,6 +186,20 @@ public class TableTests : SCTest
     }
     
     [Test]
+    public void Row_Cell_LeftBorder_Width_Setter_sets_left_border_width_in_points()
+    {
+        // Arrange
+        var pres = new Presentation(StreamOf("table-case001.pptx"));
+        var cell = pres.Slides[0].TableWithName("Table 1")[0, 0];
+        
+        // Act
+        cell.LeftBorder.Width = 2;  
+        
+        // Assert
+        cell.LeftBorder.Width.Should().Be(2);
+    }
+    
+    [Test]
     public void Row_Cell_TopBorder_Width_Getter_returns_top_border_width_in_points()
     {
         // Arrange


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding a test for setting the left border width of a cell in a PowerPoint table.

### Detailed summary
- Added a test method `Row_Cell_LeftBorder_Width_Setter_sets_left_border_width_in_points` in `TableTests.cs` to set and check the left border width of a cell.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->