### PR TITLE
Fix Shapes.Remove()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## Version 0.54.2 - Unreleased
 🐞Fixed `Slides.AddEmptySlide()` [#658](https://github.com/ShapeCrawler/ShapeCrawler/issues/658)  
+🐞Fixed `Shapes.Remove()` [#735](https://github.com/ShapeCrawler/ShapeCrawler/issues/735)  
 🐞Fixed `Image.MIME`  
 🐞Fixed `Shapes.AddPicture()`
+
 
 ## Version 0.54.1 - 2024-08-28
 🐞Fixed `IFont.LatinName` [#669](https://github.com/ShapeCrawler/ShapeCrawler/issues/669)  

--- a/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
@@ -460,17 +460,13 @@ internal sealed class SlideShapes : ISlideShapes
 
     public void Remove(IShape shape)
     {
-        if (this.shapes.Any(x => x != shape))
+        var removingShape = this.shapes.FirstOrDefault(sp => sp.Id == shape.Id);
+        if (removingShape == null)
         {
             throw new SCException("Shape is not found.");
         }
 
-        if (shape is IRemoveable removeable)
-        {
-            removeable.Remove();
-        }
-
-        throw new SCException("Shape is not cannot be removed.");
+        removingShape.Remove();
     }
 
     public T GetById<T>(int id) where T : IShape => this.shapes.GetById<T>(id);

--- a/test/ShapeCrawler.Tests.Unit/PresentationTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/PresentationTests.cs
@@ -194,7 +194,7 @@ public class PresentationTests : SCTest
         // Assert
         destPre.Slides[1].CustomData.Should().Be(sourceSlideId);
     }
-
+    
     [Test]
     public void Slides_Remove_removes_slide_from_section()
     {
@@ -451,8 +451,7 @@ public class PresentationTests : SCTest
     public void Slides_Remove_removes_slide(string file, int expectedSlidesCount)
     {
         // Arrange
-        var pptx = StreamOf(file);
-        var pres = new Presentation(pptx);
+        var pres = new Presentation(StreamOf(file));
         var removingSlide = pres.Slides[0];
         var mStream = new MemoryStream();
 
@@ -465,5 +464,23 @@ public class PresentationTests : SCTest
         pres.SaveAs(mStream);
         pres = new Presentation(mStream);
         pres.Slides.Should().HaveCount(expectedSlidesCount);
+    }
+    
+    [Test]
+    public void Slides_Insert_inserts_slide_at_the_specified_position()
+    {
+        // Arrange
+        var pptx = StreamOf("001.pptx");
+        var sourceSlide = new Presentation(pptx).Slides[0];
+        var sourceSlideId = Guid.NewGuid().ToString();
+        sourceSlide.CustomData = sourceSlideId;
+        pptx = StreamOf("002.pptx");
+        var destPre = new Presentation(pptx);
+
+        // Act
+        destPre.Slides.Insert(2, sourceSlide);
+
+        // Assert
+        destPre.Slides[1].CustomData.Should().Be(sourceSlideId);
     }
 }

--- a/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
@@ -342,7 +342,7 @@ public class ShapeCollectionTests : SCTest
     }
 
     [Test]
-    public void AddPicture_adds_SVG_picture()
+    public void AddPicture_adds_svg_picture()
     {
         // Arrange
         var pres = new Presentation();
@@ -818,65 +818,19 @@ public class ShapeCollectionTests : SCTest
         addedSlide.Should().NotBeNull();
         titleAndContentLayout.Shapes.Select(s => s.Name).Should().BeSubsetOf(addedSlide.Shapes.Select(s => s.Name));
     }
-
-    [Test]
-    public void Slides_Insert_inserts_slide_at_the_specified_position()
-    {
-        // Arrange
-        var pptx = StreamOf("001.pptx");
-        var sourceSlide = new Presentation(pptx).Slides[0];
-        var sourceSlideId = Guid.NewGuid().ToString();
-        sourceSlide.CustomData = sourceSlideId;
-        pptx = StreamOf("002.pptx");
-        var destPre = new Presentation(pptx);
-
-        // Act
-        destPre.Slides.Insert(2, sourceSlide);
-
-        // Assert
-        destPre.Slides[1].CustomData.Should().Be(sourceSlideId);
-    }
     
     [Test]
-    [TestCase("007_2 slides.pptx", 1)]
-    public void Slides_Remove_removes_slide(string file, int expectedSlidesCount)
+    public void Remove()
     {
         // Arrange
-        var pptx = StreamOf(file);
-        var pres = new Presentation(pptx);
-        var removingSlide = pres.Slides[0];
-        var mStream = new MemoryStream();
+        var pres = new Presentation();
+        var shapes = pres.Slides[0].Shapes;
+        shapes.AddRectangle(10, 10, 10, 10);
 
-        // Act
-        pres.Slides.Remove(removingSlide);
-
+        shapes.Remove(shapes.Last());
+        
         // Assert
-        pres.Slides.Should().HaveCount(expectedSlidesCount);
-
-        pres.SaveAs(mStream);
-        pres = new Presentation(mStream);
-        pres.Slides.Should().HaveCount(expectedSlidesCount);
-    }
-    
-    [Test]
-    public void Slides_Remove_removes_slide_from_section()
-    {
-        // Arrange
-        var pptxStream = StreamOf("autoshape-case017_slide-number.pptx");
-        var pres = new Presentation(pptxStream);
-        var sectionSlides = pres.Sections[0].Slides;
-        var removingSlide = sectionSlides[0];
-        var mStream = new MemoryStream();
-
-        // Act
-        pres.Slides.Remove(removingSlide);
-
-        // Assert
-        sectionSlides.Count.Should().Be(0);
-
-        pres.SaveAs(mStream);
-        pres = new Presentation(mStream);
-        sectionSlides = pres.Sections[0].Slides;
-        sectionSlides.Count.Should().Be(0);
+        shapes.Should().HaveCount(0);
+        pres.Validate();
     }
 }

--- a/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
@@ -824,9 +824,10 @@ public class ShapeCollectionTests : SCTest
     {
         // Arrange
         var pres = new Presentation();
-        var shapes = pres.Slides[0].Shapes;
+        var shapes = pres.Slide(1).Shapes; 
         shapes.AddRectangle(10, 10, 10, 10);
 
+        // Act
         shapes.Remove(shapes.Last());
         
         // Assert

--- a/test/ShapeCrawler.Tests.Unit/ShapeTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeTests.cs
@@ -400,7 +400,7 @@ public class ShapeTests : SCTest
     {
         // Arrange
         var pres = new Presentation(StreamOf("autoshape-grouping.pptx"));
-        var shape = pres.Slides[0].Shapes.GetByName("TextBox 3");
+        var shape = pres.Slides[0].Shape("TextBox 3");
 
         // Act
         shape.Remove();


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates ShapeCrawler to improve shape removal functionality and fix related bugs.

### Detailed summary
- Refactored `ShapeCollection.Remove` method to use shape ID for removal
- Updated `ShapeTests.cs` to use `Shape` method instead of `Shapes.GetByName`
- Added `Slides_Insert` test in `PresentationTests.cs`
- Modified `AddPicture_adds_svg_picture` test in `ShapeCollectionTests.cs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->