### PR TITLE
Refactor text frame and paragraph classes

### DIFF
--- a/src/ShapeCrawler/Texts/IParagraph.cs
+++ b/src/ShapeCrawler/Texts/IParagraph.cs
@@ -61,10 +61,10 @@ internal sealed class Paragraph : IParagraph
     private readonly OpenXmlPart sdkTypedOpenXmlPart;
     private readonly Lazy<Bullet> bullet;
     private readonly WrappedAParagraph wrappedAParagraph;
+    private readonly A.Paragraph aParagraph;
 
     private TextAlignment? alignment;
-    private A.Paragraph AParagraph { get; }
-
+    
     internal Paragraph(OpenXmlPart sdkTypedOpenXmlPart, A.Paragraph aParagraph)
         : this(sdkTypedOpenXmlPart, aParagraph, new WrappedAParagraph(aParagraph))
     {
@@ -73,11 +73,11 @@ internal sealed class Paragraph : IParagraph
     private Paragraph(OpenXmlPart sdkTypedOpenXmlPart, A.Paragraph aParagraph, WrappedAParagraph wrappedAParagraph)
     {
         this.sdkTypedOpenXmlPart = sdkTypedOpenXmlPart;
-        this.AParagraph = aParagraph;
+        this.aParagraph = aParagraph;
         this.wrappedAParagraph = wrappedAParagraph;
-        this.AParagraph.ParagraphProperties ??= new A.ParagraphProperties();
+        this.aParagraph.ParagraphProperties ??= new A.ParagraphProperties();
         this.bullet = new Lazy<Bullet>(this.GetBullet);
-        this.Portions = new ParagraphPortions(sdkTypedOpenXmlPart, this.AParagraph);
+        this.Portions = new ParagraphPortions(sdkTypedOpenXmlPart, this.aParagraph);
     }
 
     public bool IsRemoved { get; set; }
@@ -93,8 +93,8 @@ internal sealed class Paragraph : IParagraph
             }
 
             // To set a paragraph text we use a single portion which is the first paragraph portion.
-            var baseARun = this.AParagraph.GetFirstChild<A.Run>() !;
-            var remainingRuns = this.AParagraph.OfType<A.Run>().Where(run => run != baseARun).ToList();
+            var baseARun = this.aParagraph.GetFirstChild<A.Run>() !;
+            var remainingRuns = this.aParagraph.OfType<A.Run>().Where(run => run != baseARun).ToList();
             foreach (var removingRun in remainingRuns)
             {
                 removingRun.Remove();
@@ -123,7 +123,7 @@ internal sealed class Paragraph : IParagraph
             }
 
             // Resize
-            var sdkTextBody = this.AParagraph.Parent!;
+            var sdkTextBody = this.aParagraph.Parent!;
             var textFrame = new TextFrame(this.sdkTypedOpenXmlPart, sdkTextBody);
             textFrame.ResizeParentShape();
         }
@@ -142,10 +142,10 @@ internal sealed class Paragraph : IParagraph
                 return this.alignment.Value;
             }
 
-            var aTextAlignmentType = this.AParagraph.ParagraphProperties?.Alignment;
+            var aTextAlignmentType = this.aParagraph.ParagraphProperties?.Alignment;
             if (aTextAlignmentType == null)
             {
-                var parentShape = new AutoShape(this.sdkTypedOpenXmlPart, this.AParagraph.Ancestors<P.Shape>().First());
+                var parentShape = new AutoShape(this.sdkTypedOpenXmlPart, this.aParagraph.Ancestors<P.Shape>().First());
                 if (parentShape.PlaceholderType == PlaceholderType.CenteredTitle)
                 {
                     return TextAlignment.Center;
@@ -203,11 +203,11 @@ internal sealed class Paragraph : IParagraph
         }
     }
 
-    public void Remove() => this.AParagraph.Remove();
+    public void Remove() => this.aParagraph.Remove();
     
-    private ISpacing GetSpacing() => new Spacing(this, this.AParagraph);
+    private ISpacing GetSpacing() => new Spacing(this, this.aParagraph);
 
-    private Bullet GetBullet() => new Bullet(this.AParagraph.ParagraphProperties!);
+    private Bullet GetBullet() => new Bullet(this.aParagraph.ParagraphProperties!);
 
     private string ParseText()
     {
@@ -230,16 +230,16 @@ internal sealed class Paragraph : IParagraph
             _ => throw new ArgumentOutOfRangeException(nameof(alignmentValue))
         };
 
-        if (this.AParagraph.ParagraphProperties == null)
+        if (this.aParagraph.ParagraphProperties == null)
         {
-            this.AParagraph.ParagraphProperties = new A.ParagraphProperties
+            this.aParagraph.ParagraphProperties = new A.ParagraphProperties
             {
                 Alignment = new EnumValue<A.TextAlignmentTypeValues>(aTextAlignmentTypeValue)
             };
         }
         else
         {
-            this.AParagraph.ParagraphProperties.Alignment =
+            this.aParagraph.ParagraphProperties.Alignment =
                 new EnumValue<A.TextAlignmentTypeValues>(aTextAlignmentTypeValue);
         }
 

--- a/src/ShapeCrawler/Texts/IParagraph.cs
+++ b/src/ShapeCrawler/Texts/IParagraph.cs
@@ -21,12 +21,12 @@ public interface IParagraph
     string Text { get; set; }
 
     /// <summary>
-    ///     Gets collection of paragraph portions.
+    ///     Gets the collection of paragraph portions.
     /// </summary>
     IParagraphPortions Portions { get; }
 
     /// <summary>
-    ///     Gets paragraph bullet if bullet exist, otherwise <see langword="null"/>.
+    ///     Gets paragraph's bullet. Returns <see langword="null"/> if bullet doesn't exist.
     /// </summary>
     Bullet Bullet { get; }
 
@@ -63,6 +63,7 @@ internal sealed class Paragraph : IParagraph
     private readonly WrappedAParagraph wrappedAParagraph;
 
     private TextAlignment? alignment;
+    private A.Paragraph AParagraph { get; }
 
     internal Paragraph(OpenXmlPart sdkTypedOpenXmlPart, A.Paragraph aParagraph)
         : this(sdkTypedOpenXmlPart, aParagraph, new WrappedAParagraph(aParagraph))
@@ -180,8 +181,6 @@ internal sealed class Paragraph : IParagraph
     }
 
     public ISpacing Spacing => this.GetSpacing();
-    
-    internal A.Paragraph AParagraph { get; }
 
     public void SetFontSize(int fontSize)
     {

--- a/src/ShapeCrawler/Texts/NullTextFrame.cs
+++ b/src/ShapeCrawler/Texts/NullTextFrame.cs
@@ -2,7 +2,7 @@
 
 namespace ShapeCrawler.Texts;
 
-internal class NullTextFrame : ITextFrame
+internal readonly struct NullTextFrame : ITextFrame
 {
     private const string error = $"The shape is not a text holder. Use {nameof(IShape.IsTextHolder)} method to check it.";
     

--- a/src/ShapeCrawler/Texts/ParagraphLineBreak.cs
+++ b/src/ShapeCrawler/Texts/ParagraphLineBreak.cs
@@ -4,7 +4,7 @@ using A = DocumentFormat.OpenXml.Drawing;
 
 namespace ShapeCrawler.Texts;
 
-internal sealed class ParagraphLineBreak : IParagraphPortion
+internal sealed record ParagraphLineBreak : IParagraphPortion
 {
     private readonly A.Break aBreak;
     

--- a/src/ShapeCrawler/Texts/PortionText.cs
+++ b/src/ShapeCrawler/Texts/PortionText.cs
@@ -2,7 +2,7 @@
 
 namespace ShapeCrawler.Texts;
 
-internal class PortionText
+internal sealed record PortionText
 {
     private readonly A.Field aField;
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces changes to classes `PortionText`, `ParagraphLineBreak`, `NullTextFrame`, and `Paragraph`. It converts classes to records and struct, updates property names, and refactors code for better readability.

### Detailed summary
- `PortionText`, `ParagraphLineBreak`, and `NullTextFrame` classes converted to records or struct
- Updated property names in `IParagraph.cs`
- Refactored code in `Paragraph.cs` for better readability

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->