### PR TITLE
Rename and add test for adding an empty slide

### DIFF
--- a/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
@@ -770,7 +770,7 @@ public class ShapeCollectionTests : SCTest
     }
 
     [Test]
-    public void Add_add_adds_New_slide()
+    public void AddEmptySlide_adds_New_slide()
     {
         // Arrange
         var pptx = StreamOf("autoshape-grouping.pptx");
@@ -785,6 +785,21 @@ public class ShapeCollectionTests : SCTest
         var addedSlide = slides.Last();
         addedSlide.Should().NotBeNull();
         pres.Validate();
+    }
+    
+    [Test]
+    [Ignore("https://github.com/ShapeCrawler/ShapeCrawler/issues/9")]
+    public void AddEmptySlide_adds_empty_slide()
+    {
+        // Arrange
+        var pres = new Presentation();
+        var slides = pres.Slides;
+
+        // Act
+        slides.AddEmptySlide(SlideLayoutType.Blank);
+
+        // Assert
+        slides[1].Shapes.Should().HaveCount(0);
     }
 
     [Test]


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to rename the `Add` method in `ShapeCollectionTests.cs` to `AddEmptySlide` and add a new test for adding an empty slide.

### Detailed summary
- Renamed `Add` method to `AddEmptySlide`
- Added new test for adding an empty slide using `AddEmptySlide` method

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->