### PR TITLE
Update TextFrame to TextBox in README.md examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ var shapesCount = shapes.Count;
 
 // get text
 var shape = shapes.GetByName("TextBox 1");
-var text = shape.TextFrame!.Text;
+var text = shape.TextBox!.Text;
 ```
 
 ## How To?
@@ -61,7 +61,7 @@ var shapes = pres.Slides[0].Shapes;
 shapes.AddRectangle(x: 50, y: 60, width: 100, height: 70);
 var addedShape = shapes.Last();
 
-addedShape.TextFrame!.Text = "Hello World!";
+addedShape.TextBox!.Text = "Hello World!";
 
 pres.SaveAs("my_pres.pptx");
 ```


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the code to use `TextBox` instead of `TextFrame` for getting and setting text in PowerPoint shapes.

### Detailed summary
- Replaced `shape.TextFrame!.Text` with `shape.TextBox!.Text` to get the text from a shape.
- Changed `addedShape.TextFrame!.Text` to `addedShape.TextBox!.Text` to set text in a shape.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->