### PR TITLE
Add TableStyle and remove some warnings

### DIFF
--- a/src/ShapeCrawler/Charts/Chart.cs
+++ b/src/ShapeCrawler/Charts/Chart.cs
@@ -29,7 +29,7 @@ internal sealed class Chart : Shape, IChart
         ChartPart sdkChartPart, 
         P.GraphicFrame pGraphicFrame,
         IReadOnlyList<ICategory> categories)
-        : base(sdkTypedOpenXmlPart,pGraphicFrame)
+        : base(sdkTypedOpenXmlPart, pGraphicFrame)
     {
         this.SDKChartPart = sdkChartPart;
         this.SDKGraphicFrame = pGraphicFrame;

--- a/src/ShapeCrawler/Charts/ICategories.cs
+++ b/src/ShapeCrawler/Charts/ICategories.cs
@@ -100,8 +100,8 @@ internal sealed class Categories : IReadOnlyList<ICategory>
             }
 
             var normalizedFormula = cFormula.Text.Replace("'", string.Empty).Replace("$", string.Empty); // eg: Sheet1!$A$2:$A$5 -> Sheet1!A2:A5
-            var sheetName = Regex.Match(normalizedFormula, @".+(?=\!)",RegexOptions.None, TimeSpan.FromMilliseconds(1000)).Value; // eg: Sheet1!A2:A5 -> Sheet1
-            var cellsRange = Regex.Match(normalizedFormula, @"(?<=\!).+",RegexOptions.None, TimeSpan.FromMilliseconds(1000)).Value; // eg: Sheet1!A2:A5 -> A2:A5
+            var sheetName = Regex.Match(normalizedFormula, @".+(?=\!)", RegexOptions.None, TimeSpan.FromMilliseconds(1000)).Value; // eg: Sheet1!A2:A5 -> Sheet1
+            var cellsRange = Regex.Match(normalizedFormula, @"(?<=\!).+", RegexOptions.None, TimeSpan.FromMilliseconds(1000)).Value; // eg: Sheet1!A2:A5 -> A2:A5
             var addresses = new ExcelCellsRange(cellsRange).Addresses();
             for (var i = 0; i < addresses.Count; i++)
             {

--- a/src/ShapeCrawler/Charts/IChart.cs
+++ b/src/ShapeCrawler/Charts/IChart.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using DocumentFormat.OpenXml.Packaging;
-using P = DocumentFormat.OpenXml.Presentation;
 using C = DocumentFormat.OpenXml.Drawing.Charts;
+using P = DocumentFormat.OpenXml.Presentation;
 
 // ReSharper disable once CheckNamespace
 namespace ShapeCrawler;

--- a/src/ShapeCrawler/Charts/NullCategories.cs
+++ b/src/ShapeCrawler/Charts/NullCategories.cs
@@ -6,14 +6,14 @@ namespace ShapeCrawler.Charts;
 
 internal class NullCategories : IReadOnlyList<ICategory>
 {
-    private const string error =
+    private const string Error =
         $"Chart does not have categories. Use {nameof(IChart.HasCategories)} property to check if chart categories are available.";
     
-    public int Count => throw new SCException(error);
+    public int Count => throw new SCException(Error);
     
-    public ICategory this[int index] => throw new SCException(error);
+    public ICategory this[int index] => throw new SCException(Error);
     
-    public IEnumerator<ICategory> GetEnumerator() => throw new SCException(error);
+    public IEnumerator<ICategory> GetEnumerator() => throw new SCException(Error);
     
     IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
 }

--- a/src/ShapeCrawler/Colors/IFontColor.cs
+++ b/src/ShapeCrawler/Colors/IFontColor.cs
@@ -1,6 +1,4 @@
-﻿
-
-// ReSharper disable once CheckNamespace
+﻿// ReSharper disable once CheckNamespace
 namespace ShapeCrawler;
 
 /// <summary>

--- a/src/ShapeCrawler/Drawing/IShapeOutline.cs
+++ b/src/ShapeCrawler/Drawing/IShapeOutline.cs
@@ -1,6 +1,4 @@
-﻿
-
-// ReSharper disable once CheckNamespace
+﻿// ReSharper disable once CheckNamespace
 namespace ShapeCrawler;
 
 /// <summary>

--- a/src/ShapeCrawler/Drawing/ISlideBgImage.cs
+++ b/src/ShapeCrawler/Drawing/ISlideBgImage.cs
@@ -8,6 +8,6 @@ public interface ISlideBgImage : IImage
     /// <summary>
     ///     Presents whether the background image is presented.
     /// </summary>
-    /// <returns></returns>
+    /// <returns> bool. </returns>
     bool Present();
 }

--- a/src/ShapeCrawler/Excel/ExcelSheet.cs
+++ b/src/ShapeCrawler/Excel/ExcelSheet.cs
@@ -42,7 +42,7 @@ internal record ExcelSheet
         {
             var xWorksheet = sdkWorksheetPart.Worksheet;
             var xSheetData = xWorksheet.Elements<X.SheetData>().First();
-            var rowNumberStr = Regex.Match(address, @"\d+",RegexOptions.None, TimeSpan.FromMilliseconds(1000)).Value;
+            var rowNumberStr = Regex.Match(address, @"\d+", RegexOptions.None, TimeSpan.FromMilliseconds(1000)).Value;
             var rowNumber = int.Parse(rowNumberStr, NumberStyles.Number, NumberFormatInfo.InvariantInfo);
             var xRow = xSheetData.Elements<X.Row>().First(r => r.RowIndex! == rowNumber);
             var newXCell = new X.Cell

--- a/src/ShapeCrawler/Extensions/ShapePropertiesExtensions.cs
+++ b/src/ShapeCrawler/Extensions/ShapePropertiesExtensions.cs
@@ -34,8 +34,6 @@ internal static class ShapePropertiesExtensions
                 pShapeProperties.Append(aNoFill);
             }
         }
-
-
     }
 
     internal static void AddASolidFill(this OpenXmlCompositeElement pShapeProperties, string hex)

--- a/src/ShapeCrawler/Fonts/IndentFonts.cs
+++ b/src/ShapeCrawler/Fonts/IndentFonts.cs
@@ -79,7 +79,7 @@ internal readonly record struct IndentFonts
                     System.Globalization.CultureInfo.CurrentCulture);
 #else
             var localName = textPr.LocalName.AsSpan();
-            var level = localName.Slice(3,1); // the fourth character contains level number, eg. "lvl1pPr -> 1, lvl2pPr -> 2, etc."
+            var level = localName.Slice(3, 1); // the fourth character contains level number, eg. "lvl1pPr -> 1, lvl2pPr -> 2, etc."
             var paragraphLvl = int.Parse(level, System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.CurrentCulture);
 #endif
             if (paragraphLvl == indentLevelFor)

--- a/src/ShapeCrawler/Fonts/PortionFontSize.cs
+++ b/src/ShapeCrawler/Fonts/PortionFontSize.cs
@@ -2,8 +2,8 @@
 using DocumentFormat.OpenXml.Packaging;
 using ShapeCrawler.ShapeCollection;
 using ShapeCrawler.Texts;
-using P = DocumentFormat.OpenXml.Presentation;
 using A = DocumentFormat.OpenXml.Drawing;
+using P = DocumentFormat.OpenXml.Presentation;
 
 namespace ShapeCrawler.Fonts;
 
@@ -125,7 +125,7 @@ internal class PortionFontSize : IFontSize
         var aRunPr = parent.GetFirstChild<A.RunProperties>();
         if (aRunPr == null)
         {
-            aRunPr =  new A.RunProperties { Language = "en-US", FontSize = 1400, Dirty = false };
+            aRunPr = new A.RunProperties { Language = "en-US", FontSize = 1400, Dirty = false };
             parent.InsertAt(aRunPr, 0);
         }
 

--- a/src/ShapeCrawler/Presentations/ISlide.cs
+++ b/src/ShapeCrawler/Presentations/ISlide.cs
@@ -75,7 +75,7 @@ public interface ISlide
     ///     Returns shape with specified name.
     /// </summary>
     /// <param name="name">Shape name.</param>
-    /// <returns></returns>
+    /// <returns> The IShape requested. </returns>
     IShape Shape(string name);
     
 #if DEBUG

--- a/src/ShapeCrawler/Presentations/ISlides.cs
+++ b/src/ShapeCrawler/Presentations/ISlides.cs
@@ -21,7 +21,6 @@ public interface ISlides : IReadOnlyList<ISlide>
     /// <summary>
     ///     Adds a new slide based on the predefined layout type.
     /// </summary>
-    /// <returns>A new slide.</returns>
     void AddEmptySlide(SlideLayoutType layoutType);
 
     /// <summary>

--- a/src/ShapeCrawler/Presentations/Slide.cs
+++ b/src/ShapeCrawler/Presentations/Slide.cs
@@ -194,7 +194,8 @@ internal sealed class Slide : ISlide
     private void AddNotesSlide(IEnumerable<string> lines)
     {
         // Build up the children of the text body element
-        var textBodyChildren = new List<OpenXmlElement>() {
+        var textBodyChildren = new List<OpenXmlElement>() 
+        {
             new BodyProperties(),
             new ListStyle()
         };

--- a/src/ShapeCrawler/Presentations/SlideSize.cs
+++ b/src/ShapeCrawler/Presentations/SlideSize.cs
@@ -28,5 +28,4 @@ internal sealed class SlideSize
         var emu = UnitConverter.VerticalPixelToEmu(pixels);
         this.pSlideSize.Cy = new Int32Value((int)emu);
     }
-
 }

--- a/src/ShapeCrawler/Presentations/Slides.cs
+++ b/src/ShapeCrawler/Presentations/Slides.cs
@@ -176,8 +176,7 @@ internal sealed class Slides : ISlides
         {
             return new P.TextBody(new OpenXmlElement[]
             {
-                new DocumentFormat.OpenXml.Drawing.Paragraph(new OpenXmlElement[]
-                    { new DocumentFormat.OpenXml.Drawing.EndParagraphRunProperties() })
+                new DocumentFormat.OpenXml.Drawing.Paragraph([new DocumentFormat.OpenXml.Drawing.EndParagraphRunProperties()])
             })
             {
                 BodyProperties = new DocumentFormat.OpenXml.Drawing.BodyProperties(),

--- a/src/ShapeCrawler/Presentations/WrappedPresentationPart.cs
+++ b/src/ShapeCrawler/Presentations/WrappedPresentationPart.cs
@@ -34,5 +34,7 @@ internal readonly ref struct WrappedPresentationPart
         }
     }
 
-    internal T Last<T>() where T : OpenXmlPart => this.presentationPart.GetPartsOfType<T>().Last();
+    internal T Last<T>()
+        where T : OpenXmlPart
+        => this.presentationPart.GetPartsOfType<T>().Last();
 }

--- a/src/ShapeCrawler/ShapeCollection/GroupShapes/GroupedShapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/GroupShapes/GroupedShapes.cs
@@ -26,18 +26,20 @@ internal sealed record GroupedShapes : IShapes
 
     public IShape this[int index] => this.GroupedShapesCore()[index];
 
-    public T GetById<T>(int id) where T : IShape => (T)this.GroupedShapesCore().First(shape => shape.Id == id);
+    public T GetById<T>(int id)
+        where T : IShape => (T)this.GroupedShapesCore().First(shape => shape.Id == id);
 
-    public T? TryGetById<T>(int id) where T : IShape =>
-        (T?)this.GroupedShapesCore().FirstOrDefault(shape => shape.Id == id);
+    public T? TryGetById<T>(int id) 
+        where T : IShape => (T?)this.GroupedShapesCore().FirstOrDefault(shape => shape.Id == id);
 
     T IShapes.GetByName<T>(string name) => (T)this.GroupedShapesCore().First(shape => shape.Name == name);
 
-    T? IShapes.TryGetByName<T>(string name) where T : default =>
-        (T?)this.GroupedShapesCore().FirstOrDefault(shape => shape.Name == name);
+    T? IShapes.TryGetByName<T>(string name) 
+        where T : default => (T?)this.GroupedShapesCore().FirstOrDefault(shape => shape.Name == name);
 
     public IShape GetByName(string name) => this.GroupedShapesCore().First(shape => shape.Name == name);
-    public T Last<T>() where T : IShape => (T)this.GroupedShapesCore().Last(shape => shape is T);
+    public T Last<T>() 
+        where T : IShape => (T)this.GroupedShapesCore().Last(shape => shape is T);
 
     public T GetByName<T>(string name) => (T)this.GroupedShapesCore().First(shape => shape.Name == name);
 

--- a/src/ShapeCrawler/ShapeCollection/IMediaShape.cs
+++ b/src/ShapeCrawler/ShapeCollection/IMediaShape.cs
@@ -22,7 +22,6 @@ public interface IMediaShape : IShape
     ///     Gets bytes of video content.
     /// </summary>
     public byte[] AsByteArray();
-
 }
 
 internal class MediaShape : Shape, IMediaShape

--- a/src/ShapeCrawler/ShapeCollection/IShape.cs
+++ b/src/ShapeCrawler/ShapeCollection/IShape.cs
@@ -38,7 +38,7 @@ public interface IShape : IPosition
     /// <summary>
     ///     Gets a value indicating whether shape is a placeholder.
     /// </summary>
-    /// <returns></returns>
+    /// <returns> bool. </returns>
     bool IsPlaceholder { get; }
     
     /// <summary>

--- a/src/ShapeCrawler/ShapeCollection/IShapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/IShapes.cs
@@ -12,25 +12,29 @@ public interface IShapes : IReadOnlyList<IShape>
     ///     Gets shape by identifier.
     /// </summary>
     /// <typeparam name="T">Shape type.</typeparam>
-    T GetById<T>(int id) where T : IShape;
+    T GetById<T>(int id)
+        where T : IShape;
 
     /// <summary>
     ///     Tries to get shape by identifier, returns null if shape is not found.
     /// </summary>
     /// <typeparam name="T">Shape type.</typeparam>
-    T? TryGetById<T>(int id) where T : IShape;
+    T? TryGetById<T>(int id) 
+        where T : IShape;
 
     /// <summary>
     ///     Gets shape by name.
     /// </summary>
     /// <typeparam name="T">Shape type.</typeparam>
-    T GetByName<T>(string name) where T : IShape;
+    T GetByName<T>(string name) 
+        where T : IShape;
     
     /// <summary>
     ///     Tries to get shape by name, returns null if shape is not found.
     /// </summary>
     /// <typeparam name="T">Shape type.</typeparam>
-    T? TryGetByName<T>(string name) where T : IShape;
+    T? TryGetByName<T>(string name) 
+        where T : IShape;
 
     /// <summary>
     ///     Gets shape by name.

--- a/src/ShapeCrawler/ShapeCollection/ISlideShapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/ISlideShapes.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using ShapeCrawler.Tables;
 
 // ReSharper disable once CheckNamespace
 namespace ShapeCrawler;
@@ -17,7 +18,7 @@ public interface ISlideShapes : IShapes
     ///     Adds a new audio shape.
     /// </summary>
     void AddAudio(int x, int y, Stream audio);
-    
+
     /// <summary>
     ///     Adds a new audio shape.
     /// </summary>
@@ -60,6 +61,16 @@ public interface ISlideShapes : IShapes
     ///     Adds a new table.
     /// </summary>
     void AddTable(int x, int y, int columnsCount, int rowsCount);
+
+    /// <summary>
+    ///     Adds a new table with a custom style.
+    /// </summary>
+    void AddTable(int x, int y, int columnsCount, int rowsCount, ITableStyle style);
+
+    /// <summary>
+    ///     Adds a new table with custom style using enum.
+    /// </summary>
+    void AddTable(int x, int y, int columnsCount, int rowsCount, TableStyleEnum style);
 
     /// <summary>
     ///     Removes specified shape.

--- a/src/ShapeCrawler/ShapeCollection/ISlideShapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/ISlideShapes.cs
@@ -68,11 +68,6 @@ public interface ISlideShapes : IShapes
     void AddTable(int x, int y, int columnsCount, int rowsCount, ITableStyle style);
 
     /// <summary>
-    ///     Adds a new table with custom style using enum.
-    /// </summary>
-    void AddTable(int x, int y, int columnsCount, int rowsCount, TableStyleEnum style);
-
-    /// <summary>
     ///     Removes specified shape.
     /// </summary>
     void Remove(IShape shape);

--- a/src/ShapeCrawler/ShapeCollection/RootShape.cs
+++ b/src/ShapeCrawler/ShapeCollection/RootShape.cs
@@ -68,8 +68,8 @@ internal sealed class RootShape : CopyableShape, IRootShape
 
         if (this.GeometryType == Geometry.Rectangle)
         {
-            float left = (float)(this.X);
-            float top = (float)(this.Y);
+            float left = (float)this.X;
+            float top = (float)this.Y;
             float right = (float)(this.X + this.Width);
             float bottom = (float)(this.Y + this.Height);
             var rect = new SKRect(left, top, right, bottom);

--- a/src/ShapeCrawler/ShapeCollection/Shape.cs
+++ b/src/ShapeCrawler/ShapeCollection/Shape.cs
@@ -15,7 +15,7 @@ internal abstract class Shape : IShape
 {
     protected readonly OpenXmlPart sdkTypedOpenXmlPart;
     protected readonly OpenXmlElement pShapeTreeElement;
-    private const string customDataElementName = "ctd";
+    private const string CustomDataElementName = "ctd";
     private readonly Position position;
     private readonly ShapeSize size;
     private readonly ShapeId shapeId;
@@ -148,7 +148,7 @@ internal abstract class Shape : IShape
     {
         get
         {
-            const string pattern = @$"<{customDataElementName}>(.*)<\/{customDataElementName}>";
+            const string pattern = @$"<{CustomDataElementName}>(.*)<\/{CustomDataElementName}>";
 
 #if NETSTANDARD2_0
             var regex = new Regex(pattern, RegexOptions.None, TimeSpan.FromSeconds(100));
@@ -168,7 +168,7 @@ internal abstract class Shape : IShape
         set
         {
             var customDataElement =
-                $@"<{customDataElementName}>{value}</{customDataElementName}>";
+                $@"<{CustomDataElementName}>{value}</{CustomDataElementName}>";
             this.pShapeTreeElement.InnerXml += customDataElement;
         }
     }
@@ -188,7 +188,7 @@ internal abstract class Shape : IShape
 
     public virtual bool IsTextHolder { get; protected init; }
     
-    public virtual ITextBox TextBox { get; protected init; } = new NullTextFrame();
+    public virtual ITextBox TextBox { get; protected init; } = default(NullTextFrame);
 
     public virtual double Rotation
     {

--- a/src/ShapeCrawler/ShapeCollection/Shapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/Shapes.cs
@@ -27,18 +27,22 @@ internal sealed class Shapes : IShapes
 
     public IShape this[int index] => this.ShapesCore()[index];
 
-    public T GetById<T>(int id) where T : IShape => (T)this.ShapesCore().First(shape => shape.Id == id);
+    public T GetById<T>(int id) 
+        where T : IShape => (T)this.ShapesCore().First(shape => shape.Id == id);
 
-    public T? TryGetById<T>(int id) where T : IShape => (T?)this.ShapesCore().FirstOrDefault(shape => shape.Id == id);
+    public T? TryGetById<T>(int id) 
+        where T : IShape => (T?)this.ShapesCore().FirstOrDefault(shape => shape.Id == id);
 
-    public T GetByName<T>(string name) where T : IShape => (T)this.GetByName(name);
+    public T GetByName<T>(string name) 
+        where T : IShape => (T)this.GetByName(name);
 
-    public T? TryGetByName<T>(string name) where T : IShape =>
-        (T?)this.ShapesCore().FirstOrDefault(shape => shape.Name == name);
+    public T? TryGetByName<T>(string name) 
+        where T : IShape => (T?)this.ShapesCore().FirstOrDefault(shape => shape.Name == name);
 
     public IShape GetByName(string name) => this.ShapesCore().First(shape => shape.Name == name);
 
-    public T Last<T>() where T : IShape => (T)this.ShapesCore().Last(shape => shape is T);
+    public T Last<T>() 
+        where T : IShape => (T)this.ShapesCore().Last(shape => shape is T);
 
     public IEnumerator<IShape> GetEnumerator() => this.ShapesCore().GetEnumerator();
 

--- a/src/ShapeCrawler/ShapeCollection/SlideShapeOutline.cs
+++ b/src/ShapeCrawler/ShapeCollection/SlideShapeOutline.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using DocumentFormat.OpenXml;
+﻿using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using ShapeCrawler.Drawing;
 using ShapeCrawler.Extensions;
@@ -53,7 +52,7 @@ internal sealed class SlideShapeOutline : IShapeOutline
             aOutline = this.sdkTypedOpenXmlCompositeElement.AddAOutline();
         }
 
-        aOutline.Width = new Int32Value((Int32)UnitConverter.PointToEmu(points));
+        aOutline.Width = new Int32Value((int)UnitConverter.PointToEmu(points));
     }
     
     private void UpdateFill(OpenXmlElement child)

--- a/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
@@ -407,7 +407,7 @@ internal sealed class SlideShapes : ISlideShapes
     public void AddTable(int x, int y, int columnsCount, int rowsCount)
     {
         // default style (to keep it how it was)
-        this.AddTable(x, y, columnsCount, rowsCount, TableStyleEnum.MediumStyle2Accent1);
+        this.AddTable(x, y, columnsCount, rowsCount, TableStyle.MediumStyle2Accent1);
     }
 
     public void AddTable(int x, int y, int columnsCount, int rowsCount, ITableStyle style)
@@ -463,12 +463,6 @@ internal sealed class SlideShapes : ISlideShapes
         graphicFrame.Append(graphic);
 
         this.sdkSlidePart.Slide.CommonSlideData!.ShapeTree!.Append(graphicFrame);
-    }
-
-    public void AddTable(int x, int y, int columnsCount, int rowsCount, TableStyleEnum style)
-    {
-        ITableStyle vstyle = CommonTableStyles.GetTableStyleByEnum(style);
-        this.AddTable(x, y, columnsCount, rowsCount, vstyle);
     }
 
     public void Remove(IShape shape)

--- a/src/ShapeCrawler/Tables/CommonTableStyles.cs
+++ b/src/ShapeCrawler/Tables/CommonTableStyles.cs
@@ -4,207 +4,95 @@ using System.Collections.Generic;
 namespace ShapeCrawler.Tables;
 
 // TODO : verify the values 
-
-/// <summary>
-///     Represents the common table style.
-/// </summary>
-public enum TableStyleEnum
-{
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-// enum is self documented
-#pragma warning disable SA1602 // Enumeration items should be documented
-    NoStyleNoGrid,
-    NoStyleTableGrid,
-
-    ThemedStyle1Accent1,
-    ThemedStyle1Accent2,
-    ThemedStyle1Accent3,
-    ThemedStyle1Accent4,
-    ThemedStyle1Accent5,
-    ThemedStyle1Accent6,
-
-    ThemedStyle2Accent1,
-    ThemedStyle2Accent2,
-    ThemedStyle2Accent3,
-    ThemedStyle2Accent4,
-    ThemedStyle2Accent5,
-    ThemedStyle2Accent6,
-
-    LightStyle1,
-    LightStyle1Accent1,
-    LightStyle1Accent2,
-    LightStyle1Accent3,
-    LightStyle1Accent4,
-    LightStyle1Accent5,
-    LightStyle1Accent6,
-
-    LightStyle2,
-    LightStyle2Accent1,
-    LightStyle2Accent2,
-    LightStyle2Accent3,
-    LightStyle2Accent4,
-    LightStyle2Accent5,
-    LightStyle2Accent6,
-
-    LightStyle3,
-    LightStyle3Accent1,
-    LightStyle3Accent2,
-    LightStyle3Accent3,
-    LightStyle3Accent4,
-    LightStyle3Accent5,
-    LightStyle3Accent6,
-
-    MediumStyle1,
-    MediumStyle1Accent1,
-    MediumStyle1Accent2,
-    MediumStyle1Accent3,
-    MediumStyle1Accent4,
-    MediumStyle1Accent5,
-    MediumStyle1Accent6,
-
-    MediumStyle2,
-    MediumStyle2Accent1,
-    MediumStyle2Accent2,
-    MediumStyle2Accent3,
-    MediumStyle2Accent4,
-    MediumStyle2Accent5,
-    MediumStyle2Accent6,
-
-    MediumStyle3,
-    MediumStyle3Accent1,
-    MediumStyle3Accent2,
-    MediumStyle3Accent3,
-    MediumStyle3Accent4,
-    MediumStyle3Accent5,
-    MediumStyle3Accent6,
-
-    MediumStyle4,
-    MediumStyle4Accent1,
-    MediumStyle4Accent2,
-    MediumStyle4Accent3,
-    MediumStyle4Accent4,
-    MediumStyle4Accent5,
-    MediumStyle4Accent6,
-
-    DarkStyle1,
-    DarkStyle1Accent1,
-    DarkStyle1Accent2,
-    DarkStyle1Accent3,
-    DarkStyle1Accent4,
-    DarkStyle1Accent5,
-    DarkStyle1Accent6,
-
-    DarkStyle2,
-    DarkStyle2Accent1Accent2,
-    DarkStyle2Accent3Accent4,
-    DarkStyle2Accent5Accent6
-#pragma warning restore SA1602 // Enumeration items should be documented
-
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
-}
-
 internal static class CommonTableStyles
 {
-    public static readonly Dictionary<TableStyleEnum, TableStyle> Styles = new Dictionary<TableStyleEnum, TableStyle>
+    public static readonly Dictionary<string, ITableStyle> Styles = new Dictionary<string, ITableStyle>
     {
-        { TableStyleEnum.NoStyleNoGrid, new TableStyle("No Style, No Grid", "{2D5ABB26-0587-4C30-8999-92F81FD0307C}") },
-        { TableStyleEnum.NoStyleTableGrid, new TableStyle("No Style, Table Grid", "{5940675A-B579-460E-94D1-54222C63F5DA}") },
-        { TableStyleEnum.ThemedStyle1Accent1, new TableStyle("Themed Style 1 - Accent 1", "{3C2FFA5D-87B4-456A-9821-1D502468CF0F}") },
-        { TableStyleEnum.ThemedStyle1Accent2, new TableStyle("Themed Style 1 - Accent 2", "{284E427A-3D55-4303-BF80-6455036E1DE7}") },
-        { TableStyleEnum.ThemedStyle1Accent3, new TableStyle("Themed Style 1 - Accent 3", "{69C7853C-536D-4A76-A0AE-DD22124D55A5}") },
-        { TableStyleEnum.ThemedStyle1Accent4, new TableStyle("Themed Style 1 - Accent 4", "{775DCB02-9BB8-47FD-8907-85C794F793BA}") },
-        { TableStyleEnum.ThemedStyle1Accent5, new TableStyle("Themed Style 1 - Accent 5", "{35758FB7-9AC5-4552-8A53-C91805E547FA}") },
-        { TableStyleEnum.ThemedStyle1Accent6, new TableStyle("Themed Style 1 - Accent 6", "{08FB837D-C827-4EFA-A057-4D05807E0F7C}") },
-        { TableStyleEnum.ThemedStyle2Accent1, new TableStyle("Themed Style 2 - Accent 1", "{D113A9D2-9D6B-4929-AA2D-F23B5EE8CBE7}") },
-        { TableStyleEnum.ThemedStyle2Accent2, new TableStyle("Themed Style 2 - Accent 2", "{18603FDC-E32A-4AB5-989C-0864C3EAD2B8}") },
-        { TableStyleEnum.ThemedStyle2Accent3, new TableStyle("Themed Style 2 - Accent 3", "{306799F8-075E-4A3A-A7F6-7FBC6576F1A4}") },
-        { TableStyleEnum.ThemedStyle2Accent4, new TableStyle("Themed Style 2 - Accent 4", "{E269D01E-BC32-4049-B463-5C60D7B0CCD2}") },
-        { TableStyleEnum.ThemedStyle2Accent5, new TableStyle("Themed Style 2 - Accent 5", "{327F97BB-C833-4FB7-BDE5-3F7075034690}") },
-        { TableStyleEnum.ThemedStyle2Accent6, new TableStyle("Themed Style 2 - Accent 6", "{638B1855-1B75-4FBE-930C-398BA8C253C6}") },
-        { TableStyleEnum.LightStyle1, new TableStyle("Light Style 1", "{9D7B26C5-4107-4FEC-AEDC-1716B250A1EF}") },
-        { TableStyleEnum.LightStyle1Accent1, new TableStyle("Light Style 1 - Accent 1", "{3B4B98B0-60AC-42C2-AFA5-B58CD77FA1E5}") },
-        { TableStyleEnum.LightStyle1Accent2, new TableStyle("Light Style 1 - Accent 2", "{0E3FDE45-AF77-4B5C-9715-49D594BDF05E}") },
-        { TableStyleEnum.LightStyle1Accent3, new TableStyle("Light Style 1 - Accent 3", "{C083E6E3-FA7D-4D7B-A595-EF9225AFEA82}") },
-        { TableStyleEnum.LightStyle1Accent4, new TableStyle("Light Style 1 - Accent 4", "{D27102A9-8310-4765-A935-A1911B00CA55}") },
-        { TableStyleEnum.LightStyle1Accent5, new TableStyle("Light Style 1 - Accent 5", "{5FD0F851-EC5A-4D38-B0AD-8093EC10F338}") },
-        { TableStyleEnum.LightStyle1Accent6, new TableStyle("Light Style 1 - Accent 6", "{68D230F3-CF80-4859-8CE7-A43EE81993B5}") },
-        { TableStyleEnum.LightStyle2, new TableStyle("Light Style 2", "{7E9639D4-E3E2-4D34-9284-5A2195B3D0D7}") },
-        { TableStyleEnum.LightStyle2Accent1, new TableStyle("Light Style 2 - Accent 1", "{69012ECD-51FC-41F1-AA8D-1B2483CD663E}") },
-        { TableStyleEnum.LightStyle2Accent2, new TableStyle("Light Style 2 - Accent 2", "{72833802-FEF1-4C79-8D5D-14CF1EAF98D9}") },
-        { TableStyleEnum.LightStyle2Accent3, new TableStyle("Light Style 2 - Accent 3", "{F2DE63D5-997A-4646-A377-4702673A728D}") },
-        { TableStyleEnum.LightStyle2Accent4, new TableStyle("Light Style 2 - Accent 4", "{17292A2E-F333-43FB-9621-5CBBE7FDCDCB}") },
-        { TableStyleEnum.LightStyle2Accent5, new TableStyle("Light Style 2 - Accent 5", "{5A111915-BE36-4E01-A7E5-04B1672EAD32}") },
-        { TableStyleEnum.LightStyle2Accent6, new TableStyle("Light Style 2 - Accent 6", "{912C8C85-51F0-491E-9774-3900AFEF0FD7}") },
-        { TableStyleEnum.LightStyle3, new TableStyle("Light Style 3", "{616DA210-FB5B-4158-B5E0-FEB733F419BA}") },
-        { TableStyleEnum.LightStyle3Accent1, new TableStyle("Light Style 3 - Accent 1", "{BC89EF96-8CEA-46FF-86C4-4CE0E7609802}") },
-        { TableStyleEnum.LightStyle3Accent2, new TableStyle("Light Style 3 - Accent 2", "{5DA37D80-6434-44D0-A028-1B22A696006F}") },
-        { TableStyleEnum.LightStyle3Accent3, new TableStyle("Light Style 3 - Accent 3", "{8799B23B-EC83-4686-B30A-512413B5E67A}") },
-        { TableStyleEnum.LightStyle3Accent4, new TableStyle("Light Style 3 - Accent 4", "{ED083AE6-46FA-4A59-8FB0-9F97EB10719F}") },
-        { TableStyleEnum.LightStyle3Accent5, new TableStyle("Light Style 3 - Accent 5", "{BDBED569-4797-4DF1-A0F4-6AAB3CD982D8}") },
-        { TableStyleEnum.LightStyle3Accent6, new TableStyle("Light Style 3 - Accent 6", "{E8B1032C-EA38-4F05-BA0D-38AFFFC7BED3}") },
-        { TableStyleEnum.MediumStyle1, new TableStyle("Medium Style 1", "{793D81CF-94F2-401A-BA57-92F5A7B2D0C5}") },
-        { TableStyleEnum.MediumStyle1Accent1, new TableStyle("Medium Style 1 - Accent 1", "{B301B821-A1FF-4177-AEE7-76D212191A09}") },
-        { TableStyleEnum.MediumStyle1Accent2, new TableStyle("Medium Style 1 - Accent 2", "{9DCAF9ED-07DC-4A11-8D7F-57B35C25682E}") },
-        { TableStyleEnum.MediumStyle1Accent3, new TableStyle("Medium Style 1 - Accent 3", "{1FECB4D8-DB02-4DC6-A0A2-4F2EBAE1DC90}") },
-        { TableStyleEnum.MediumStyle1Accent4, new TableStyle("Medium Style 1 - Accent 4", "{1E171933-4619-4E11-9A3F-F7608DF75F80}") },
-        { TableStyleEnum.MediumStyle1Accent5, new TableStyle("Medium Style 1 - Accent 5", "{FABFCF23-3B69-468F-B69F-88F6DE6A72F2}") },
-        { TableStyleEnum.MediumStyle1Accent6, new TableStyle("Medium Style 1 - Accent 6", "{10A1B5D5-9B99-4C35-A422-299274C87663}") },
-        { TableStyleEnum.MediumStyle2, new TableStyle("Medium Style 2", "{073A0DAA-6AF3-43AB-8588-CEC1D06C72B9}") },
-        { TableStyleEnum.MediumStyle2Accent1, new TableStyle("Medium Style 2 - Accent 1", "{5C22544A-7EE6-4342-B048-85BDC9FD1C3A}") },
-        { TableStyleEnum.MediumStyle2Accent2, new TableStyle("Medium Style 2 - Accent 2", "{21E4AEA4-8DFA-4A89-87EB-49C32662AFE0}") },
-        { TableStyleEnum.MediumStyle2Accent3, new TableStyle("Medium Style 2 - Accent 3", "{F5AB1C69-6EDB-4FF4-983F-18BD219EF322}") },
-        { TableStyleEnum.MediumStyle2Accent4, new TableStyle("Medium Style 2 - Accent 4", "{00A15C55-8517-42AA-B614-E9B94910E393}") },
-        { TableStyleEnum.MediumStyle2Accent5, new TableStyle("Medium Style 2 - Accent 5", "{7DF18680-E054-41AD-8BC1-D1AEF772440D}") },
-        { TableStyleEnum.MediumStyle2Accent6, new TableStyle("Medium Style 2 - Accent 6", "{93296810-A885-4BE3-A3E7-6D5BEEA58F35}") },
-        { TableStyleEnum.MediumStyle3, new TableStyle("Medium Style 3", "{8EC20E35-A176-4012-BC5E-935CFFF8708E}") },
-        { TableStyleEnum.MediumStyle3Accent1, new TableStyle("Medium Style 3 - Accent 1", "{6E25E649-3F16-4E02-A733-19D2CDBF48F0}") },
-        { TableStyleEnum.MediumStyle3Accent2, new TableStyle("Medium Style 3 - Accent 2", "{85BE263C-DBD7-4A20-BB59-AAB30ACAA65A}") },
-        { TableStyleEnum.MediumStyle3Accent3, new TableStyle("Medium Style 3 - Accent 3", "{EB344D84-9AFB-497E-A393-DC336BA19D2E}") },
-        { TableStyleEnum.MediumStyle3Accent4, new TableStyle("Medium Style 3 - Accent 4", "{EB9631B5-78F2-41C9-869B-9F39066F8104}") },
-        { TableStyleEnum.MediumStyle3Accent5, new TableStyle("Medium Style 3 - Accent 5", "{74C1A8A3-306A-4EB7-A6B1-4F7E0EB9C5D6}") },
-        { TableStyleEnum.MediumStyle3Accent6, new TableStyle("Medium Style 3 - Accent 6", "{2A488322-F2BA-4B5B-9748-0D474271808F}") },
-        { TableStyleEnum.MediumStyle4, new TableStyle("Medium Style 4", "{D7AC3CCA-C797-4891-BE02-D94E43425B78}") },
-        { TableStyleEnum.MediumStyle4Accent1, new TableStyle("Medium Style 4 - Accent 1", "{69CF1AB2-1976-4502-BF36-3FF5EA218861}") },
-        { TableStyleEnum.MediumStyle4Accent2, new TableStyle("Medium Style 4 - Accent 2", "{8A107856-5554-42FB-B03E-39F5DBC370BA}") },
-        { TableStyleEnum.MediumStyle4Accent3, new TableStyle("Medium Style 4 - Accent 3", "{0505E3EF-67EA-436B-97B2-0124C06EBD24}") },
-        { TableStyleEnum.MediumStyle4Accent4, new TableStyle("Medium Style 4 - Accent 4", "{C4B1156A-380E-4F78-BDF5-A606A8083BF9}") },
-        { TableStyleEnum.MediumStyle4Accent5, new TableStyle("Medium Style 4 - Accent 5", "{22838BEF-8BB2-4498-84A7-C5851F593DF1}") },
-        { TableStyleEnum.MediumStyle4Accent6, new TableStyle("Medium Style 4 - Accent 6", "{16D9F66E-5EB9-4882-86FB-DCBF35E3C3E4}") },
-        { TableStyleEnum.DarkStyle1, new TableStyle("Dark Style 1", "{E8034E78-7F5D-4C2E-B375-FC64B27BC917}") },
-        { TableStyleEnum.DarkStyle1Accent1, new TableStyle("Dark Style 1 - Accent 1", "{125E5076-3810-47DD-B79F-674D7AD40C01}") },
-        { TableStyleEnum.DarkStyle1Accent2, new TableStyle("Dark Style 1 - Accent 2", "{37CE84F3-28C3-443E-9E96-99CF82512B78}") },
-        { TableStyleEnum.DarkStyle1Accent3, new TableStyle("Dark Style 1 - Accent 3", "{D03447BB-5D67-496B-8E87-E561075AD55C}") },
-        { TableStyleEnum.DarkStyle1Accent4, new TableStyle("Dark Style 1 - Accent 4", "{E929F9F4-4A8F-4326-A1B4-22849713DDAB}") },
-        { TableStyleEnum.DarkStyle1Accent5, new TableStyle("Dark Style 1 - Accent 5", "{8FD4443E-F989-4FC4-A0C8-D5A2AF1F390B}") },
-        { TableStyleEnum.DarkStyle1Accent6, new TableStyle("Dark Style 1 - Accent 6", "{AF606853-7671-496A-8E4F-DF71F8EC918B}") },
-        { TableStyleEnum.DarkStyle2, new TableStyle("Dark Style 2", "{5202B0CA-FC54-4496-8BCA-5EF66A818D29}") },
-        { TableStyleEnum.DarkStyle2Accent1Accent2, new TableStyle("Dark Style 2 - Accent 1, Accent 2", "{0660B408-B3CF-4A94-85FC-2B1E0A45F4A2}") },
-        { TableStyleEnum.DarkStyle2Accent3Accent4, new TableStyle("Dark Style 2 - Accent 3, Accent 4", "{91EBBBCC-DAD2-459C-BE2E-F6DE35CF9A28}") },
-        { TableStyleEnum.DarkStyle2Accent5Accent6, new TableStyle("Dark Style 2 - Accent 5, Accent 6", "{46F890A9-2807-4EBB-B81D-B2AA78EC7F39}") }
+        { "No Style, No Grid", TableStyle.NoStyleNoGrid },
+        { "No Style, Table Grid", TableStyle.NoStyleTableGrid },
+        { "Themed Style 1 - Accent 1", TableStyle.ThemedStyle1Accent1 },
+        { "Themed Style 1 - Accent 2", TableStyle.ThemedStyle1Accent2 },
+        { "Themed Style 1 - Accent 3", TableStyle.ThemedStyle1Accent3 },
+        { "Themed Style 1 - Accent 4", TableStyle.ThemedStyle1Accent4 },
+        { "Themed Style 1 - Accent 5", TableStyle.ThemedStyle1Accent5 },
+        { "Themed Style 1 - Accent 6", TableStyle.ThemedStyle1Accent6 },
+        { "Themed Style 2 - Accent 1", TableStyle.ThemedStyle2Accent1 },
+        { "Themed Style 2 - Accent 2", TableStyle.ThemedStyle2Accent2 },
+        { "Themed Style 2 - Accent 3", TableStyle.ThemedStyle2Accent3 },
+        { "Themed Style 2 - Accent 4", TableStyle.ThemedStyle2Accent4 },
+        { "Themed Style 2 - Accent 5", TableStyle.ThemedStyle2Accent5 },
+        { "Themed Style 2 - Accent 6", TableStyle.ThemedStyle2Accent6 },
+        { "Light Style 1", TableStyle.LightStyle1 },
+        { "Light Style 1 - Accent 1", TableStyle.LightStyle1Accent1 },
+        { "Light Style 1 - Accent 2", TableStyle.LightStyle1Accent2 },
+        { "Light Style 1 - Accent 3", TableStyle.LightStyle1Accent3 },
+        { "Light Style 1 - Accent 4", TableStyle.LightStyle1Accent4 },
+        { "Light Style 1 - Accent 5", TableStyle.LightStyle1Accent5 },
+        { "Light Style 1 - Accent 6", TableStyle.LightStyle1Accent6 },
+        { "Light Style 2", TableStyle.LightStyle2 },
+        { "Light Style 2 - Accent 1", TableStyle.LightStyle2Accent1 },
+        { "Light Style 2 - Accent 2", TableStyle.LightStyle2Accent2 },
+        { "Light Style 2 - Accent 3", TableStyle.LightStyle2Accent3 },
+        { "Light Style 2 - Accent 4", TableStyle.LightStyle2Accent4 },
+        { "Light Style 2 - Accent 5", TableStyle.LightStyle2Accent5 },
+        { "Light Style 2 - Accent 6", TableStyle.LightStyle2Accent6 },
+        { "Light Style 3", TableStyle.LightStyle3 },
+        { "Light Style 3 - Accent 1", TableStyle.LightStyle3Accent1 },
+        { "Light Style 3 - Accent 2", TableStyle.LightStyle3Accent2 },
+        { "Light Style 3 - Accent 3", TableStyle.LightStyle3Accent3 },
+        { "Light Style 3 - Accent 4", TableStyle.LightStyle3Accent4 },
+        { "Light Style 3 - Accent 5", TableStyle.LightStyle3Accent5 },
+        { "Light Style 3 - Accent 6", TableStyle.LightStyle3Accent6 },
+        { "Medium Style 1", TableStyle.MediumStyle1 },
+        { "Medium Style 1 - Accent 1", TableStyle.MediumStyle1Accent1 },
+        { "Medium Style 1 - Accent 2", TableStyle.MediumStyle1Accent2 },
+        { "Medium Style 1 - Accent 3", TableStyle.MediumStyle1Accent3 },
+        { "Medium Style 1 - Accent 4", TableStyle.MediumStyle1Accent4 },
+        { "Medium Style 1 - Accent 5", TableStyle.MediumStyle1Accent5 },
+        { "Medium Style 1 - Accent 6", TableStyle.MediumStyle1Accent6 },
+        { "Medium Style 2", TableStyle.MediumStyle2 },
+        { "Medium Style 2 - Accent 1", TableStyle.MediumStyle2Accent1 },
+        { "Medium Style 2 - Accent 2", TableStyle.MediumStyle2Accent2 },
+        { "Medium Style 2 - Accent 3", TableStyle.MediumStyle2Accent3 },
+        { "Medium Style 2 - Accent 4", TableStyle.MediumStyle2Accent4 },
+        { "Medium Style 2 - Accent 5", TableStyle.MediumStyle2Accent5 },
+        { "Medium Style 2 - Accent 6", TableStyle.MediumStyle2Accent6 },
+        { "Medium Style 3", TableStyle.MediumStyle3 },
+        { "Medium Style 3 - Accent 1", TableStyle.MediumStyle3Accent1 },
+        { "Medium Style 3 - Accent 2", TableStyle.MediumStyle3Accent2 },
+        { "Medium Style 3 - Accent 3", TableStyle.MediumStyle3Accent3 },
+        { "Medium Style 3 - Accent 4", TableStyle.MediumStyle3Accent4 },
+        { "Medium Style 3 - Accent 5", TableStyle.MediumStyle3Accent5 },
+        { "Medium Style 3 - Accent 6", TableStyle.MediumStyle3Accent6 },
+        { "Medium Style 4", TableStyle.MediumStyle4 },
+        { "Medium Style 4 - Accent 1", TableStyle.MediumStyle4Accent1 },
+        { "Medium Style 4 - Accent 2", TableStyle.MediumStyle4Accent2 },
+        { "Medium Style 4 - Accent 3", TableStyle.MediumStyle4Accent3 },
+        { "Medium Style 4 - Accent 4", TableStyle.MediumStyle4Accent4 },
+        { "Medium Style 4 - Accent 5", TableStyle.MediumStyle4Accent5 },
+        { "Medium Style 4 - Accent 6", TableStyle.MediumStyle4Accent6 },
+        { "Dark Style 1", TableStyle.DarkStyle1 },
+        { "Dark Style 1 - Accent 1", TableStyle.DarkStyle1Accent1 },
+        { "Dark Style 1 - Accent 2", TableStyle.DarkStyle1Accent2 },
+        { "Dark Style 1 - Accent 3", TableStyle.DarkStyle1Accent3 },
+        { "Dark Style 1 - Accent 5", TableStyle.DarkStyle1Accent5 },
+        { "Dark Style 1 - Accent 4", TableStyle.DarkStyle1Accent4 },
+        { "Dark Style 1 - Accent 6", TableStyle.DarkStyle1Accent6 },
+        { "Dark Style 2", TableStyle.DarkStyle2 },
+        { "Dark Style 2 - Accent 1, Accent 2", TableStyle.DarkStyle2Accent1Accent2 },
+        { "Dark Style 2 - Accent 3, Accent 4", TableStyle.DarkStyle2Accent3Accent4 }, 
+        { "Dark Style 2 - Accent 5, Accent 6", TableStyle.DarkStyle2Accent5Accent6 }
     };
 
-
-
-    /// <summary>
-    ///     Gets the style using enum.
-    /// </summary>
-    public static ITableStyle GetTableStyleByEnum(TableStyleEnum enum_value)
-    {
-        return CommonTableStyles.Styles[enum_value];
-    }
 
     /// <summary>
     ///     Get the style using its name.
     /// </summary>
     public static ITableStyle? GetTableStyleByName(string name)
     {
-        // Search through the dictionary for the matching name
-        foreach (var value in CommonTableStyles.Styles)
+        if (CommonTableStyles.Styles.TryGetValue(name, out ITableStyle? style))
         {
-            if (value.Value.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
-            {
-                return value.Value;
-            }
+            return style;
         }
 
         // If no matching table style is found, return null

--- a/src/ShapeCrawler/Tables/CommonTableStyles.cs
+++ b/src/ShapeCrawler/Tables/CommonTableStyles.cs
@@ -1,0 +1,328 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ShapeCrawler.Tables;
+
+// TODO : verify the values 
+
+/// <summary>
+///     Represents the common table style.
+/// </summary>
+public enum TableStyleEnum
+{
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+// enum is self documented
+#pragma warning disable SA1602 // Enumeration items should be documented
+    NoStyleNoGrid,
+    NoStyleTableGrid,
+
+    ThemedStyle1Accent1,
+    ThemedStyle1Accent2,
+    ThemedStyle1Accent3,
+    ThemedStyle1Accent4,
+    ThemedStyle1Accent5,
+    ThemedStyle1Accent6,
+
+    ThemedStyle2Accent1,
+    ThemedStyle2Accent2,
+    ThemedStyle2Accent3,
+    ThemedStyle2Accent4,
+    ThemedStyle2Accent5,
+    ThemedStyle2Accent6,
+
+    LightStyle1,
+    LightStyle1Accent1,
+    LightStyle1Accent2,
+    LightStyle1Accent3,
+    LightStyle1Accent4,
+    LightStyle1Accent5,
+    LightStyle1Accent6,
+
+    LightStyle2,
+    LightStyle2Accent1,
+    LightStyle2Accent2,
+    LightStyle2Accent3,
+    LightStyle2Accent4,
+    LightStyle2Accent5,
+    LightStyle2Accent6,
+
+    LightStyle3,
+    LightStyle3Accent1,
+    LightStyle3Accent2,
+    LightStyle3Accent3,
+    LightStyle3Accent4,
+    LightStyle3Accent5,
+    LightStyle3Accent6,
+
+    MediumStyle1,
+    MediumStyle1Accent1,
+    MediumStyle1Accent2,
+    MediumStyle1Accent3,
+    MediumStyle1Accent4,
+    MediumStyle1Accent5,
+    MediumStyle1Accent6,
+
+    MediumStyle2,
+    MediumStyle2Accent1,
+    MediumStyle2Accent2,
+    MediumStyle2Accent3,
+    MediumStyle2Accent4,
+    MediumStyle2Accent5,
+    MediumStyle2Accent6,
+
+    MediumStyle3,
+    MediumStyle3Accent1,
+    MediumStyle3Accent2,
+    MediumStyle3Accent3,
+    MediumStyle3Accent4,
+    MediumStyle3Accent5,
+    MediumStyle3Accent6,
+
+    MediumStyle4,
+    MediumStyle4Accent1,
+    MediumStyle4Accent2,
+    MediumStyle4Accent3,
+    MediumStyle4Accent4,
+    MediumStyle4Accent5,
+    MediumStyle4Accent6,
+
+    DarkStyle1,
+    DarkStyle1Accent1,
+    DarkStyle1Accent2,
+    DarkStyle1Accent3,
+    DarkStyle1Accent4,
+    DarkStyle1Accent5,
+    DarkStyle1Accent6,
+
+    DarkStyle2,
+    DarkStyle2Accent1Accent2,
+    DarkStyle2Accent3Accent4,
+    DarkStyle2Accent5Accent6
+#pragma warning restore SA1602 // Enumeration items should be documented
+
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
+}
+
+internal static class CommonTableStyles
+{
+    public static readonly Dictionary<TableStyleEnum, TableStyle> Styles = new Dictionary<TableStyleEnum, TableStyle>
+    {
+        { TableStyleEnum.NoStyleNoGrid, new TableStyle("No Style, No Grid", "{2D5ABB26-0587-4C30-8999-92F81FD0307C}") },
+        { TableStyleEnum.NoStyleTableGrid, new TableStyle("No Style, Table Grid", "{5940675A-B579-460E-94D1-54222C63F5DA}") },
+        { TableStyleEnum.ThemedStyle1Accent1, new TableStyle("Themed Style 1 - Accent 1", "{3C2FFA5D-87B4-456A-9821-1D502468CF0F}") },
+        { TableStyleEnum.ThemedStyle1Accent2, new TableStyle("Themed Style 1 - Accent 2", "{284E427A-3D55-4303-BF80-6455036E1DE7}") },
+        { TableStyleEnum.ThemedStyle1Accent3, new TableStyle("Themed Style 1 - Accent 3", "{69C7853C-536D-4A76-A0AE-DD22124D55A5}") },
+        { TableStyleEnum.ThemedStyle1Accent4, new TableStyle("Themed Style 1 - Accent 4", "{775DCB02-9BB8-47FD-8907-85C794F793BA}") },
+        { TableStyleEnum.ThemedStyle1Accent5, new TableStyle("Themed Style 1 - Accent 5", "{35758FB7-9AC5-4552-8A53-C91805E547FA}") },
+        { TableStyleEnum.ThemedStyle1Accent6, new TableStyle("Themed Style 1 - Accent 6", "{08FB837D-C827-4EFA-A057-4D05807E0F7C}") },
+        { TableStyleEnum.ThemedStyle2Accent1, new TableStyle("Themed Style 2 - Accent 1", "{D113A9D2-9D6B-4929-AA2D-F23B5EE8CBE7}") },
+        { TableStyleEnum.ThemedStyle2Accent2, new TableStyle("Themed Style 2 - Accent 2", "{18603FDC-E32A-4AB5-989C-0864C3EAD2B8}") },
+        { TableStyleEnum.ThemedStyle2Accent3, new TableStyle("Themed Style 2 - Accent 3", "{306799F8-075E-4A3A-A7F6-7FBC6576F1A4}") },
+        { TableStyleEnum.ThemedStyle2Accent4, new TableStyle("Themed Style 2 - Accent 4", "{E269D01E-BC32-4049-B463-5C60D7B0CCD2}") },
+        { TableStyleEnum.ThemedStyle2Accent5, new TableStyle("Themed Style 2 - Accent 5", "{327F97BB-C833-4FB7-BDE5-3F7075034690}") },
+        { TableStyleEnum.ThemedStyle2Accent6, new TableStyle("Themed Style 2 - Accent 6", "{638B1855-1B75-4FBE-930C-398BA8C253C6}") },
+        { TableStyleEnum.LightStyle1, new TableStyle("Light Style 1", "{9D7B26C5-4107-4FEC-AEDC-1716B250A1EF}") },
+        { TableStyleEnum.LightStyle1Accent1, new TableStyle("Light Style 1 - Accent 1", "{3B4B98B0-60AC-42C2-AFA5-B58CD77FA1E5}") },
+        { TableStyleEnum.LightStyle1Accent2, new TableStyle("Light Style 1 - Accent 2", "{0E3FDE45-AF77-4B5C-9715-49D594BDF05E}") },
+        { TableStyleEnum.LightStyle1Accent3, new TableStyle("Light Style 1 - Accent 3", "{C083E6E3-FA7D-4D7B-A595-EF9225AFEA82}") },
+        { TableStyleEnum.LightStyle1Accent4, new TableStyle("Light Style 1 - Accent 4", "{D27102A9-8310-4765-A935-A1911B00CA55}") },
+        { TableStyleEnum.LightStyle1Accent5, new TableStyle("Light Style 1 - Accent 5", "{5FD0F851-EC5A-4D38-B0AD-8093EC10F338}") },
+        { TableStyleEnum.LightStyle1Accent6, new TableStyle("Light Style 1 - Accent 6", "{68D230F3-CF80-4859-8CE7-A43EE81993B5}") },
+        { TableStyleEnum.LightStyle2, new TableStyle("Light Style 2", "{7E9639D4-E3E2-4D34-9284-5A2195B3D0D7}") },
+        { TableStyleEnum.LightStyle2Accent1, new TableStyle("Light Style 2 - Accent 1", "{69012ECD-51FC-41F1-AA8D-1B2483CD663E}") },
+        { TableStyleEnum.LightStyle2Accent2, new TableStyle("Light Style 2 - Accent 2", "{72833802-FEF1-4C79-8D5D-14CF1EAF98D9}") },
+        { TableStyleEnum.LightStyle2Accent3, new TableStyle("Light Style 2 - Accent 3", "{F2DE63D5-997A-4646-A377-4702673A728D}") },
+        { TableStyleEnum.LightStyle2Accent4, new TableStyle("Light Style 2 - Accent 4", "{17292A2E-F333-43FB-9621-5CBBE7FDCDCB}") },
+        { TableStyleEnum.LightStyle2Accent5, new TableStyle("Light Style 2 - Accent 5", "{5A111915-BE36-4E01-A7E5-04B1672EAD32}") },
+        { TableStyleEnum.LightStyle2Accent6, new TableStyle("Light Style 2 - Accent 6", "{912C8C85-51F0-491E-9774-3900AFEF0FD7}") },
+        { TableStyleEnum.LightStyle3, new TableStyle("Light Style 3", "{616DA210-FB5B-4158-B5E0-FEB733F419BA}") },
+        { TableStyleEnum.LightStyle3Accent1, new TableStyle("Light Style 3 - Accent 1", "{BC89EF96-8CEA-46FF-86C4-4CE0E7609802}") },
+        { TableStyleEnum.LightStyle3Accent2, new TableStyle("Light Style 3 - Accent 2", "{5DA37D80-6434-44D0-A028-1B22A696006F}") },
+        { TableStyleEnum.LightStyle3Accent3, new TableStyle("Light Style 3 - Accent 3", "{8799B23B-EC83-4686-B30A-512413B5E67A}") },
+        { TableStyleEnum.LightStyle3Accent4, new TableStyle("Light Style 3 - Accent 4", "{ED083AE6-46FA-4A59-8FB0-9F97EB10719F}") },
+        { TableStyleEnum.LightStyle3Accent5, new TableStyle("Light Style 3 - Accent 5", "{BDBED569-4797-4DF1-A0F4-6AAB3CD982D8}") },
+        { TableStyleEnum.LightStyle3Accent6, new TableStyle("Light Style 3 - Accent 6", "{E8B1032C-EA38-4F05-BA0D-38AFFFC7BED3}") },
+        { TableStyleEnum.MediumStyle1, new TableStyle("Medium Style 1", "{793D81CF-94F2-401A-BA57-92F5A7B2D0C5}") },
+        { TableStyleEnum.MediumStyle1Accent1, new TableStyle("Medium Style 1 - Accent 1", "{B301B821-A1FF-4177-AEE7-76D212191A09}") },
+        { TableStyleEnum.MediumStyle1Accent2, new TableStyle("Medium Style 1 - Accent 2", "{9DCAF9ED-07DC-4A11-8D7F-57B35C25682E}") },
+        { TableStyleEnum.MediumStyle1Accent3, new TableStyle("Medium Style 1 - Accent 3", "{1FECB4D8-DB02-4DC6-A0A2-4F2EBAE1DC90}") },
+        { TableStyleEnum.MediumStyle1Accent4, new TableStyle("Medium Style 1 - Accent 4", "{1E171933-4619-4E11-9A3F-F7608DF75F80}") },
+        { TableStyleEnum.MediumStyle1Accent5, new TableStyle("Medium Style 1 - Accent 5", "{FABFCF23-3B69-468F-B69F-88F6DE6A72F2}") },
+        { TableStyleEnum.MediumStyle1Accent6, new TableStyle("Medium Style 1 - Accent 6", "{10A1B5D5-9B99-4C35-A422-299274C87663}") },
+        { TableStyleEnum.MediumStyle2, new TableStyle("Medium Style 2", "{073A0DAA-6AF3-43AB-8588-CEC1D06C72B9}") },
+        { TableStyleEnum.MediumStyle2Accent1, new TableStyle("Medium Style 2 - Accent 1", "{5C22544A-7EE6-4342-B048-85BDC9FD1C3A}") },
+        { TableStyleEnum.MediumStyle2Accent2, new TableStyle("Medium Style 2 - Accent 2", "{21E4AEA4-8DFA-4A89-87EB-49C32662AFE0}") },
+        { TableStyleEnum.MediumStyle2Accent3, new TableStyle("Medium Style 2 - Accent 3", "{F5AB1C69-6EDB-4FF4-983F-18BD219EF322}") },
+        { TableStyleEnum.MediumStyle2Accent4, new TableStyle("Medium Style 2 - Accent 4", "{00A15C55-8517-42AA-B614-E9B94910E393}") },
+        { TableStyleEnum.MediumStyle2Accent5, new TableStyle("Medium Style 2 - Accent 5", "{7DF18680-E054-41AD-8BC1-D1AEF772440D}") },
+        { TableStyleEnum.MediumStyle2Accent6, new TableStyle("Medium Style 2 - Accent 6", "{93296810-A885-4BE3-A3E7-6D5BEEA58F35}") },
+        { TableStyleEnum.MediumStyle3, new TableStyle("Medium Style 3", "{8EC20E35-A176-4012-BC5E-935CFFF8708E}") },
+        { TableStyleEnum.MediumStyle3Accent1, new TableStyle("Medium Style 3 - Accent 1", "{6E25E649-3F16-4E02-A733-19D2CDBF48F0}") },
+        { TableStyleEnum.MediumStyle3Accent2, new TableStyle("Medium Style 3 - Accent 2", "{85BE263C-DBD7-4A20-BB59-AAB30ACAA65A}") },
+        { TableStyleEnum.MediumStyle3Accent3, new TableStyle("Medium Style 3 - Accent 3", "{EB344D84-9AFB-497E-A393-DC336BA19D2E}") },
+        { TableStyleEnum.MediumStyle3Accent4, new TableStyle("Medium Style 3 - Accent 4", "{EB9631B5-78F2-41C9-869B-9F39066F8104}") },
+        { TableStyleEnum.MediumStyle3Accent5, new TableStyle("Medium Style 3 - Accent 5", "{74C1A8A3-306A-4EB7-A6B1-4F7E0EB9C5D6}") },
+        { TableStyleEnum.MediumStyle3Accent6, new TableStyle("Medium Style 3 - Accent 6", "{2A488322-F2BA-4B5B-9748-0D474271808F}") },
+        { TableStyleEnum.MediumStyle4, new TableStyle("Medium Style 4", "{D7AC3CCA-C797-4891-BE02-D94E43425B78}") },
+        { TableStyleEnum.MediumStyle4Accent1, new TableStyle("Medium Style 4 - Accent 1", "{69CF1AB2-1976-4502-BF36-3FF5EA218861}") },
+        { TableStyleEnum.MediumStyle4Accent2, new TableStyle("Medium Style 4 - Accent 2", "{8A107856-5554-42FB-B03E-39F5DBC370BA}") },
+        { TableStyleEnum.MediumStyle4Accent3, new TableStyle("Medium Style 4 - Accent 3", "{0505E3EF-67EA-436B-97B2-0124C06EBD24}") },
+        { TableStyleEnum.MediumStyle4Accent4, new TableStyle("Medium Style 4 - Accent 4", "{C4B1156A-380E-4F78-BDF5-A606A8083BF9}") },
+        { TableStyleEnum.MediumStyle4Accent5, new TableStyle("Medium Style 4 - Accent 5", "{22838BEF-8BB2-4498-84A7-C5851F593DF1}") },
+        { TableStyleEnum.MediumStyle4Accent6, new TableStyle("Medium Style 4 - Accent 6", "{16D9F66E-5EB9-4882-86FB-DCBF35E3C3E4}") },
+        { TableStyleEnum.DarkStyle1, new TableStyle("Dark Style 1", "{E8034E78-7F5D-4C2E-B375-FC64B27BC917}") },
+        { TableStyleEnum.DarkStyle1Accent1, new TableStyle("Dark Style 1 - Accent 1", "{125E5076-3810-47DD-B79F-674D7AD40C01}") },
+        { TableStyleEnum.DarkStyle1Accent2, new TableStyle("Dark Style 1 - Accent 2", "{37CE84F3-28C3-443E-9E96-99CF82512B78}") },
+        { TableStyleEnum.DarkStyle1Accent3, new TableStyle("Dark Style 1 - Accent 3", "{D03447BB-5D67-496B-8E87-E561075AD55C}") },
+        { TableStyleEnum.DarkStyle1Accent4, new TableStyle("Dark Style 1 - Accent 4", "{E929F9F4-4A8F-4326-A1B4-22849713DDAB}") },
+        { TableStyleEnum.DarkStyle1Accent5, new TableStyle("Dark Style 1 - Accent 5", "{8FD4443E-F989-4FC4-A0C8-D5A2AF1F390B}") },
+        { TableStyleEnum.DarkStyle1Accent6, new TableStyle("Dark Style 1 - Accent 6", "{AF606853-7671-496A-8E4F-DF71F8EC918B}") },
+        { TableStyleEnum.DarkStyle2, new TableStyle("Dark Style 2", "{5202B0CA-FC54-4496-8BCA-5EF66A818D29}") },
+        { TableStyleEnum.DarkStyle2Accent1Accent2, new TableStyle("Dark Style 2 - Accent 1, Accent 2", "{0660B408-B3CF-4A94-85FC-2B1E0A45F4A2}") },
+        { TableStyleEnum.DarkStyle2Accent3Accent4, new TableStyle("Dark Style 2 - Accent 3, Accent 4", "{91EBBBCC-DAD2-459C-BE2E-F6DE35CF9A28}") },
+        { TableStyleEnum.DarkStyle2Accent5Accent6, new TableStyle("Dark Style 2 - Accent 5, Accent 6", "{46F890A9-2807-4EBB-B81D-B2AA78EC7F39}") }
+    };
+
+
+
+    /// <summary>
+    ///     Gets the style using enum.
+    /// </summary>
+    public static ITableStyle GetTableStyleByEnum(TableStyleEnum enum_value)
+    {
+        return CommonTableStyles.Styles[enum_value];
+    }
+
+    /// <summary>
+    ///     Get the style using its name.
+    /// </summary>
+    public static ITableStyle? GetTableStyleByName(string name)
+    {
+        // Search through the dictionary for the matching name
+        foreach (var value in CommonTableStyles.Styles)
+        {
+            if (value.Value.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
+            {
+                return value.Value;
+            }
+        }
+
+        // If no matching table style is found, return null
+        return null;
+    }
+
+    /// <summary>
+    ///     Get the style using its GUID.
+    /// </summary>
+    public static ITableStyle? GetTableStyleByGUID(string guid)
+    {
+        // Search through the dictionary for the matching GUID
+        foreach (var value in CommonTableStyles.Styles)
+        {
+            if (value.Value.GUID.Equals(guid, StringComparison.OrdinalIgnoreCase))
+            {
+                return value.Value;
+            }
+        }
+
+        // If no matching table style is found, return null
+        return null;
+    }
+
+    /// <summary>
+    ///     Get the style either by name or GUID.
+    /// </summary>
+    public static ITableStyle? SearchTableStyle(string search)
+    {
+        var res = GetTableStyleByName(search);
+
+        if (res == null)
+        {
+            res = GetTableStyleByGUID(search);
+        }
+
+        return res;
+    }
+}
+
+
+/*
+
+//list found here : https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2010/hh273476(v=office.14)?redirectedfrom=MSDN
+
+' No Style, No Grid: {2D5ABB26-0587-4C30-8999-92F81FD0307C}
+' Themed Style 1 - Accent 1: {3C2FFA5D-87B4-456A-9821-1D502468CF0F}
+' Themed Style 1 - Accent 2: {284E427A-3D55-4303-BF80-6455036E1DE7}
+' Themed Style 1 - Accent 3: {69C7853C-536D-4A76-A0AE-DD22124D55A5}
+' Themed Style 1 - Accent 4: {775DCB02-9BB8-47FD-8907-85C794F793BA}
+' Themed Style 1 - Accent 5: {35758FB7-9AC5-4552-8A53-C91805E547FA}
+' Themed Style 1 - Accent 6: {08FB837D-C827-4EFA-A057-4D05807E0F7C}
+' No Style, Table Grid: {5940675A-B579-460E-94D1-54222C63F5DA}
+' Themed Style 2 - Accent 1: {D113A9D2-9D6B-4929-AA2D-F23B5EE8CBE7}
+' Themed Style 2 - Accent 2: {18603FDC-E32A-4AB5-989C-0864C3EAD2B8}
+' Themed Style 2 - Accent 3: {306799F8-075E-4A3A-A7F6-7FBC6576F1A4}
+' Themed Style 2 - Accent 4: {E269D01E-BC32-4049-B463-5C60D7B0CCD2}
+' Themed Style 2 - Accent 5: {327F97BB-C833-4FB7-BDE5-3F7075034690}
+' Themed Style 2 - Accent 6: {638B1855-1B75-4FBE-930C-398BA8C253C6}
+' Light Style 1: {9D7B26C5-4107-4FEC-AEDC-1716B250A1EF}
+' Light Style 1 - Accent 1: {3B4B98B0-60AC-42C2-AFA5-B58CD77FA1E5}
+' Light Style 1 - Accent 2: {0E3FDE45-AF77-4B5C-9715-49D594BDF05E}
+' Light Style 1 - Accent 3: {C083E6E3-FA7D-4D7B-A595-EF9225AFEA82}
+' Light Style 1 - Accent 4: {D27102A9-8310-4765-A935-A1911B00CA55}
+' Light Style 1 - Accent 5: {5FD0F851-EC5A-4D38-B0AD-8093EC10F338}
+' Light Style 1 - Accent 6: {68D230F3-CF80-4859-8CE7-A43EE81993B5}
+' Light Style 2: {7E9639D4-E3E2-4D34-9284-5A2195B3D0D7}
+' Light Style 2 - Accent 1: {69012ECD-51FC-41F1-AA8D-1B2483CD663E}
+' Light Style 2 - Accent 2: {72833802-FEF1-4C79-8D5D-14CF1EAF98D9}
+' Light Style 2 - Accent 3: {F2DE63D5-997A-4646-A377-4702673A728D}
+' Light Style 2 - Accent 4: {17292A2E-F333-43FB-9621-5CBBE7FDCDCB}
+' Light Style 2 - Accent 5: {5A111915-BE36-4E01-A7E5-04B1672EAD32}
+' Light Style 2 - Accent 6: {912C8C85-51F0-491E-9774-3900AFEF0FD7}
+' Light Style 3: {616DA210-FB5B-4158-B5E0-FEB733F419BA}
+' Light Style 3 - Accent 1: {BC89EF96-8CEA-46FF-86C4-4CE0E7609802}
+' Light Style 3 - Accent 2: {5DA37D80-6434-44D0-A028-1B22A696006F}
+' Light Style 3 - Accent 3: {8799B23B-EC83-4686-B30A-512413B5E67A}
+' Light Style 3 - Accent 4: {ED083AE6-46FA-4A59-8FB0-9F97EB10719F}
+' Light Style 3 - Accent 5: {BDBED569-4797-4DF1-A0F4-6AAB3CD982D8}
+' Light Style 3 - Accent 6: {E8B1032C-EA38-4F05-BA0D-38AFFFC7BED3}
+' Medium Style 1: {793D81CF-94F2-401A-BA57-92F5A7B2D0C5}
+' Medium Style 1 - Accent 1: {B301B821-A1FF-4177-AEE7-76D212191A09}
+' Medium Style 1 - Accent 2: {9DCAF9ED-07DC-4A11-8D7F-57B35C25682E}
+' Medium Style 1 - Accent 3: {1FECB4D8-DB02-4DC6-A0A2-4F2EBAE1DC90}
+' Medium Style 1 - Accent 4: {1E171933-4619-4E11-9A3F-F7608DF75F80}
+' Medium Style 1 - Accent 5: {FABFCF23-3B69-468F-B69F-88F6DE6A72F2}
+' Medium Style 1 - Accent 6: {10A1B5D5-9B99-4C35-A422-299274C87663}
+' Medium Style 2: {073A0DAA-6AF3-43AB-8588-CEC1D06C72B9}
+' Medium Style 2 - Accent 1: {5C22544A-7EE6-4342-B048-85BDC9FD1C3A}
+' Medium Style 2 - Accent 2: {21E4AEA4-8DFA-4A89-87EB-49C32662AFE0}
+' Medium Style 2 - Accent 3: {F5AB1C69-6EDB-4FF4-983F-18BD219EF322}
+' Medium Style 2 - Accent 4: {00A15C55-8517-42AA-B614-E9B94910E393}
+' Medium Style 2 - Accent 5: {7DF18680-E054-41AD-8BC1-D1AEF772440D}
+' Medium Style 2 - Accent 6: {93296810-A885-4BE3-A3E7-6D5BEEA58F35}
+' Medium Style 3: {8EC20E35-A176-4012-BC5E-935CFFF8708E}
+' Medium Style 3 - Accent 1: {6E25E649-3F16-4E02-A733-19D2CDBF48F0}
+' Medium Style 3 - Accent 2: {85BE263C-DBD7-4A20-BB59-AAB30ACAA65A}
+' Medium Style 3 - Accent 3: {EB344D84-9AFB-497E-A393-DC336BA19D2E}
+' Medium Style 3 - Accent 4: {EB9631B5-78F2-41C9-869B-9F39066F8104}
+' Medium Style 3 - Accent 5: {74C1A8A3-306A-4EB7-A6B1-4F7E0EB9C5D6}
+' Medium Style 3 - Accent 6: {2A488322-F2BA-4B5B-9748-0D474271808F}
+' Medium Style 4: {D7AC3CCA-C797-4891-BE02-D94E43425B78}
+' Medium Style 4 - Accent 1: {69CF1AB2-1976-4502-BF36-3FF5EA218861}
+' Medium Style 4 - Accent 2: {8A107856-5554-42FB-B03E-39F5DBC370BA}
+' Medium Style 4 - Accent 3: {0505E3EF-67EA-436B-97B2-0124C06EBD24}
+' Medium Style 4 - Accent 4: {C4B1156A-380E-4F78-BDF5-A606A8083BF9}
+' Medium Style 4 - Accent 5: {22838BEF-8BB2-4498-84A7-C5851F593DF1}
+' Medium Style 4 - Accent 6: {16D9F66E-5EB9-4882-86FB-DCBF35E3C3E4}
+' Dark Style 1: {E8034E78-7F5D-4C2E-B375-FC64B27BC917}
+' Dark Style 1 - Accent 1: {125E5076-3810-47DD-B79F-674D7AD40C01}
+' Dark Style 1 - Accent 2: {37CE84F3-28C3-443E-9E96-99CF82512B78}
+' Dark Style 1 - Accent 3: {D03447BB-5D67-496B-8E87-E561075AD55C}
+' Dark Style 1 - Accent 4: {E929F9F4-4A8F-4326-A1B4-22849713DDAB}
+' Dark Style 1 - Accent 5:{8FD4443E-F989-4FC4-A0C8-D5A2AF1F390B}
+' Dark Style 1 - Accent 6: {AF606853-7671-496A-8E4F-DF71F8EC918B}
+' Dark Style 2: {5202B0CA-FC54-4496-8BCA-5EF66A818D29}
+' Dark Style 2 - Accent 1/Accent 2: {0660B408-B3CF-4A94-85FC-2B1E0A45F4A2}
+' Dark Style 2 - Accent 3/Accent 4: {91EBBBCC-DAD2-459C-BE2E-F6DE35CF9A28}
+' Dark Style 2 - Accent 5/Accent 6: {46F890A9-2807-4EBB-B81D-B2AA78EC7F39}
+
+ */

--- a/src/ShapeCrawler/Tables/IBorder.cs
+++ b/src/ShapeCrawler/Tables/IBorder.cs
@@ -1,6 +1,4 @@
-﻿
-
-// ReSharper disable once CheckNamespace
+﻿// ReSharper disable once CheckNamespace
 namespace ShapeCrawler;
 
 /// <summary>

--- a/src/ShapeCrawler/Tables/ITable.cs
+++ b/src/ShapeCrawler/Tables/ITable.cs
@@ -6,6 +6,7 @@ using DocumentFormat.OpenXml.Packaging;
 using ShapeCrawler.Exceptions;
 using ShapeCrawler.Extensions;
 using ShapeCrawler.ShapeCollection;
+using ShapeCrawler.Tables;
 using SkiaSharp;
 using A = DocumentFormat.OpenXml.Drawing;
 using P = DocumentFormat.OpenXml.Presentation;
@@ -29,6 +30,16 @@ public interface ITable : IShape
     ITableRows Rows { get; }
 
     /// <summary>
+    ///     Gets or sets the table style.
+    /// </summary>
+    ITableStyle TableStyle { get; set; }
+
+    /// <summary>
+    ///     Sets the table style using enum.
+    /// </summary>
+    TableStyleEnum TableStyleByEnum { set; }
+
+    /// <summary>
     ///     Gets cell by row and column indexes.
     /// </summary>
     ITableCell this[int rowIndex, int columnIndex] { get; }
@@ -49,9 +60,10 @@ public interface ITable : IShape
     void UpdateFill(string colorHex);
 }
 
-internal sealed class Table : CopyableShape, ITable 
+internal sealed class Table : CopyableShape, ITable
 {
     private readonly P.GraphicFrame pGraphicFrame;
+    private ITableStyle? tableStyle;
 
     internal Table(OpenXmlPart sdkTypedOpenXmlPart, OpenXmlCompositeElement pShapeTreeElement)
         : base(sdkTypedOpenXmlPart, pShapeTreeElement)
@@ -61,11 +73,23 @@ internal sealed class Table : CopyableShape, ITable
     }
 
     public override ShapeType ShapeType => ShapeType.Table;
-    
+
     public IReadOnlyList<IColumn> Columns => this.GetColumnList(); // TODO: make lazy
-    
+
     public ITableRows Rows { get; }
-    
+
+    public ITableStyle TableStyle
+    {
+        get => this.GetTableStyle();
+        set => this.SetTableStyle(value);
+    }
+
+    // est-ce que c'est utile ?
+    public TableStyleEnum TableStyleByEnum
+    {
+        set => this.SetTableStyle(CommonTableStyles.GetTableStyleByEnum(value));
+    }
+
     public override bool Removeable => true;
 
     public override Geometry GeometryType => Geometry.Rectangle;
@@ -117,7 +141,7 @@ internal sealed class Table : CopyableShape, ITable
         {
             this.MergeVertically(maxRowIndex, minRowIndex, aTableRows, minColIndex, maxColIndex);
         }
-        
+
         this.RemoveColumnIfNeeded(aTableRows);
         this.RemoveRowIfNeeded();
     }
@@ -147,10 +171,32 @@ internal sealed class Table : CopyableShape, ITable
         return false;
     }
 
+    private void SetTableStyle(ITableStyle style)
+    {
+        this.ATable.TableProperties!.GetFirstChild<A.TableStyleId>() !.Text = style.GUID;
+        this.tableStyle = style;
+    }
+
+    private ITableStyle GetTableStyle()
+    {
+        if (this.tableStyle is null)
+        {
+            var tableStyleId = this.ATable.TableProperties!.GetFirstChild<A.TableStyleId>() !.Text;
+
+            var style = CommonTableStyles.GetTableStyleByGUID(tableStyleId);
+
+            style ??= new TableStyle("Custom Style", tableStyleId);
+
+            this.tableStyle = style;
+        }
+
+        return this.tableStyle;
+    }
+
     private void RemoveRowIfNeeded()
     {
         int rowIdx = 0;
-    
+
         while (rowIdx < this.Rows.Count)
         {
             var cells = this.Rows[rowIdx].Cells.OfType<TableCell>().ToList();
@@ -174,7 +220,7 @@ internal sealed class Table : CopyableShape, ITable
             }
         }
     }
-    
+
     private void MergeVertically(
         int bottomIndex,
         int topRowIndex,
@@ -225,9 +271,9 @@ internal sealed class Table : CopyableShape, ITable
     }
 
     private void MergeHorizontal(
-        int maxColIndex, 
-        int minColIndex, 
-        int minRowIndex, 
+        int maxColIndex,
+        int minColIndex,
+        int minRowIndex,
         int maxRowIndex,
         List<A.TableRow> aTableRows)
     {
@@ -246,7 +292,7 @@ internal sealed class Table : CopyableShape, ITable
             }
         }
     }
-    
+
     private IReadOnlyList<Column> GetColumnList()
     {
         IEnumerable<A.GridColumn> aGridColumns = this.ATable.TableGrid!.Elements<A.GridColumn>();
@@ -269,7 +315,7 @@ internal sealed class Table : CopyableShape, ITable
             if (topColumnCellSpan > 1 && sameGridSpan)
             {
                 var deleteColumnCount = topColumnCellSpan.Value - 1;
-                
+
                 // Delete a:gridCol elements and append width of deleting column to merged column
                 for (int i = 0; i < deleteColumnCount; i++)
                 {
@@ -277,7 +323,7 @@ internal sealed class Table : CopyableShape, ITable
                     column.AGridColumn.Remove();
                     this.Columns[colIdx].Width += column.Width;
                 }
-                
+
                 // Delete a:tc elements
                 foreach (var aTblRow in aTableRows)
                 {
@@ -287,7 +333,7 @@ internal sealed class Table : CopyableShape, ITable
                         aTblCell.Remove();
                     }
                 }
-                
+
                 colIdx += topColumnCellSpan.Value;
             }
             else

--- a/src/ShapeCrawler/Tables/ITable.cs
+++ b/src/ShapeCrawler/Tables/ITable.cs
@@ -35,11 +35,6 @@ public interface ITable : IShape
     ITableStyle TableStyle { get; set; }
 
     /// <summary>
-    ///     Sets the table style using enum.
-    /// </summary>
-    TableStyleEnum TableStyleByEnum { set; }
-
-    /// <summary>
     ///     Gets cell by row and column indexes.
     /// </summary>
     ITableCell this[int rowIndex, int columnIndex] { get; }
@@ -82,12 +77,6 @@ internal sealed class Table : CopyableShape, ITable
     {
         get => this.GetTableStyle();
         set => this.SetTableStyle(value);
-    }
-
-    // est-ce que c'est utile ?
-    public TableStyleEnum TableStyleByEnum
-    {
-        set => this.SetTableStyle(CommonTableStyles.GetTableStyleByEnum(value));
     }
 
     public override bool Removeable => true;
@@ -183,10 +172,9 @@ internal sealed class Table : CopyableShape, ITable
         {
             var tableStyleId = this.ATable.TableProperties!.GetFirstChild<A.TableStyleId>() !.Text;
 
-            var style = CommonTableStyles.GetTableStyleByGUID(tableStyleId);
+            var style = CommonTableStyles.GetTableStyleByGUID(tableStyleId) !;
 
-            style ??= new TableStyle("Custom Style", tableStyleId);
-
+            // style ??= new TableStyle("Custom Style", tableStyleId);
             this.tableStyle = style;
         }
 

--- a/src/ShapeCrawler/Tables/ITableStyle.cs
+++ b/src/ShapeCrawler/Tables/ITableStyle.cs
@@ -45,33 +45,3 @@ internal class TableStyle : ITableStyle
         return hashCode;
     }
 }
-
-// ici on aura les modifications en rapport au tableau
-
-/* A cote pour ne pas oublier : marge dans les cells */
-
-/*
- Comment utiliser 
-
-AddTable( xxx )
-
-ITable table ;
-
-table.Style = xxx 
- 
- */
-
-
-/*
-Scenario a prendre en compte
-
-
-On a l'enum on veut recuperer sa classe => lib (trivia)
-On a le Nom, on veut recuperer l'enum => User
-On a le GUID, on veut recuperer l'enum => lib
-
-Un dictionnaire avec comme cle [ nom/GUID ] et valeur enum
-
-Une classe static avec la liste des classes + fonction convert  Enum => Class
-
-*/ 

--- a/src/ShapeCrawler/Tables/ITableStyle.cs
+++ b/src/ShapeCrawler/Tables/ITableStyle.cs
@@ -20,15 +20,162 @@ public interface ITableStyle
 
 internal class TableStyle : ITableStyle
 {
-    public TableStyle(string name, string guid)
+    public TableStyle(string name)
     {
         this.Name = name;
-        this.GUID = guid;
     }
-    
+
+    public static ITableStyle NoStyleNoGrid => new TableStyle("No Style, No Grid") { GUID = "{2D5ABB26-0587-4C30-8999-92F81FD0307C}" };
+
+    public static ITableStyle NoStyleTableGrid => new TableStyle("No Style, Table Grid") { GUID = "{5940675A-B579-460E-94D1-54222C63F5DA}" };
+
+    public static ITableStyle ThemedStyle1Accent1 => new TableStyle("Themed Style 1 - Accent 1") { GUID = "{3C2FFA5D-87B4-456A-9821-1D502468CF0F}" };
+
+    public static ITableStyle ThemedStyle1Accent2 => new TableStyle("Themed Style 1 - Accent 2") { GUID = "{284E427A-3D55-4303-BF80-6455036E1DE7}" };
+
+    public static ITableStyle ThemedStyle1Accent3 => new TableStyle("Themed Style 1 - Accent 3") { GUID = "{69C7853C-536D-4A76-A0AE-DD22124D55A5}" };
+
+    public static ITableStyle ThemedStyle1Accent4 => new TableStyle("Themed Style 1 - Accent 4") { GUID = "{775DCB02-9BB8-47FD-8907-85C794F793BA}" };
+
+    public static ITableStyle ThemedStyle1Accent5 => new TableStyle("Themed Style 1 - Accent 5") { GUID = "{35758FB7-9AC5-4552-8A53-C91805E547FA}" };
+
+    public static ITableStyle ThemedStyle1Accent6 => new TableStyle("Themed Style 1 - Accent 6") { GUID = "{08FB837D-C827-4EFA-A057-4D05807E0F7C}" };
+
+    public static ITableStyle ThemedStyle2Accent1 => new TableStyle("Themed Style 2 - Accent 1") { GUID = "{D113A9D2-9D6B-4929-AA2D-F23B5EE8CBE7}" };
+
+    public static ITableStyle ThemedStyle2Accent2 => new TableStyle("Themed Style 2 - Accent 2") { GUID = "{18603FDC-E32A-4AB5-989C-0864C3EAD2B8}" };
+
+    public static ITableStyle ThemedStyle2Accent3 => new TableStyle("Themed Style 2 - Accent 3") { GUID = "{306799F8-075E-4A3A-A7F6-7FBC6576F1A4}" };
+
+    public static ITableStyle ThemedStyle2Accent4 => new TableStyle("Themed Style 2 - Accent 4") { GUID = "{E269D01E-BC32-4049-B463-5C60D7B0CCD2}" };
+
+    public static ITableStyle ThemedStyle2Accent5 => new TableStyle("Themed Style 2 - Accent 5") { GUID = "{327F97BB-C833-4FB7-BDE5-3F7075034690}" };
+
+    public static ITableStyle ThemedStyle2Accent6 => new TableStyle("Themed Style 2 - Accent 6") { GUID = "{638B1855-1B75-4FBE-930C-398BA8C253C6}" };
+
+    public static ITableStyle LightStyle1 => new TableStyle("Light Style 1") { GUID = "{9D7B26C5-4107-4FEC-AEDC-1716B250A1EF}" };
+
+    public static ITableStyle LightStyle1Accent1 => new TableStyle("Light Style 1 - Accent 1") { GUID = "{3B4B98B0-60AC-42C2-AFA5-B58CD77FA1E5}" };
+
+    public static ITableStyle LightStyle1Accent2 => new TableStyle("Light Style 1 - Accent 2") { GUID = "{0E3FDE45-AF77-4B5C-9715-49D594BDF05E}" };
+
+    public static ITableStyle LightStyle1Accent3 => new TableStyle("Light Style 1 - Accent 3") { GUID = "{C083E6E3-FA7D-4D7B-A595-EF9225AFEA82}" };
+
+    public static ITableStyle LightStyle1Accent4 => new TableStyle("Light Style 1 - Accent 4") { GUID = "{D27102A9-8310-4765-A935-A1911B00CA55}" };
+
+    public static ITableStyle LightStyle1Accent5 => new TableStyle("Light Style 1 - Accent 5") { GUID = "{5FD0F851-EC5A-4D38-B0AD-8093EC10F338}" };
+
+    public static ITableStyle LightStyle1Accent6 => new TableStyle("Light Style 1 - Accent 6") { GUID = "{68D230F3-CF80-4859-8CE7-A43EE81993B5}" };
+
+    public static ITableStyle LightStyle2 => new TableStyle("Light Style 2") { GUID = "{7E9639D4-E3E2-4D34-9284-5A2195B3D0D7}" };
+
+    public static ITableStyle LightStyle2Accent1 => new TableStyle("Light Style 2 - Accent 1") { GUID = "{69012ECD-51FC-41F1-AA8D-1B2483CD663E}" };
+
+    public static ITableStyle LightStyle2Accent2 => new TableStyle("Light Style 2 - Accent 2") { GUID = "{72833802-FEF1-4C79-8D5D-14CF1EAF98D9}" };
+
+    public static ITableStyle LightStyle2Accent3 => new TableStyle("Light Style 2 - Accent 3") { GUID = "{F2DE63D5-997A-4646-A377-4702673A728D}" };
+
+    public static ITableStyle LightStyle2Accent4 => new TableStyle("Light Style 2 - Accent 4") { GUID = "{17292A2E-F333-43FB-9621-5CBBE7FDCDCB}" };
+
+    public static ITableStyle LightStyle2Accent5 => new TableStyle("Light Style 2 - Accent 5") { GUID = "{5A111915-BE36-4E01-A7E5-04B1672EAD32}" };
+
+    public static ITableStyle LightStyle2Accent6 => new TableStyle("Light Style 2 - Accent 6") { GUID = "{912C8C85-51F0-491E-9774-3900AFEF0FD7}" };
+
+    public static ITableStyle LightStyle3 => new TableStyle("Light Style 3") { GUID = "{616DA210-FB5B-4158-B5E0-FEB733F419BA}" };
+
+    public static ITableStyle LightStyle3Accent1 => new TableStyle("Light Style 3 - Accent 1") { GUID = "{BC89EF96-8CEA-46FF-86C4-4CE0E7609802}" };
+
+    public static ITableStyle LightStyle3Accent2 => new TableStyle("Light Style 3 - Accent 2") { GUID = "{5DA37D80-6434-44D0-A028-1B22A696006F}" };
+
+    public static ITableStyle LightStyle3Accent3 => new TableStyle("Light Style 3 - Accent 3") { GUID = "{8799B23B-EC83-4686-B30A-512413B5E67A}" };
+
+    public static ITableStyle LightStyle3Accent4 => new TableStyle("Light Style 3 - Accent 4") { GUID = "{ED083AE6-46FA-4A59-8FB0-9F97EB10719F}" };
+
+    public static ITableStyle LightStyle3Accent5 => new TableStyle("Light Style 3 - Accent 5") { GUID = "{BDBED569-4797-4DF1-A0F4-6AAB3CD982D8}" };
+
+    public static ITableStyle LightStyle3Accent6 => new TableStyle("Light Style 3 - Accent 6") { GUID = "{E8B1032C-EA38-4F05-BA0D-38AFFFC7BED3}" };
+
+    public static ITableStyle MediumStyle1 => new TableStyle("Medium Style 1") { GUID = "{793D81CF-94F2-401A-BA57-92F5A7B2D0C5}" };
+
+    public static ITableStyle MediumStyle1Accent1 => new TableStyle("Medium Style 1 - Accent 1") { GUID = "{B301B821-A1FF-4177-AEE7-76D212191A09}" };
+
+    public static ITableStyle MediumStyle1Accent2 => new TableStyle("Medium Style 1 - Accent 2") { GUID = "{9DCAF9ED-07DC-4A11-8D7F-57B35C25682E}" };
+
+    public static ITableStyle MediumStyle1Accent3 => new TableStyle("Medium Style 1 - Accent 3") { GUID = "{1FECB4D8-DB02-4DC6-A0A2-4F2EBAE1DC90}" };
+
+    public static ITableStyle MediumStyle1Accent4 => new TableStyle("Medium Style 1 - Accent 4") { GUID = "{1E171933-4619-4E11-9A3F-F7608DF75F80}" };
+
+    public static ITableStyle MediumStyle1Accent5 => new TableStyle("Medium Style 1 - Accent 5") { GUID = "{FABFCF23-3B69-468F-B69F-88F6DE6A72F2}" };
+
+    public static ITableStyle MediumStyle1Accent6 => new TableStyle("Medium Style 1 - Accent 6") { GUID = "{10A1B5D5-9B99-4C35-A422-299274C87663}" };
+
+    public static ITableStyle MediumStyle2 => new TableStyle("Medium Style 2") { GUID = "{073A0DAA-6AF3-43AB-8588-CEC1D06C72B9}" };
+
+    public static ITableStyle MediumStyle2Accent1 => new TableStyle("Medium Style 2 - Accent 1") { GUID = "{5C22544A-7EE6-4342-B048-85BDC9FD1C3A}" };
+
+    public static ITableStyle MediumStyle2Accent2 => new TableStyle("Medium Style 2 - Accent 2") { GUID = "{21E4AEA4-8DFA-4A89-87EB-49C32662AFE0}" };
+
+    public static ITableStyle MediumStyle2Accent3 => new TableStyle("Medium Style 2 - Accent 3") { GUID = "{F5AB1C69-6EDB-4FF4-983F-18BD219EF322}" };
+
+    public static ITableStyle MediumStyle2Accent4 => new TableStyle("Medium Style 2 - Accent 4") { GUID = "{00A15C55-8517-42AA-B614-E9B94910E393}" };
+
+    public static ITableStyle MediumStyle2Accent5 => new TableStyle("Medium Style 2 - Accent 5") { GUID = "{7DF18680-E054-41AD-8BC1-D1AEF772440D}" };
+
+    public static ITableStyle MediumStyle2Accent6 => new TableStyle("Medium Style 2 - Accent 6") { GUID = "{93296810-A885-4BE3-A3E7-6D5BEEA58F35}" };
+
+    public static ITableStyle MediumStyle3 => new TableStyle("Medium Style 3") { GUID = "{8EC20E35-A176-4012-BC5E-935CFFF8708E}" };
+
+    public static ITableStyle MediumStyle3Accent1 => new TableStyle("Medium Style 3 - Accent 1") { GUID = "{6E25E649-3F16-4E02-A733-19D2CDBF48F0}" };
+
+    public static ITableStyle MediumStyle3Accent2 => new TableStyle("Medium Style 3 - Accent 2") { GUID = "{85BE263C-DBD7-4A20-BB59-AAB30ACAA65A}" };
+
+    public static ITableStyle MediumStyle3Accent3 => new TableStyle("Medium Style 3 - Accent 3") { GUID = "{EB344D84-9AFB-497E-A393-DC336BA19D2E}" };
+
+    public static ITableStyle MediumStyle3Accent4 => new TableStyle("Medium Style 3 - Accent 4") { GUID = "{EB9631B5-78F2-41C9-869B-9F39066F8104}" };
+
+    public static ITableStyle MediumStyle3Accent5 => new TableStyle("Medium Style 3 - Accent 5") { GUID = "{74C1A8A3-306A-4EB7-A6B1-4F7E0EB9C5D6}" };
+
+    public static ITableStyle MediumStyle3Accent6 => new TableStyle("Medium Style 3 - Accent 6") { GUID = "{2A488322-F2BA-4B5B-9748-0D474271808F}" };
+
+    public static ITableStyle MediumStyle4 => new TableStyle("Medium Style 4") { GUID = "{D7AC3CCA-C797-4891-BE02-D94E43425B78}" };
+
+    public static ITableStyle MediumStyle4Accent1 => new TableStyle("Medium Style 4 - Accent 1") { GUID = "{69CF1AB2-1976-4502-BF36-3FF5EA218861}" };
+
+    public static ITableStyle MediumStyle4Accent2 => new TableStyle("Medium Style 4 - Accent 2") { GUID = "{8A107856-5554-42FB-B03E-39F5DBC370BA}" };
+
+    public static ITableStyle MediumStyle4Accent3 => new TableStyle("Medium Style 4 - Accent 3") { GUID = "{0505E3EF-67EA-436B-97B2-0124C06EBD24}" };
+
+    public static ITableStyle MediumStyle4Accent4 => new TableStyle("Medium Style 4 - Accent 4") { GUID = "{C4B1156A-380E-4F78-BDF5-A606A8083BF9}" };
+
+    public static ITableStyle MediumStyle4Accent5 => new TableStyle("Medium Style 4 - Accent 5") { GUID = "{22838BEF-8BB2-4498-84A7-C5851F593DF1}" };
+
+    public static ITableStyle MediumStyle4Accent6 => new TableStyle("Medium Style 4 - Accent 6") { GUID = "{16D9F66E-5EB9-4882-86FB-DCBF35E3C3E4}" };
+
+    public static ITableStyle DarkStyle1 => new TableStyle("Dark Style 1") { GUID = "{E8034E78-7F5D-4C2E-B375-FC64B27BC917}" };
+
+    public static ITableStyle DarkStyle1Accent1 => new TableStyle("Dark Style 1 - Accent 1") { GUID = "{125E5076-3810-47DD-B79F-674D7AD40C01}" };
+
+    public static ITableStyle DarkStyle1Accent2 => new TableStyle("Dark Style 1 - Accent 2") { GUID = "{37CE84F3-28C3-443E-9E96-99CF82512B78}" };
+
+    public static ITableStyle DarkStyle1Accent3 => new TableStyle("Dark Style 1 - Accent 3") { GUID = "{D03447BB-5D67-496B-8E87-E561075AD55C}" };
+
+    public static ITableStyle DarkStyle1Accent4 => new TableStyle("Dark Style 1 - Accent 4") { GUID = "{E929F9F4-4A8F-4326-A1B4-22849713DDAB}" };
+
+    public static ITableStyle DarkStyle1Accent5 => new TableStyle("Dark Style 1 - Accent 5") { GUID = "{8FD4443E-F989-4FC4-A0C8-D5A2AF1F390B}" };
+
+    public static ITableStyle DarkStyle1Accent6 => new TableStyle("Dark Style 1 - Accent 6") { GUID = "{AF606853-7671-496A-8E4F-DF71F8EC918B}" };
+
+    public static ITableStyle DarkStyle2 => new TableStyle("Dark Style 2") { GUID = "{5202B0CA-FC54-4496-8BCA-5EF66A818D29}" };
+
+    public static ITableStyle DarkStyle2Accent1Accent2 => new TableStyle("Dark Style 2 - Accent 1, Accent 2") { GUID = "{0660B408-B3CF-4A94-85FC-2B1E0A45F4A2}" };
+
+    public static ITableStyle DarkStyle2Accent3Accent4 => new TableStyle("Dark Style 2 - Accent 3, Accent 4") { GUID = "{91EBBBCC-DAD2-459C-BE2E-F6DE35CF9A28}" };
+
+    public static ITableStyle DarkStyle2Accent5Accent6 => new TableStyle("Dark Style 2 - Accent 5, Accent 6") { GUID = "{46F890A9-2807-4EBB-B81D-B2AA78EC7F39}" };
+
     public string Name { get; }
 
-    public string GUID { get; }
+    public string GUID { get; private set; } = string.Empty;
 
     public override bool Equals(object? obj)
     {

--- a/src/ShapeCrawler/Tables/ITableStyle.cs
+++ b/src/ShapeCrawler/Tables/ITableStyle.cs
@@ -1,0 +1,77 @@
+﻿using System.Collections.Generic;
+
+namespace ShapeCrawler.Tables;
+
+/// <summary>
+///     Represents the tablestyle of a table.
+/// </summary>
+public interface ITableStyle
+{
+    /// <summary>
+    ///     Gets the name of the style.
+    /// </summary> 
+    public string Name { get; }
+
+    /// <summary>
+    ///     Gets the GUID of the style.
+    /// </summary>
+    public string GUID { get; }
+}
+
+internal class TableStyle : ITableStyle
+{
+    public TableStyle(string name, string guid)
+    {
+        this.Name = name;
+        this.GUID = guid;
+    }
+    
+    public string Name { get; }
+
+    public string GUID { get; }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is ITableStyle style &&
+               this.Name == style.Name &&
+               this.GUID == style.GUID;
+    }
+
+    public override int GetHashCode()
+    {
+        int hashCode = 1242478914;
+        hashCode = (hashCode * -1521134295) + EqualityComparer<string>.Default.GetHashCode(this.Name);
+        hashCode = (hashCode * -1521134295) + EqualityComparer<string>.Default.GetHashCode(this.GUID);
+        return hashCode;
+    }
+}
+
+// ici on aura les modifications en rapport au tableau
+
+/* A cote pour ne pas oublier : marge dans les cells */
+
+/*
+ Comment utiliser 
+
+AddTable( xxx )
+
+ITable table ;
+
+table.Style = xxx 
+ 
+ */
+
+
+/*
+Scenario a prendre en compte
+
+
+On a l'enum on veut recuperer sa classe => lib (trivia)
+On a le Nom, on veut recuperer l'enum => User
+On a le GUID, on veut recuperer l'enum => lib
+
+Un dictionnaire avec comme cle [ nom/GUID ] et valeur enum
+
+Une classe static avec la liste des classes + fonction convert  Enum => Class
+
+*/ 

--- a/src/ShapeCrawler/Texts/ARunInstance.cs
+++ b/src/ShapeCrawler/Texts/ARunInstance.cs
@@ -9,7 +9,7 @@ internal sealed class ARunBuilder
     internal ARunBuilder()
     {
         this.aRun = new A.Run();
-        var aRunProperties =  new A.RunProperties { Language = "en-US", FontSize = 1400, Dirty = false };
+        var aRunProperties = new A.RunProperties { Language = "en-US", FontSize = 1400, Dirty = false };
         var aText = new A.Text
         {
             Text = string.Empty

--- a/src/ShapeCrawler/Texts/IParagraphPortion.cs
+++ b/src/ShapeCrawler/Texts/IParagraphPortion.cs
@@ -27,7 +27,7 @@ public interface IParagraphPortion
     Color TextHighlightColor { get; set; }
 
     /// <summary>
-    /// 	Removes portion from paragraph.
+    ///     Removes portion from paragraph.
     /// </summary>
     void Remove();
 }

--- a/src/ShapeCrawler/Texts/IParagraphPortions.cs
+++ b/src/ShapeCrawler/Texts/IParagraphPortions.cs
@@ -32,7 +32,7 @@ public interface IParagraphPortions : IEnumerable<IParagraphPortion>
     void AddText(string text);
 
     /// <summary>
-    /// 	Adds Line Break.
+    ///     Adds Line Break.
     /// </summary>
     void AddLineBreak();
 

--- a/src/ShapeCrawler/Texts/ITextBox.cs
+++ b/src/ShapeCrawler/Texts/ITextBox.cs
@@ -16,14 +16,14 @@ public interface ITextBox
     /// </summary>
     string Text { get; set; }
 
-	/// <summary>
-	///     Gets or sets the text vertical alignment.
-	/// </summary>
+    /// <summary>
+    ///     Gets or sets the text vertical alignment.
+    /// </summary>
     TextVerticalAlignment VerticalAlignment { get; set; }
- 
-	/// <summary>
-	///     Gets or sets the Autofit type.
-	/// </summary>
+
+    /// <summary>
+    ///     Gets or sets the Autofit type.
+    /// </summary>
     AutofitType AutofitType { get; set; }
 
     /// <summary>
@@ -50,7 +50,7 @@ public interface ITextBox
     ///     Gets a value indicating whether the text is wrapped in the shape.
     /// </summary>
     bool TextWrapped { get; }
-    
+
     /// <summary>
     ///     Gets XPath.
     /// </summary>

--- a/src/ShapeCrawler/Texts/NullTextFrame.cs
+++ b/src/ShapeCrawler/Texts/NullTextFrame.cs
@@ -4,53 +4,53 @@ namespace ShapeCrawler.Texts;
 
 internal readonly struct NullTextFrame : ITextBox
 {
-    private const string error = $"The shape is not a text holder. Use {nameof(IShape.IsTextHolder)} method to check it.";
+    private const string Error = $"The shape is not a text holder. Use {nameof(IShape.IsTextHolder)} method to check it.";
     
-    public IParagraphs Paragraphs => throw new Exception(error);
+    public IParagraphs Paragraphs => throw new Exception(Error);
 
     public string Text
     {
-        get => throw new Exception(error); 
-        set => throw new Exception(error);
+        get => throw new Exception(Error); 
+        set => throw new Exception(Error);
     }
 
     public AutofitType AutofitType
     {
-        get => throw new Exception(error); 
-        set => throw new Exception(error);
+        get => throw new Exception(Error); 
+        set => throw new Exception(Error);
     }
     
     public decimal LeftMargin 
     { 
-        get => throw new Exception(error); 
-        set => throw new Exception(error);
+        get => throw new Exception(Error); 
+        set => throw new Exception(Error);
     }
 
     public decimal RightMargin
     {
-        get => throw new Exception(error); 
-        set => throw new Exception(error);
+        get => throw new Exception(Error); 
+        set => throw new Exception(Error);
     }
 
     public decimal TopMargin
     {
-        get => throw new Exception(error); 
-        set => throw new Exception(error);
+        get => throw new Exception(Error); 
+        set => throw new Exception(Error);
     }
 
     public decimal BottomMargin
     {
-        get => throw new Exception(error); 
-        set => throw new Exception(error);
+        get => throw new Exception(Error); 
+        set => throw new Exception(Error);
     }
 
-    public bool TextWrapped => throw new Exception(error);
+    public bool TextWrapped => throw new Exception(Error);
     
-    public string SDKXPath => throw new Exception(error);
+    public string SDKXPath => throw new Exception(Error);
 
     public TextVerticalAlignment VerticalAlignment 
     {
-        get => throw new Exception(error);
-        set => throw new Exception(error);
+        get => throw new Exception(Error);
+        set => throw new Exception(Error);
     }
 }

--- a/src/ShapeCrawler/Texts/TextFrame.cs
+++ b/src/ShapeCrawler/Texts/TextFrame.cs
@@ -9,7 +9,7 @@ using ShapeCrawler.Shared;
 using ShapeCrawler.Units;
 using SkiaSharp;
 using A = DocumentFormat.OpenXml.Drawing;
-using P = DocumentFormat.OpenXml.Presentation; 
+using P = DocumentFormat.OpenXml.Presentation;
 
 namespace ShapeCrawler.Texts;
 
@@ -18,17 +18,17 @@ internal sealed record TextFrame : ITextBox
     private readonly OpenXmlPart sdkTypedOpenXmlPart;
     private readonly OpenXmlElement sdkTextBody;
 
-	private TextVerticalAlignment? valignment ;
+    private TextVerticalAlignment? valignment;
 
-	internal TextFrame(OpenXmlPart sdkTypedOpenXmlPart, OpenXmlElement sdkTextBody)
+    internal TextFrame(OpenXmlPart sdkTypedOpenXmlPart, OpenXmlElement sdkTextBody)
     {
         this.sdkTypedOpenXmlPart = sdkTypedOpenXmlPart;
         this.sdkTextBody = sdkTextBody;
-	}
+    }
 
     public IParagraphs Paragraphs => new Paragraphs(this.sdkTypedOpenXmlPart, this.sdkTextBody);
 
-	public string Text
+    public string Text
     {
         get
         {
@@ -124,14 +124,14 @@ internal sealed record TextFrame : ITextBox
                     aBodyPr.Append(shrink);
                     break;
                 case AutofitType.Resize:
-                {
-                    dontAutofit?.Remove();
-                    shrink?.Remove();
-                    resize = new A.ShapeAutoFit();
-                    aBodyPr.Append(resize);
-                    this.ResizeParentShape();
-                    break;
-                }
+                    {
+                        dontAutofit?.Remove();
+                        shrink?.Remove();
+                        resize = new A.ShapeAutoFit();
+                        aBodyPr.Append(resize);
+                        this.ResizeParentShape();
+                        break;
+                    }
 
                 default:
                     throw new ArgumentOutOfRangeException(nameof(value), value, null);
@@ -167,59 +167,57 @@ internal sealed record TextFrame : ITextBox
 
     public string SDKXPath => new XmlPath(this.sdkTextBody).XPath;
 
-	public TextVerticalAlignment VerticalAlignment
+    public TextVerticalAlignment VerticalAlignment
     {
-        get 
+        get
         {
             if (this.valignment.HasValue)
             {
                 return this.valignment.Value;
             }
-			
+
             var aBodyPr = this.sdkTextBody.GetFirstChild<A.BodyProperties>();
-			
+
             if (aBodyPr!.Anchor!.Value == A.TextAnchoringTypeValues.Center)
-			{
-				this.valignment = TextVerticalAlignment.Middle;
-			}
+            {
+                this.valignment = TextVerticalAlignment.Middle;
+            }
+            else if (aBodyPr!.Anchor!.Value == A.TextAnchoringTypeValues.Bottom)
+            {
+                this.valignment = TextVerticalAlignment.Bottom;
+            }
+            else
+            {
+                this.valignment = TextVerticalAlignment.Top;
+            }
 
-			else if (aBodyPr!.Anchor!.Value == A.TextAnchoringTypeValues.Bottom)
-			{
-				this.valignment = TextVerticalAlignment.Bottom;
-			}
-
-			else
-			{
-				this.valignment = TextVerticalAlignment.Top;
-			}
-			
             return this.valignment.Value;
-		}
+        }
 
         set => this.SetVerticalAlignment(value);
     }
 
-	private void SetVerticalAlignment(TextVerticalAlignment alignmentValue)
-	{
-		var aTextAlignmentTypeValue = alignmentValue switch
-		{
-			TextVerticalAlignment.Top => A.TextAnchoringTypeValues.Top,
-			TextVerticalAlignment.Middle => A.TextAnchoringTypeValues.Center,
-			TextVerticalAlignment.Bottom => A.TextAnchoringTypeValues.Bottom,
-			_ => throw new ArgumentOutOfRangeException(nameof(alignmentValue))
-		};
+    private void SetVerticalAlignment(TextVerticalAlignment alignmentValue)
+    {
+        var aTextAlignmentTypeValue = alignmentValue switch
+        {
+            TextVerticalAlignment.Top => A.TextAnchoringTypeValues.Top,
+            TextVerticalAlignment.Middle => A.TextAnchoringTypeValues.Center,
+            TextVerticalAlignment.Bottom => A.TextAnchoringTypeValues.Bottom,
+            _ => throw new ArgumentOutOfRangeException(nameof(alignmentValue))
+        };
 
-		var aBodyPr = this.sdkTextBody.GetFirstChild<A.BodyProperties>();
+        var aBodyPr = this.sdkTextBody.GetFirstChild<A.BodyProperties>();
 
-		if (aBodyPr is not null)
-		{
-			aBodyPr.Anchor = aTextAlignmentTypeValue;
-		}
+        if (aBodyPr is not null)
+        {
+            aBodyPr.Anchor = aTextAlignmentTypeValue;
+        }
 
-		this.valignment = alignmentValue;
-	}
-     
-	public void ResizeParentShape()
+        this.valignment = alignmentValue;
+    }
+
+    public void ResizeParentShape()
     {
         if (this.AutofitType != AutofitType.Resize)
         {

--- a/test/ShapeCrawler.Tests.Unit/TableTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/TableTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using FluentAssertions;
 using NUnit.Framework;
+using ShapeCrawler.Tables;
 using ShapeCrawler.Tests.Unit.Helpers;
 using A = DocumentFormat.OpenXml.Drawing;
 
@@ -8,7 +9,68 @@ namespace ShapeCrawler.Tests.Unit;
 
 public class TableTests : SCTest
 {
-    [Test]
+	[Test]
+	public void TableStyle_Getter_return_style_of_table()
+	{
+		// Arrange
+		var pptx = StreamOf("009_table.pptx");
+		var pres = new Presentation(pptx);
+		var table = (ITable)pres.Slides[2].Shapes.First(sp => sp.Id == 3);
+
+		// Act 
+		var tableStyle = table.TableStyle;
+
+		// Assert
+		tableStyle.Should().Be(CommonTableStyles.GetTableStyleByEnum(TableStyleEnum.MediumStyle2Accent1));
+		pres.Validate();
+	}
+
+	[Test]
+	public void TableStyle_Setter_set_style()
+	{
+		// Arrange
+		var pptx = StreamOf("009_table.pptx");
+		var pres = new Presentation(pptx);
+		var table = (ITable)pres.Slides[2].Shapes.First(sp => sp.Id == 3);
+		var mStream = new MemoryStream();
+
+		// Act
+		table.TableStyle = CommonTableStyles.GetTableStyleByEnum(TableStyleEnum.ThemedStyle1Accent4);
+
+		// Assert
+		table.TableStyle.Should().Be(CommonTableStyles.GetTableStyleByEnum(TableStyleEnum.ThemedStyle1Accent4));
+
+
+		pres.SaveAs(mStream);
+		pres = new Presentation(mStream);
+		table = (ITable)pres.Slides[2].Shapes.First(sp => sp.Id == 3);
+		table.TableStyle.Should().Be(CommonTableStyles.GetTableStyleByEnum(TableStyleEnum.ThemedStyle1Accent4));
+		pres.Validate();
+	}
+
+	[Test]
+	public void TableStyle_Setter_set_style_using_enum()
+	{
+		// Arrange
+		var pptx = StreamOf("009_table.pptx");
+		var pres = new Presentation(pptx);
+		var table = (ITable)pres.Slides[2].Shapes.First(sp => sp.Id == 3);
+		var mStream = new MemoryStream();
+
+		// Act
+		table.TableStyleByEnum = TableStyleEnum.MediumStyle4;
+
+		// Assert
+		table.TableStyle.Should().Be(CommonTableStyles.GetTableStyleByEnum(TableStyleEnum.MediumStyle4));
+
+		pres.SaveAs(mStream);
+		pres = new Presentation(mStream);
+		table = (ITable)pres.Slides[2].Shapes.First(sp => sp.Id == 3);
+		table.TableStyle.Should().Be(CommonTableStyles.GetTableStyleByEnum(TableStyleEnum.MediumStyle4));
+		pres.Validate();
+	}
+
+	[Test]
     public void RemoveColumnAt_removes_column_by_specified_index()
     {
         // Arrange

--- a/test/ShapeCrawler.Tests.Unit/TableTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/TableTests.cs
@@ -21,7 +21,7 @@ public class TableTests : SCTest
 		var tableStyle = table.TableStyle;
 
 		// Assert
-		tableStyle.Should().Be(CommonTableStyles.GetTableStyleByEnum(TableStyleEnum.MediumStyle2Accent1));
+		tableStyle.Should().BeEquivalentTo(TableStyle.MediumStyle2Accent1);
 		pres.Validate();
 	}
 
@@ -35,38 +35,14 @@ public class TableTests : SCTest
 		var mStream = new MemoryStream();
 
 		// Act
-		table.TableStyle = CommonTableStyles.GetTableStyleByEnum(TableStyleEnum.ThemedStyle1Accent4);
+		table.TableStyle = TableStyle.ThemedStyle1Accent4;
 
 		// Assert
-		table.TableStyle.Should().Be(CommonTableStyles.GetTableStyleByEnum(TableStyleEnum.ThemedStyle1Accent4));
-
-
+		table.TableStyle.Should().BeEquivalentTo(TableStyle.ThemedStyle1Accent4);
 		pres.SaveAs(mStream);
 		pres = new Presentation(mStream);
 		table = (ITable)pres.Slides[2].Shapes.First(sp => sp.Id == 3);
-		table.TableStyle.Should().Be(CommonTableStyles.GetTableStyleByEnum(TableStyleEnum.ThemedStyle1Accent4));
-		pres.Validate();
-	}
-
-	[Test]
-	public void TableStyle_Setter_set_style_using_enum()
-	{
-		// Arrange
-		var pptx = StreamOf("009_table.pptx");
-		var pres = new Presentation(pptx);
-		var table = (ITable)pres.Slides[2].Shapes.First(sp => sp.Id == 3);
-		var mStream = new MemoryStream();
-
-		// Act
-		table.TableStyleByEnum = TableStyleEnum.MediumStyle4;
-
-		// Assert
-		table.TableStyle.Should().Be(CommonTableStyles.GetTableStyleByEnum(TableStyleEnum.MediumStyle4));
-
-		pres.SaveAs(mStream);
-		pres = new Presentation(mStream);
-		table = (ITable)pres.Slides[2].Shapes.First(sp => sp.Id == 3);
-		table.TableStyle.Should().Be(CommonTableStyles.GetTableStyleByEnum(TableStyleEnum.MediumStyle4));
+		table.TableStyle.Should().BeEquivalentTo(TableStyle.ThemedStyle1Accent4);
 		pres.Validate();
 	}
 


### PR DESCRIPTION
When creating a table, a arbitrary default style is add. With this commit, we will be able to change it.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on enhancing the code quality and organization within the `ShapeCrawler` library. It introduces improvements in documentation, code formatting, and the addition of a new `ITableStyle` interface along with its implementations.

### Detailed summary
- Updated XML documentation for various methods and properties.
- Improved code formatting for better readability.
- Added `ITableStyle` interface and `TableStyle` class for table styling.
- Introduced `CommonTableStyles` class to manage predefined table styles.
- Updated the `AddTable` method to include a style parameter.
- Enhanced exception handling in `NullTextFrame`.
- Refactored method signatures across multiple interfaces for consistency.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->