### PR TITLE
Update editorconfig

### DIFF
--- a/src/ShapeCrawler/.editorconfig
+++ b/src/ShapeCrawler/.editorconfig
@@ -279,7 +279,6 @@ csharp_preserve_single_line_statements = true
 #### Naming styles ####
 
 # Naming rules
-
 dotnet_naming_rule.interface_should_be_begins_with_i.severity = error
 dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
 dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
@@ -293,7 +292,6 @@ dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_m
 dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
 
 # Symbol specifications
-
 dotnet_naming_symbols.interface.applicable_kinds = interface
 dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
 dotnet_naming_symbols.interface.required_modifiers = 
@@ -307,7 +305,6 @@ dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, int
 dotnet_naming_symbols.non_field_members.required_modifiers = 
 
 # Naming styles
-
 dotnet_naming_style.pascal_case.required_prefix = 
 dotnet_naming_style.pascal_case.required_suffix = 
 dotnet_naming_style.pascal_case.word_separator = 
@@ -317,7 +314,7 @@ dotnet_naming_style.begins_with_i.required_prefix = I
 dotnet_naming_style.begins_with_i.required_suffix = 
 dotnet_naming_style.begins_with_i.word_separator = 
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
-[*.{cs,vb}]
+
 dotnet_style_coalesce_expression = true:error
 dotnet_style_null_propagation = true:error
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true:error

--- a/src/ShapeCrawler/.editorconfig
+++ b/src/ShapeCrawler/.editorconfig
@@ -88,7 +88,7 @@ dotnet_diagnostic.CS8619.severity = error
 dotnet_diagnostic.CS8621.severity = error
 dotnet_diagnostic.CS8629.severity = error
 dotnet_diagnostic.CS8764.severity = error
-dotnet_diagnostic.CS8766.severity = suggestion
+dotnet_diagnostic.CS8766.severity = error
 dotnet_diagnostic.CS8767.severity = error
 
 #### Core EditorConfig Options ####
@@ -164,70 +164,70 @@ dotnet_style_allow_statement_immediately_after_block_experimental = true
 #### C# Coding Conventions ####
 
 # var preferences
-csharp_style_var_elsewhere = false
-csharp_style_var_for_built_in_types = false
-csharp_style_var_when_type_is_apparent = false
+csharp_style_var_elsewhere = true:silent
+csharp_style_var_for_built_in_types = true:silent
+csharp_style_var_when_type_is_apparent = true:silent
 
 # Expression-bodied members
-csharp_style_expression_bodied_accessors = true
-csharp_style_expression_bodied_constructors = false
-csharp_style_expression_bodied_indexers = true
-csharp_style_expression_bodied_lambdas = true
-csharp_style_expression_bodied_local_functions = false
-csharp_style_expression_bodied_methods = false
-csharp_style_expression_bodied_operators = false
-csharp_style_expression_bodied_properties = true
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = false:silent
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
 
 # Pattern matching preferences
 csharp_style_pattern_matching_over_as_with_null_check = true
 csharp_style_pattern_matching_over_is_with_cast_check = true
-csharp_style_prefer_extended_property_pattern = true
+csharp_style_prefer_extended_property_pattern = true:suggestion
 csharp_style_prefer_not_pattern = true
 csharp_style_prefer_pattern_matching = true
-csharp_style_prefer_switch_expression = true
+csharp_style_prefer_switch_expression = true:suggestion
 
 # Null-checking preferences
-csharp_style_conditional_delegate_call = true
+csharp_style_conditional_delegate_call = true:suggestion
 
 # Modifier preferences
-csharp_prefer_static_anonymous_function = true
-csharp_prefer_static_local_function = true
+csharp_prefer_static_anonymous_function = true:suggestion
+csharp_prefer_static_local_function = true:suggestion
 csharp_preferred_modifier_order = public,private,protected,internal,file,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,required,volatile,async
-csharp_style_prefer_readonly_struct = true
-csharp_style_prefer_readonly_struct_member = true
+csharp_style_prefer_readonly_struct = true:suggestion
+csharp_style_prefer_readonly_struct_member = true:suggestion
 
 # Code-block preferences
-csharp_prefer_braces = true
-csharp_prefer_simple_using_statement = true
-csharp_style_namespace_declarations = block_scoped
-csharp_style_prefer_method_group_conversion = true
-csharp_style_prefer_primary_constructors = true
-csharp_style_prefer_top_level_statements = true
+csharp_prefer_braces = true:silent
+csharp_prefer_simple_using_statement = true:error
+csharp_style_namespace_declarations = file_scoped:error
+csharp_style_prefer_method_group_conversion = true:silent
+csharp_style_prefer_primary_constructors = true:error
+csharp_style_prefer_top_level_statements = true:silent
 
 # Expression-level preferences
-csharp_prefer_simple_default_expression = true
-csharp_style_deconstructed_variable_declaration = true
-csharp_style_implicit_object_creation_when_type_is_apparent = true
-csharp_style_inlined_variable_declaration = true
-csharp_style_prefer_index_operator = true
-csharp_style_prefer_local_over_anonymous_function = true
-csharp_style_prefer_null_check_over_type_check = true
-csharp_style_prefer_range_operator = true
-csharp_style_prefer_tuple_swap = true
-csharp_style_prefer_utf8_string_literals = true
-csharp_style_throw_expression = true
-csharp_style_unused_value_assignment_preference = discard_variable
-csharp_style_unused_value_expression_statement_preference = discard_variable
+csharp_prefer_simple_default_expression = true:error
+csharp_style_deconstructed_variable_declaration = true:error
+csharp_style_implicit_object_creation_when_type_is_apparent = true:error
+csharp_style_inlined_variable_declaration = true:error
+csharp_style_prefer_index_operator = true:error
+csharp_style_prefer_local_over_anonymous_function = true:error
+csharp_style_prefer_null_check_over_type_check = true:error
+csharp_style_prefer_range_operator = true:error
+csharp_style_prefer_tuple_swap = true:error
+csharp_style_prefer_utf8_string_literals = true:error
+csharp_style_throw_expression = true:error
+csharp_style_unused_value_assignment_preference = discard_variable:error
+csharp_style_unused_value_expression_statement_preference = discard_variable:silent
 
 # 'using' directive preferences
-csharp_using_directive_placement = outside_namespace
+csharp_using_directive_placement = outside_namespace:silent
 
 # New line preferences
-csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true
-csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = true
-csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental = true
-csharp_style_allow_blank_lines_between_consecutive_braces_experimental = true
-csharp_style_allow_embedded_statements_on_same_line_experimental = true
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true:silent
+csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = true:silent
+csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental = true:silent
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = true:silent
+csharp_style_allow_embedded_statements_on_same_line_experimental = true:silent
 
 #### C# Formatting Rules ####
 
@@ -280,15 +280,15 @@ csharp_preserve_single_line_statements = true
 
 # Naming rules
 
-dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = error
 dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
 dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
 
-dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.severity = error
 dotnet_naming_rule.types_should_be_pascal_case.symbols = types
 dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
 
-dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = error
 dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
 dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
 
@@ -317,3 +317,32 @@ dotnet_naming_style.begins_with_i.required_prefix = I
 dotnet_naming_style.begins_with_i.required_suffix = 
 dotnet_naming_style.begins_with_i.word_separator = 
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
+[*.{cs,vb}]
+dotnet_style_coalesce_expression = true:error
+dotnet_style_null_propagation = true:error
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:error
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_object_initializer = true:error
+dotnet_style_collection_initializer = true:error
+dotnet_style_prefer_simplified_boolean_expressions = true:error
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+dotnet_style_explicit_tuple_names = true:error
+dotnet_style_prefer_inferred_tuple_names = true:error
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:error
+dotnet_style_prefer_compound_assignment = true:error
+dotnet_style_prefer_simplified_interpolation = true:error
+dotnet_style_prefer_collection_expression = when_types_loosely_match:error
+dotnet_style_namespace_match_folder = true:error
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+tab_width = 4
+indent_size = 4
+end_of_line = crlf
+dotnet_style_predefined_type_for_member_access = true:silent
+dotnet_style_readonly_field = true:suggestion
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
+dotnet_style_allow_multiple_blank_lines_experimental = true:silent
+dotnet_style_allow_statement_immediately_after_block_experimental = true:silent
+dotnet_code_quality_unused_parameters = all:suggestion
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent

--- a/src/ShapeCrawler/Charts/IChart.cs
+++ b/src/ShapeCrawler/Charts/IChart.cs
@@ -39,7 +39,7 @@ public interface IChart : IShape
     /// <summary>
     ///     Gets chart title.
     /// </summary>
-    string Title { get; }
+    string? Title { get; }
 
     /// <summary>
     ///     Gets a value indicating whether the chart has categories.

--- a/src/ShapeCrawler/Presentations/ISlide.cs
+++ b/src/ShapeCrawler/Presentations/ISlide.cs
@@ -14,7 +14,7 @@ public interface ISlide
     /// <summary>
     ///     Gets background image.
     /// </summary>
-    IImage Background { get; }
+    IImage? Background { get; }
 
     /// <summary>
     ///     Gets or sets custom data. It returns <see langword="null"/> if custom data is not presented.

--- a/src/ShapeCrawler/Presentations/ReadOnlySlides.cs
+++ b/src/ShapeCrawler/Presentations/ReadOnlySlides.cs
@@ -27,7 +27,7 @@ internal sealed record ReadOnlySlides : IReadOnlyList<ISlide>
     {
         if (!this.sdkSlideParts.Any())
         {
-            return new List<Slide>(0);
+            return [];
         }
         
         var sdkPresDocument = (PresentationDocument)this.sdkSlideParts.First().OpenXmlPackage;

--- a/src/ShapeCrawler/Presentations/Slide.cs
+++ b/src/ShapeCrawler/Presentations/Slide.cs
@@ -113,7 +113,7 @@ internal sealed class Slide : ISlide
         if (tablesOnSlide.Any())
         {
             returnList.AddRange(tablesOnSlide.SelectMany(table =>
-                table.Rows.SelectMany(row => row.Cells).Select(cell => cell.TextFrame)));
+                table.Rows.SelectMany(row => row.Cells).Select(cell => cell.TextBox)));
         }
 
         // if there are groups on that slide, they need to be added as well since those are not direct descendants of the slide either

--- a/src/ShapeCrawler/SectionCollection/ISections.cs
+++ b/src/ShapeCrawler/SectionCollection/ISections.cs
@@ -72,7 +72,7 @@ internal sealed class Sections : ISections
         var p14SectionList = this.sdkPresDocument.PresentationPart!.Presentation.PresentationExtensionList
             ?.Descendants<P14.SectionList>().FirstOrDefault();
         return p14SectionList == null
-            ? new List<Section>(0)
+            ? []
             : p14SectionList.OfType<P14.Section>().Select(p14Section => new Section(this.sdkPresDocument, p14Section))
                 .ToList();
     }

--- a/src/ShapeCrawler/ShapeCollection/AudioType.cs
+++ b/src/ShapeCrawler/ShapeCollection/AudioType.cs
@@ -9,10 +9,10 @@ public enum AudioType
     /// <summary>
     ///    MP3 audio.
     /// </summary>
-    MP3,
+    Mp3,
     
     /// <summary>
     ///     WAVE audio.
     /// </summary>
-    WAVE
+    Wave
 }

--- a/src/ShapeCrawler/ShapeCollection/IMediaShape.cs
+++ b/src/ShapeCrawler/ShapeCollection/IMediaShape.cs
@@ -16,7 +16,7 @@ public interface IMediaShape : IShape
     /// <summary>
     ///     Gets MIME type.
     /// </summary>
-    string MIME { get; }
+    string Mime { get; }
     
     /// <summary>
     ///     Gets bytes of video content.
@@ -49,7 +49,7 @@ internal class MediaShape : Shape, IMediaShape
     
     public override bool Removeable => true;
 
-    public string MIME
+    public string Mime
     {
         get
         {

--- a/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
@@ -56,7 +56,7 @@ internal sealed class SlideShapes : ISlideShapes
         }
     }
 
-    public void AddAudio(int x, int y, Stream audio) => this.AddAudio(x, y, audio, AudioType.MP3);
+    public void AddAudio(int x, int y, Stream audio) => this.AddAudio(x, y, audio, AudioType.Mp3);
 
     public void AddAudio(int x, int y, Stream audio, AudioType type)
     {
@@ -64,11 +64,11 @@ internal sealed class SlideShapes : ISlideShapes
         string? extension;
         switch (type)
         {
-            case AudioType.MP3:
+            case AudioType.Mp3:
                 contentType = "audio/mpeg";
                 extension = ".mp3";
                 break;
-            case AudioType.WAVE:
+            case AudioType.Wave:
                 contentType = "audio/wav";
                 extension = ".wav";
                 break;

--- a/src/ShapeCrawler/Tables/ITableCell.cs
+++ b/src/ShapeCrawler/Tables/ITableCell.cs
@@ -4,7 +4,7 @@ using ShapeCrawler.Tables;
 using ShapeCrawler.Texts;
 using A = DocumentFormat.OpenXml.Drawing;
 
-// ReSharper disable CheckNamespace
+// ReSharper disable once CheckNamespace
 namespace ShapeCrawler;
 
 /// <summary>
@@ -15,7 +15,7 @@ public interface ITableCell
     /// <summary>
     ///     Gets text box.
     /// </summary>
-    ITextBox TextFrame { get; }
+    ITextBox TextBox { get; }
 
     /// <summary>
     ///     Gets a value indicating whether cell belongs to merged cell.
@@ -55,7 +55,7 @@ internal sealed class TableCell : ITableCell
         this.ATableCell = aTableCell;
         this.RowIndex = rowIndex;
         this.ColumnIndex = columnIndex;
-        this.TextFrame = new TextFrame(sdkTypedOpenXmlPart, this.ATableCell.TextBody!);
+        this.TextBox = new TextFrame(sdkTypedOpenXmlPart, this.ATableCell.TextBody!);
         var aTcPr = aTableCell.TableCellProperties!;
         this.Fill = new TableCellFill(sdkTypedOpenXmlPart, aTcPr);
         this.TopBorder = new TopBorder(aTableCell.TableCellProperties!);
@@ -79,7 +79,7 @@ internal sealed class TableCell : ITableCell
 
     public IBorder RightBorder { get; }
 
-    public ITextBox TextFrame { get; }
+    public ITextBox TextBox { get; }
 
     internal A.TableCell ATableCell { get; }
 

--- a/src/ShapeCrawler/Texts/IParagraph.cs
+++ b/src/ShapeCrawler/Texts/IParagraph.cs
@@ -186,7 +186,7 @@ internal sealed class Paragraph : IParagraph
     {
         foreach (var portion in this.Portions)
         {
-            portion.Font.Size = fontSize;
+            portion.Font!.Size = fontSize;
         }
     }
 

--- a/src/ShapeCrawler/Texts/IParagraphPortion.cs
+++ b/src/ShapeCrawler/Texts/IParagraphPortion.cs
@@ -14,7 +14,7 @@ public interface IParagraphPortion
     /// <summary>
     ///     Gets font.
     /// </summary>
-    ITextPortionFont Font { get; }
+    ITextPortionFont? Font { get; }
 
     /// <summary>
     ///     Gets or sets hypelink.

--- a/src/ShapeCrawler/Texts/IParagraphs.cs
+++ b/src/ShapeCrawler/Texts/IParagraphs.cs
@@ -55,7 +55,7 @@ internal readonly struct Paragraphs : IParagraphs
         var aParagraphs = this.sdkTextBody.Elements<A.Paragraph>().ToList();
         if (!aParagraphs.Any())
         {
-            return new List<Paragraph>(0);
+            return [];
         }
 
         var paraList = new List<Paragraph>();

--- a/src/ShapeCrawler/Texts/TextFrame.cs
+++ b/src/ShapeCrawler/Texts/TextFrame.cs
@@ -262,7 +262,7 @@ internal sealed record TextFrame : ITextBox
         using var paint = new SKPaint();
         paint.Color = SKColors.Black;
         var firstPortion = this.Paragraphs.First().Portions.First();
-        paint.TextSize = (float)firstPortion.Font.Size;
+        paint.TextSize = (float)firstPortion.Font!.Size;
         var typeFace = SKTypeface.FromFamilyName(firstPortion.Font.LatinName);
         paint.Typeface = typeFace;
         float leftMarginPx = (float)UnitConverter.CentimeterToPixel(this.LeftMargin);
@@ -346,7 +346,7 @@ internal sealed record TextFrame : ITextBox
     {
         var popularPortion = baseParagraph.Portions.GroupBy(p => p.Font!.Size).OrderByDescending(x => x.Count())
             .First().First();
-        var font = popularPortion.Font;
+        var font = popularPortion.Font!;
 
         var parent = this.sdkTextBody.Parent!;
         var shapeSize = new ShapeSize(this.sdkTypedOpenXmlPart, parent);

--- a/test/ShapeCrawler.Tests.Unit/FontColorTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/FontColorTests.cs
@@ -58,7 +58,7 @@ public class FontColorTests : SCTest
         // Arrange
         var pres = new Presentation(StreamOf("001.pptx"));
         var table = pres.Slides[1].Shapes.GetById<ITable>(4);
-        var fontColor = table.Rows[0].Cells[0].TextFrame.Paragraphs[0].Portions[0].Font.Color;
+        var fontColor = table.Rows[0].Cells[0].TextBox.Paragraphs[0].Portions[0].Font.Color;
 
         // Act-Assert
         fontColor.Hex.Should().Be("FF0000");

--- a/test/ShapeCrawler.Tests.Unit/FontTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/FontTests.cs
@@ -51,7 +51,7 @@ public class FontTests : SCTest
         // Arrange
         var pres = new Presentation(StreamOf("009_table.pptx"));
         var table = pres.Slides[2].Shapes.GetById<ITable>(3);
-        var portion = table.Rows[0].Cells[0].TextFrame.Paragraphs[0].Portions[0];
+        var portion = table.Rows[0].Cells[0].TextBox.Paragraphs[0].Portions[0];
 
         // Act-Assert
         portion.Font.Size.Should().Be(18);
@@ -300,8 +300,8 @@ public class FontTests : SCTest
         slide.Shapes.AddTable(40, 40, 6, 5);
         var table = (ITable)slide.Shapes.Last();
         var cell = table[1, 2];
-        cell.TextFrame.Text = "Test";
-        var font = cell.TextFrame.Paragraphs.First().Portions.First().Font;
+        cell.TextBox.Text = "Test";
+        var font = cell.TextBox.Paragraphs.First().Portions.First().Font;
 
         // Act
         font.LatinName = "Arial";

--- a/test/ShapeCrawler.Tests.Unit/ParagraphPortionTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ParagraphPortionTests.cs
@@ -13,7 +13,7 @@ public class ParagraphPortionTests : SCTest
         var pptx = StreamOf("009_table");
         var pres = new Presentation(pptx);
         IParagraphPortion portion = ((ITable)pres.Slides[2].Shapes.First(sp => sp.Id == 3)).Rows[0].Cells[0]
-            .TextFrame
+            .TextBox
             .Paragraphs[0].Portions[0];
 
         // Act
@@ -105,7 +105,7 @@ public class ParagraphPortionTests : SCTest
         var pptxStream =  StreamOf("table-case001.pptx");
         var pres = new Presentation(pptxStream);
         var table = pres.Slides[0].Shapes.GetByName<ITable>("Table 1");
-        var portion = table.Rows[0].Cells[0].TextFrame.Paragraphs[0].Portions[0];
+        var portion = table.Rows[0].Cells[0].TextBox.Paragraphs[0].Portions[0];
 
         // Act
         portion.Hyperlink = "https://github.com/ShapeCrawler/ShapeCrawler";

--- a/test/ShapeCrawler.Tests.Unit/ParagraphTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ParagraphTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using DocumentFormat.OpenXml.Drawing.Wordprocessing;
 using FluentAssertions;
 using NUnit.Framework;
 using ShapeCrawler.Tests.Unit.Helpers;
@@ -69,21 +70,21 @@ public class ParagraphTests : SCTest
     }
 
     [Test]
-    public void Alignment_Setter_updates_text_horizontal_alignment_of_table_Cell()
+    public void HorizontalAlignment_Setter_sets_horizontal_alignment()
     {
         // Arrange
         var pres = new Presentation();
-        pres.Slides[0].Shapes.AddTable(10, 10, 2, 2);
-        var table = (ITable)pres.Slides[0].Shapes.Last();
-        var cellTextFrame = table.Rows[0].Cells[0].TextFrame;
-        cellTextFrame.Text = "some-text";
-        var paragraph = cellTextFrame.Paragraphs[0];
+        pres.Slide(1).Shapes.AddTable(10, 10, 2, 2);
+        var table = pres.Slide(1).Shapes.Last<ITable>();
+        var textFrame = table.Rows[0].Cells[0].TextBox;
+        textFrame.Text = "some-text";
+        var paragraph = textFrame.Paragraphs[0];
         
         // Act 
-        cellTextFrame.VerticalAlignment = TextVerticalAlignment.Bottom;
+        paragraph.HorizontalAlignment = TextHorizontalAlignment.Center;
 
         // Assert 
-		cellTextFrame.VerticalAlignment.Should().Be(TextVerticalAlignment.Bottom);
+        paragraph.HorizontalAlignment.Should().Be(TextHorizontalAlignment.Center);
         pres.Validate();
     }
 
@@ -179,7 +180,7 @@ public class ParagraphTests : SCTest
         // Arrange
         var textBox1 = ((IShape)new Presentation(StreamOf("008.pptx")).Slides[0].Shapes.First(sp => sp.Id == 37)).TextBox;
         var textBox2 = ((ITable)new Presentation(StreamOf("009_table.pptx")).Slides[2].Shapes.First(sp => sp.Id == 3)).Rows[0].Cells[0]
-            .TextFrame;
+            .TextBox;
 
         // Act
         string paragraphTextCase1 = textBox1.Paragraphs[0].Text;

--- a/test/ShapeCrawler.Tests.Unit/ParagraphTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ParagraphTests.cs
@@ -254,21 +254,18 @@ public class ParagraphTests : SCTest
     [Test]
     [SlideShape("001.pptx", 1, "TextBox 3", TextHorizontalAlignment.Center)]
     [SlideShape("001.pptx", 1, "Head 1", TextHorizontalAlignment.Center)]
-    public void Alignment_Getter_returns_text_horizontal_alignment(IShape autoShape, TextHorizontalAlignment expectedAlignment)
+    public void HorizontalAlignment_Getter_returns_text_horizontal_alignment(IShape autoShape, TextHorizontalAlignment expectedAlignment)
     {
         // Arrange
         var paragraph = autoShape.TextBox.Paragraphs[0];
 
-        // Act
-        var textAlignment = paragraph.HorizontalAlignment;
-
-        // Assert
-        textAlignment.Should().Be(expectedAlignment);
+        // Act-Assert
+        paragraph.HorizontalAlignment.Should().Be(expectedAlignment);
     }
 
     [Test]
     [TestCase("001.pptx", 1, "TextBox 4")]
-    public void Alignment_Setter_updates_text_horizontal_alignment(string presName, int slideNumber, string shapeName)
+    public void HorizontalAlignment_Setter_updates_text_horizontal_alignment(string presName, int slideNumber, string shapeName)
     {
         // Arrange
         var pres = new Presentation(StreamOf(presName));

--- a/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
@@ -297,7 +297,7 @@ public class ShapeCollectionTests : SCTest
         var shapes = pres.Slides[1].Shapes;
 
         // Act
-        shapes.AddAudio(300, 100, wav, AudioType.WAVE);
+        shapes.AddAudio(300, 100, wav, AudioType.Wave);
 
         // Assert
         var addedAudio = pres.Slides[1].Shapes.OfType<IMediaShape>().Last();

--- a/test/ShapeCrawler.Tests.Unit/ShapeTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeTests.cs
@@ -31,7 +31,7 @@ public class ShapeTests : SCTest
         var audioShape = pres.Slides[0].Shapes.GetByName<IMediaShape>("Audio 1");
 
         // Act
-        var mime = audioShape.MIME;
+        var mime = audioShape.Mime;
 
         // Assert
         mime.Should().Be("audio/mpeg");
@@ -61,7 +61,7 @@ public class ShapeTests : SCTest
         var videoShape = pres.Slides[0].Shapes.GetByName<IMediaShape>("Video 1");
 
         // Act
-        var mime = videoShape.MIME;
+        var mime = videoShape.Mime;
 
         // Assert
         mime.Should().Be("video/mp4");

--- a/test/ShapeCrawler.Tests.Unit/TableTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/TableTests.cs
@@ -260,14 +260,14 @@ public class TableTests : SCTest
         // Assert
         table[0, 0].IsMergedCell.Should().BeTrue();
         table[0, 1].IsMergedCell.Should().BeTrue();
-        table[0, 0].TextFrame.Text.Should().Be($"id5{Environment.NewLine}Text0_1");
+        table[0, 0].TextBox.Text.Should().Be($"id5{Environment.NewLine}Text0_1");
 
         presentation.SaveAs(mStream);
         presentation = new Presentation(mStream);
         table = (ITable)presentation.Slides[2].Shapes.First(sp => sp.Id == 5);
         table[0, 0].IsMergedCell.Should().BeTrue();
         table[0, 1].IsMergedCell.Should().BeTrue();
-        table[0, 0].TextFrame.Text.Should().Be($"id5{Environment.NewLine}Text0_1");
+        table[0, 0].TextBox.Text.Should().Be($"id5{Environment.NewLine}Text0_1");
     }
 
     [Test(Description = "MergeCells #2")]
@@ -292,8 +292,8 @@ public class TableTests : SCTest
         {
             tableSc[0, 1].IsMergedCell.Should().BeTrue();
             tableSc[0, 2].IsMergedCell.Should().BeTrue();
-            tableSc[0, 1].TextFrame.Text.Should().Be("Text0_2");
-            tableSc[0, 2].TextFrame.Text.Should().Be("Text0_2");
+            tableSc[0, 1].TextBox.Text.Should().Be("Text0_2");
+            tableSc[0, 2].TextBox.Text.Should().Be("Text0_2");
         }
     }
 
@@ -369,8 +369,8 @@ public class TableTests : SCTest
             string expectedText = $"id5{Environment.NewLine}Text1_0";
             table[0, 0].IsMergedCell.Should().BeTrue();
             table[0, 1].IsMergedCell.Should().BeFalse();
-            table[0, 0].TextFrame.Text.Should().Be(expectedText);
-            table[1, 0].TextFrame.Text.Should().Be(expectedText);
+            table[0, 0].TextBox.Text.Should().Be(expectedText);
+            table[1, 0].TextBox.Text.Should().Be(expectedText);
         }
     }
 
@@ -396,14 +396,14 @@ public class TableTests : SCTest
         var pres = new Presentation();
         pres.Slides[0].Shapes.AddTable(10, 10, 3, 4);
         var table = (ITable)pres.Slides[0].Shapes.Last();
-        table[1, 0].TextFrame.Text = "A";
-        table[3, 0].TextFrame.Text = "B";
+        table[1, 0].TextBox.Text = "A";
+        table[3, 0].TextBox.Text = "B";
 
         // Act
         table.MergeCells(table[1, 0], table[2, 0]);
 
         // Assert
-        table[1, 0].TextFrame.Text.Should().Be("A");
+        table[1, 0].TextBox.Text.Should().Be("A");
     }
 
     [Test(Description = "MergeCells #6")]

--- a/test/ShapeCrawler.Tests.Unit/TextBoxTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/TextBoxTests.cs
@@ -318,16 +318,13 @@ namespace ShapeCrawler.Tests.Unit
 
         [Test]
 		[SlideShape("014.pptx", 2, 5, TextVerticalAlignment.Middle)] 
-		public void Text_Getter_returns_vertical_alignment(IShape shape, TextVerticalAlignment expectedVAlignment)
+		public void VerticalAlignment_Getter_returns_vertical_alignment(IShape shape, TextVerticalAlignment expectedVAlignment)
         {
             // Arrange
-            var textFrame = ((IShape)shape).TextBox;
+            var textBox = shape.TextBox;
 
-            // Act
-            var valignment = textFrame.VerticalAlignment;
-
-            // Assert
-            valignment.Should().Be(expectedVAlignment);
+            // Act-Assert
+            textBox.VerticalAlignment.Should().Be(expectedVAlignment);
         }
 
         [Test]
@@ -522,7 +519,7 @@ namespace ShapeCrawler.Tests.Unit
 
 		[Test]
 		[TestCase("001.pptx", 1, "TextBox 4")]
-		public void Alignment_Setter_updates_text_vertical_alignment(string presName, int slideNumber, string shapeName)
+		public void VerticalAlignment_Setter_updates_text_vertical_alignment(string presName, int slideNumber, string shapeName)
 		{
 			// Arrange
 			var pres = new Presentation(StreamOf(presName));
@@ -531,6 +528,7 @@ namespace ShapeCrawler.Tests.Unit
 
 			// Act
 			textbox.VerticalAlignment = TextVerticalAlignment.Bottom;
+            SaveResult(pres);
 
 			// Assert
 			textbox.VerticalAlignment.Should().Be(TextVerticalAlignment.Bottom);

--- a/test/ShapeCrawler.Tests.Unit/TextBoxTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/TextBoxTests.cs
@@ -528,7 +528,6 @@ namespace ShapeCrawler.Tests.Unit
 
 			// Act
 			textbox.VerticalAlignment = TextVerticalAlignment.Bottom;
-            SaveResult(pres);
 
 			// Assert
 			textbox.VerticalAlignment.Should().Be(TextVerticalAlignment.Bottom);

--- a/test/ShapeCrawler.Tests.Unit/TextFrameTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/TextFrameTests.cs
@@ -20,11 +20,11 @@ namespace ShapeCrawler.Tests.Unit
                 .TextBox;
             var textFrame2 = ((ITable)new Presentation(StreamOf("001.pptx")).Slides[1].Shapes.First(sp => sp.Id == 3))
                 .Rows[0].Cells[0]
-                .TextFrame;
+                .TextBox;
             var textFrame3 =
                 ((ITable)new Presentation(StreamOf("009_table.pptx")).Slides[2].Shapes.First(sp => sp.Id == 3)).Rows[0]
                 .Cells[0]
-                .TextFrame;
+                .TextBox;
 
             // Act
             var text1 = textFrame1.Text;
@@ -430,7 +430,7 @@ namespace ShapeCrawler.Tests.Unit
         {
             // Arrange
             var pres = new Presentation(StreamOf("009_table.pptx"));
-            var textFrame = pres.Slides[2].Shapes.GetById<ITable>(3).Rows[0].Cells[0].TextFrame;
+            var textFrame = pres.Slides[2].Shapes.GetById<ITable>(3).Rows[0].Cells[0].TextBox;
 
             // Act
             var paragraphsCount = textFrame.Paragraphs.Count;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving nullability annotations and renaming properties for consistency across various interfaces and classes in the `ShapeCrawler` library. It also updates tests to reflect these changes.

### Detailed summary
- Updated `Font.Size` to nullable in `IParagraphPortion`.
- Changed `Title` and `Background` properties to nullable in `IChart` and `ISlide`.
- Renamed `TextFrame` to `TextBox` in multiple interfaces and classes.
- Updated audio types from `MP3` and `WAVE` to `Mp3` and `Wave`.
- Adjusted tests to reflect property renaming and nullable changes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->