### PR TITLE
Upgrade SkiaSharp

### DIFF
--- a/src/ShapeCrawler/ShapeCollection/AutoShape.cs
+++ b/src/ShapeCrawler/ShapeCollection/AutoShape.cs
@@ -17,11 +17,11 @@ internal sealed class AutoShape : CopyableShape
     internal AutoShape(
         OpenXmlPart sdkTypedOpenXmlPart,
         P.Shape pShape,
-        TextFrame textFrame)
+        TextBox textBox)
         : this(sdkTypedOpenXmlPart, pShape)
     {
         this.IsTextHolder = true;
-        this.TextBox = textFrame;
+        this.TextBox = textBox;
     }
 
     internal AutoShape(
@@ -103,7 +103,7 @@ internal sealed class AutoShape : CopyableShape
             float bottom = (float)(this.Y + this.Height);
             var rect = new SKRect(left, top, right, bottom);
             slideCanvas.DrawRect(rect, paint);
-            var textFrame = (TextFrame)this.TextBox!;
+            var textFrame = (TextBox)this.TextBox!;
             textFrame.Draw(slideCanvas, left, top);
         }
     }

--- a/src/ShapeCrawler/ShapeCollection/GroupShapes/GroupedShapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/GroupShapes/GroupedShapes.cs
@@ -67,7 +67,7 @@ internal sealed record GroupedShapes : IShapes
                         new AutoShape(
                             this.sdkTypedOpenXmlPart,
                             pShape,
-                            new TextFrame(this.sdkTypedOpenXmlPart, pShape.TextBody)));
+                            new TextBox(this.sdkTypedOpenXmlPart, pShape.TextBody)));
                 }
                 else
                 {

--- a/src/ShapeCrawler/ShapeCollection/RootShape.cs
+++ b/src/ShapeCrawler/ShapeCollection/RootShape.cs
@@ -53,29 +53,4 @@ internal sealed class RootShape : CopyableShape, IRootShape
         var autoShapes = new WrappedPShapeTree(pShapeTree);
         autoShapes.Add(this.pShape);
     }
-
-    internal void Draw(SKCanvas slideCanvas)
-    {
-        var skColorOutline = SKColor.Parse(this.Outline.HexColor);
-
-        using var paint = new SKPaint
-        {
-            Color = skColorOutline,
-            IsAntialias = true,
-            StrokeWidth = (float)UnitConverter.PointToPixel(this.Outline.Weight),
-            Style = SKPaintStyle.Stroke
-        };
-
-        if (this.GeometryType == Geometry.Rectangle)
-        {
-            float left = (float)this.X;
-            float top = (float)this.Y;
-            float right = (float)(this.X + this.Width);
-            float bottom = (float)(this.Y + this.Height);
-            var rect = new SKRect(left, top, right, bottom);
-            slideCanvas.DrawRect(rect, paint);
-            var textFrame = (TextFrame)this.TextBox!;
-            textFrame.Draw(slideCanvas, left, top);
-        }
-    }
 }

--- a/src/ShapeCrawler/ShapeCollection/RootShape.cs
+++ b/src/ShapeCrawler/ShapeCollection/RootShape.cs
@@ -1,7 +1,4 @@
 ﻿using DocumentFormat.OpenXml.Packaging;
-using ShapeCrawler.Shared;
-using ShapeCrawler.Texts;
-using SkiaSharp;
 using P = DocumentFormat.OpenXml.Presentation;
 
 namespace ShapeCrawler.ShapeCollection;

--- a/src/ShapeCrawler/ShapeCollection/Shapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/Shapes.cs
@@ -113,7 +113,7 @@ internal sealed class Shapes : IShapes
                             new AutoShape(
                                 this.sdkTypedOpenXmlPart,
                                 pShape,
-                                new TextFrame(
+                                new TextBox(
                                     this.sdkTypedOpenXmlPart, pShape.TextBody))));
                 }
                 else

--- a/src/ShapeCrawler/ShapeCrawler.csproj
+++ b/src/ShapeCrawler/ShapeCrawler.csproj
@@ -73,7 +73,7 @@ This library provides a simplified object model on top of the Open XML SDK for m
     <PackageReference Include="DocumentFormat.OpenXml" Version="3.0.2" />
     <PackageReference Include="DocumentFormat.OpenXml.Linq" Version="3.0.2" />
     <PackageReference Include="SkiaSharp" Version="3.0.0-preview.4.1" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.8" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.0.0-preview.4.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/ShapeCrawler/ShapeCrawler.csproj
+++ b/src/ShapeCrawler/ShapeCrawler.csproj
@@ -72,7 +72,7 @@ This library provides a simplified object model on top of the Open XML SDK for m
   <ItemGroup>
     <PackageReference Include="DocumentFormat.OpenXml" Version="3.0.2" />
     <PackageReference Include="DocumentFormat.OpenXml.Linq" Version="3.0.2" />
-    <PackageReference Include="SkiaSharp" Version="2.88.8" />
+    <PackageReference Include="SkiaSharp" Version="3.0.0-preview.4.1" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.8" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/src/ShapeCrawler/Tables/ITableCell.cs
+++ b/src/ShapeCrawler/Tables/ITableCell.cs
@@ -55,7 +55,7 @@ internal sealed class TableCell : ITableCell
         this.ATableCell = aTableCell;
         this.RowIndex = rowIndex;
         this.ColumnIndex = columnIndex;
-        this.TextBox = new TextFrame(sdkTypedOpenXmlPart, this.ATableCell.TextBody!);
+        this.TextBox = new TextBox(sdkTypedOpenXmlPart, this.ATableCell.TextBody!);
         var aTcPr = aTableCell.TableCellProperties!;
         this.Fill = new TableCellFill(sdkTypedOpenXmlPart, aTcPr);
         this.TopBorder = new TopBorder(aTableCell.TableCellProperties!);

--- a/src/ShapeCrawler/Texts/IParagraph.cs
+++ b/src/ShapeCrawler/Texts/IParagraph.cs
@@ -124,7 +124,7 @@ internal sealed class Paragraph : IParagraph
 
             // Resize
             var sdkTextBody = this.aParagraph.Parent!;
-            var textFrame = new TextFrame(this.sdkTypedOpenXmlPart, sdkTextBody);
+            var textFrame = new TextBox(this.sdkTypedOpenXmlPart, sdkTextBody);
             textFrame.ResizeParentShape();
         }
     }

--- a/src/ShapeCrawler/Texts/Text.cs
+++ b/src/ShapeCrawler/Texts/Text.cs
@@ -25,7 +25,7 @@ internal readonly ref struct Text
             : this.font.LatinName;
         var skFont = new SKFont
         {
-            Size = new Points(font.Size).AsPixels(),
+            Size = new Points(this.font.Size).AsPixels(),
             Typeface = SKTypeface.FromFamilyName(fontFamily)
         };
         

--- a/src/ShapeCrawler/Texts/Text.cs
+++ b/src/ShapeCrawler/Texts/Text.cs
@@ -1,0 +1,34 @@
+﻿using ShapeCrawler.Units;
+using SkiaSharp;
+
+namespace ShapeCrawler.Texts;
+
+internal readonly ref struct Text
+{
+    private readonly string text;
+    private readonly ITextPortionFont font;
+
+    internal Text(string text, ITextPortionFont font)
+    {
+        this.text = text;
+        this.font = font;
+    }
+
+    /// <summary>
+    ///     Gets text width in pixels.
+    /// </summary>
+    internal decimal Width => this.GetWidth();
+
+    private decimal GetWidth()
+    {
+        var fontFamily = this.font.LatinName == "Calibri Light" ? "Calibri" // for unknown reasons, SkiaSharp uses "Segoe UI" instead of "Calibri Light"
+            : this.font.LatinName;
+        var skFont = new SKFont
+        {
+            Size = new Points(font.Size).AsPixels(),
+            Typeface = SKTypeface.FromFamilyName(fontFamily)
+        };
+        
+        return (decimal)skFont.MeasureText(this.text);
+    }
+}

--- a/src/ShapeCrawler/Texts/TextBox.cs
+++ b/src/ShapeCrawler/Texts/TextBox.cs
@@ -12,14 +12,14 @@ using P = DocumentFormat.OpenXml.Presentation;
 
 namespace ShapeCrawler.Texts;
 
-internal sealed record TextFrame : ITextBox
+internal sealed record TextBox : ITextBox
 {
     private readonly OpenXmlPart sdkTypedOpenXmlPart;
     private readonly OpenXmlElement sdkTextBody;
 
     private TextVerticalAlignment? valignment;
 
-    internal TextFrame(OpenXmlPart sdkTypedOpenXmlPart, OpenXmlElement sdkTextBody)
+    internal TextBox(OpenXmlPart sdkTypedOpenXmlPart, OpenXmlElement sdkTextBody)
     {
         this.sdkTypedOpenXmlPart = sdkTypedOpenXmlPart;
         this.sdkTextBody = sdkTextBody;
@@ -340,13 +340,13 @@ internal sealed record TextFrame : ITextBox
         SKPaint paint,
         decimal lMarginPixel,
         decimal rMarginPixel,
-        TextFrame textFrame,
+        TextBox textBox,
         OpenXmlElement parent,
         ITextPortionFont font)
     {
-        if (!textFrame.TextWrapped)
+        if (!textBox.TextWrapped)
         {
-            var longerText = textFrame.Paragraphs
+            var longerText = textBox.Paragraphs
                 .Select(x => new { x.Text, x.Text.Length })
                 .OrderByDescending(x => x.Length)
                 .First().Text;

--- a/src/ShapeCrawler/Texts/TextFrame.cs
+++ b/src/ShapeCrawler/Texts/TextFrame.cs
@@ -6,7 +6,6 @@ using DocumentFormat.OpenXml.Packaging;
 using ShapeCrawler.Positions;
 using ShapeCrawler.ShapeCollection;
 using ShapeCrawler.Shared;
-using ShapeCrawler.Units;
 using SkiaSharp;
 using A = DocumentFormat.OpenXml.Drawing;
 using P = DocumentFormat.OpenXml.Presentation;

--- a/src/ShapeCrawler/Texts/TextFrame.cs
+++ b/src/ShapeCrawler/Texts/TextFrame.cs
@@ -231,10 +231,6 @@ internal sealed record TextFrame : ITextBox
         var scFont = popularPortion.Font;
 
         var paint = new SKPaint();
-        // paint.TextSize = new Points(scFont.Size).AsPixels();
-        var fontFamily = scFont.LatinName == "Calibri Light" ? "Calibri" // for unknown reasons, SkiaSharp uses "Segoe UI" instead of "Calibri Light"
-            : scFont.LatinName;
-        // paint.Typeface = SKTypeface.FromFamilyName(fontFamily);
         paint.IsAntialias = true;
 
         var lMarginPixel = UnitConverter.CentimeterToPixel(this.LeftMargin);
@@ -242,11 +238,9 @@ internal sealed record TextFrame : ITextBox
         var tMarginPixel = UnitConverter.CentimeterToPixel(this.TopMargin);
         var bMarginPixel = UnitConverter.CentimeterToPixel(this.BottomMargin);
 
-        // var textRect = default(SKRect);
         var text = this.Text.ToUpper();
-        // paint.MeasureText(text, ref textRect);
         var textWidth = new Text(text, scFont).Width;
-        var textHeight = (decimal)scFont.Size;
+        var textHeight = scFont.Size;
         var shapeSize = new ShapeSize(this.sdkTypedOpenXmlPart, this.sdkTextBody.Ancestors<P.Shape>().First());
         var currentBlockWidth = shapeSize.Width() - lMarginPixel - rMarginPixel;
         var currentBlockHeight = shapeSize.Height() - tMarginPixel - bMarginPixel;
@@ -357,9 +351,7 @@ internal sealed record TextFrame : ITextBox
                 .Select(x => new { x.Text, x.Text.Length })
                 .OrderByDescending(x => x.Length)
                 .First().Text;
-            // var paraTextRect = default(SKRect);
             
-            // var widthInPixels = paint.MeasureText(longerText, ref paraTextRect);
             var widthInPixels = new Text(longerText, font).Width;
             
             var newWidth = (int)(widthInPixels * (decimal)1.4) // SkiaSharp uses 72 Dpi (https://stackoverflow.com/a/69916569/2948684), ShapeCrawler uses 96 Dpi. 96/72 = 1.4 

--- a/src/ShapeCrawler/Texts/TextFrame.cs
+++ b/src/ShapeCrawler/Texts/TextFrame.cs
@@ -228,13 +228,13 @@ internal sealed record TextFrame : ITextBox
         var popularPortion = baseParagraph.Portions.OfType<TextParagraphPortion>().GroupBy(p => p.Font.Size)
             .OrderByDescending(x => x.Count())
             .First().First();
-        var font = popularPortion.Font;
+        var scFont = popularPortion.Font;
 
         var paint = new SKPaint();
-        paint.TextSize = new Points(font.Size).AsPixels();
-        var fontFamily = font.LatinName == "Calibri Light" ? "Calibri" // for unknown reasons, SkiaSharp uses "Segoe UI" instead of "Calibri Light"
-            : font.LatinName;
-        paint.Typeface = SKTypeface.FromFamilyName(fontFamily);
+        // paint.TextSize = new Points(scFont.Size).AsPixels();
+        var fontFamily = scFont.LatinName == "Calibri Light" ? "Calibri" // for unknown reasons, SkiaSharp uses "Segoe UI" instead of "Calibri Light"
+            : scFont.LatinName;
+        // paint.Typeface = SKTypeface.FromFamilyName(fontFamily);
         paint.IsAntialias = true;
 
         var lMarginPixel = UnitConverter.CentimeterToPixel(this.LeftMargin);
@@ -242,33 +242,22 @@ internal sealed record TextFrame : ITextBox
         var tMarginPixel = UnitConverter.CentimeterToPixel(this.TopMargin);
         var bMarginPixel = UnitConverter.CentimeterToPixel(this.BottomMargin);
 
-        var textRect = default(SKRect);
+        // var textRect = default(SKRect);
         var text = this.Text.ToUpper();
-        paint.MeasureText(text, ref textRect);
-        var textWidth = (decimal)textRect.Width;
-        var textHeight = (decimal)paint.TextSize;
+        // paint.MeasureText(text, ref textRect);
+        var textWidth = new Text(text, scFont).Width;
+        var textHeight = (decimal)scFont.Size;
         var shapeSize = new ShapeSize(this.sdkTypedOpenXmlPart, this.sdkTextBody.Ancestors<P.Shape>().First());
         var currentBlockWidth = shapeSize.Width() - lMarginPixel - rMarginPixel;
         var currentBlockHeight = shapeSize.Height() - tMarginPixel - bMarginPixel;
 
         this.UpdateShapeHeight(textWidth, currentBlockWidth, textHeight, tMarginPixel, bMarginPixel, currentBlockHeight, this.sdkTextBody.Parent!);
-        this.UpdateShapeWidthIfNeeded(paint, lMarginPixel, rMarginPixel, this, this.sdkTextBody.Parent!);
+        this.UpdateShapeWidthIfNeeded(paint, lMarginPixel, rMarginPixel, this, this.sdkTextBody.Parent!, scFont);
     }
 
     internal void Draw(SKCanvas slideCanvas, float shapeX, float shapeY)
     {
-        using var paint = new SKPaint();
-        paint.Color = SKColors.Black;
-        var firstPortion = this.Paragraphs.First().Portions.First();
-        paint.TextSize = (float)firstPortion.Font!.Size;
-        var typeFace = SKTypeface.FromFamilyName(firstPortion.Font.LatinName);
-        paint.Typeface = typeFace;
-        float leftMarginPx = (float)UnitConverter.CentimeterToPixel(this.LeftMargin);
-        float topMarginPx = (float)UnitConverter.CentimeterToPixel(this.TopMargin);
-        float fontHeightPx = (float)UnitConverter.PointToPixel(16);
-        float x = shapeX + leftMarginPx;
-        float y = shapeY + topMarginPx + fontHeightPx;
-        slideCanvas.DrawText(this.Text, x, y, paint);
+        throw new NotImplementedException();
     }
 
     private decimal GetLeftMargin()
@@ -359,7 +348,8 @@ internal sealed record TextFrame : ITextBox
         decimal lMarginPixel,
         decimal rMarginPixel,
         TextFrame textFrame,
-        OpenXmlElement parent)
+        OpenXmlElement parent,
+        ITextPortionFont font)
     {
         if (!textFrame.TextWrapped)
         {
@@ -367,13 +357,13 @@ internal sealed record TextFrame : ITextBox
                 .Select(x => new { x.Text, x.Text.Length })
                 .OrderByDescending(x => x.Length)
                 .First().Text;
-            var paraTextRect = default(SKRect);
-            var widthInPixels = paint.MeasureText(longerText, ref paraTextRect);
-
-            // SkiaSharp uses 72 Dpi (https://stackoverflow.com/a/69916569/2948684), ShapeCrawler uses 96 Dpi.
-            // 96/72=1.4
-            const double Scale = 1.4;
-            var newWidth = (int)(widthInPixels * Scale) + lMarginPixel + rMarginPixel;
+            // var paraTextRect = default(SKRect);
+            
+            // var widthInPixels = paint.MeasureText(longerText, ref paraTextRect);
+            var widthInPixels = new Text(longerText, font).Width;
+            
+            var newWidth = (int)(widthInPixels * (decimal)1.4) // SkiaSharp uses 72 Dpi (https://stackoverflow.com/a/69916569/2948684), ShapeCrawler uses 96 Dpi. 96/72 = 1.4 
+                           + lMarginPixel + rMarginPixel;
             new ShapeSize(this.sdkTypedOpenXmlPart, parent).UpdateWidth(newWidth);
         }
     }
@@ -383,53 +373,59 @@ internal sealed record TextFrame : ITextBox
         var surface = SKSurface.Create(new SKImageInfo(shapeWidth, shapeHeight));
         var canvas = surface.Canvas;
 
-        var paint = new SKPaint();
-        var fontSize = font.Size;
-        paint.TextSize = (float)fontSize;
-        paint.Typeface = SKTypeface.FromFamilyName(font.LatinName);
-        paint.IsAntialias = true;
+        var paint = new SKPaint
+        {
+            IsAntialias = true
+        };
+
+        var skFont = new SKFont
+        {
+            Size = (float)font.Size,
+            Typeface = SKTypeface.FromFamilyName(font.LatinName)
+        };
+
         const int defaultPaddingSize = 10;
         const int topBottomPadding = defaultPaddingSize * 2;
         var wordMaxY = shapeHeight - topBottomPadding;
 
         var rect = new SKRect(defaultPaddingSize, defaultPaddingSize, shapeWidth - defaultPaddingSize, shapeHeight - defaultPaddingSize);
 
-        var spaceWidth = paint.MeasureText(" ");
+        var spaceWidth = skFont.MeasureText(" ");
 
         var wordX = rect.Left;
-        var wordY = rect.Top + paint.TextSize;
+        var wordY = rect.Top + skFont.Size;
 
         var words = text.Split(' ').ToList();
         for (var i = 0; i < words.Count;)
         {
             var word = words[i];
-            var wordWidth = paint.MeasureText(word);
+            var wordWidth = skFont.MeasureText(word);
             if (wordWidth <= rect.Right - wordX)
             {
-                canvas.DrawText(word, wordX, wordY, paint);
+                canvas.DrawText(word, wordX, wordY, SKTextAlign.Left, skFont, paint);
                 wordX += wordWidth + spaceWidth;
             }
             else
             {
-                wordY += paint.FontSpacing;
+                wordY += skFont.Spacing;
                 wordX = rect.Left;
 
                 if (wordY > wordMaxY)
                 {
-                    if (paint.TextSize <= 5) // Min reduce font size
+                    if (skFont.Size <= 5) // Min reduce font size
                     {
                         break;
                     }
 
-                    paint.TextSize = --paint.TextSize;
+                    skFont.Size = --skFont.Size;
                     wordX = rect.Left;
-                    wordY = rect.Top + paint.TextSize;
+                    wordY = rect.Top + skFont.Size;
                     i = -1;
                 }
                 else
                 {
                     wordX += wordWidth + spaceWidth;
-                    canvas.DrawText(word, wordX, wordY, paint);
+                    canvas.DrawText(word, wordX, wordY, SKTextAlign.Left, skFont, paint);
                 }
             }
 
@@ -437,11 +433,11 @@ internal sealed record TextFrame : ITextBox
         }
 
         const int dpi = 96;
-        var points = Math.Round(paint.TextSize * 72 / dpi, 0);
+        var points = Math.Round(skFont.Size * 72 / dpi, 0);
 
         return (int)points;
     }
-
+    
     private void UpdateShapeHeight(
         decimal textWidth,
         decimal currentBlockWidth,

--- a/test/ShapeCrawler.Tests.Unit/ParagraphTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ParagraphTests.cs
@@ -129,15 +129,15 @@ public class ParagraphTests : SCTest
     {
         // Arrange
         var pres = new Presentation(StreamOf("autoshape-case003.pptx"));
-        var shape = pres.Slides[0].Shapes.GetByName<IShape>("AutoShape 4");
+        var shape = pres.Slide(1).Shape("AutoShape 4");
         var paragraph = shape.TextBox.Paragraphs[0];
             
         // Act
         paragraph.Text = "AutoShape 4 some text";
 
         // Assert
-        shape.Height.Should().BeApproximately(58.81m,0.01m);
-        shape.Y.Should().Be(142m);
+        shape.Height.Should().BeApproximately(51.48m,0.01m);
+        shape.Y.Should().Be(145m);
     }
 
     [Test]

--- a/test/ShapeCrawler.Tests.Unit/TextBoxTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/TextBoxTests.cs
@@ -100,15 +100,15 @@ namespace ShapeCrawler.Tests.Unit
         {
             // Arrange
             var pres = new Presentation(StreamOf("autoshape-case003.pptx"));
-            var shape = pres.Slides[0].Shape("AutoShape 4");
-            var textFrame = shape.TextBox;
+            var shape = pres.Slide(1).Shape("AutoShape 4");
+            var textBox = shape.TextBox;
 
             // Act
-            textFrame.Text = "AutoShape 4 some text";
+            textBox.Text = "AutoShape 4 some text";
 
             // Assert
-            shape.Height.Should().BeApproximately(58.81m, 0.01m);
-            shape.Y.Should().Be(146m);
+            shape.Height.Should().BeApproximately(51.48m, 0.01m);
+            shape.Y.Should().Be(149m);
             pres.Validate();
         }
 
@@ -149,16 +149,15 @@ namespace ShapeCrawler.Tests.Unit
         public void AutofitType_Setter_updates_height()
         {
             // Arrange
-            var pptxStream = StreamOf("autoshape-case003.pptx");
-            var pres = new Presentation(pptxStream);
-            var shape = pres.Slides[0].Shapes.GetByName<IShape>("AutoShape 7");
-            var textFrame = shape.TextBox!;
+            var pres = new Presentation(StreamOf("autoshape-case003.pptx"));
+            var shape = pres.Slide(1).Shape("AutoShape 7");
+            var textBox = shape.TextBox!;
 
             // Act
-            textFrame.AutofitType = AutofitType.Resize;
+            textBox.AutofitType = AutofitType.Resize;
 
             // Assert
-            shape.Height.Should().BeApproximately(44.14m, 0.01m);
+            shape.Height.Should().BeApproximately(40.48m, 0.01m);
             pres.Validate();
         }
 
@@ -292,7 +291,7 @@ namespace ShapeCrawler.Tests.Unit
             shape.TextBox.Text = "Some sentence. Some sentence";
 
             // Assert
-            shape.Height.Should().BeApproximately(114.81m, 0.01m);
+            shape.Height.Should().BeApproximately(93.48m, 0.01m);
         }
 
         [Test]

--- a/test/ShapeCrawler.Tests.Unit/TextBoxTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/TextBoxTests.cs
@@ -4,7 +4,7 @@ using ShapeCrawler.Tests.Unit.Helpers;
 
 namespace ShapeCrawler.Tests.Unit
 {
-    public class TextFrameTests : SCTest
+    public class TextBoxTests : SCTest
     {
         [Test]
         public void Text_Getter_returns_text_of_table_Cell()


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on refactoring the `TextFrame` class to `TextBox`, updating its usage throughout the codebase. It also includes changes to the handling of text dimensions and rendering, improving the text measurement and layout logic.

### Detailed summary
- Renamed `TextFrame` to `TextBox` in multiple files.
- Updated constructors and method signatures to use `TextBox`.
- Changed text measurement logic to utilize a new `Text` struct for width calculations.
- Adjusted text rendering logic to accommodate new font handling.
- Modified test cases to reflect changes in shape dimensions and text properties.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->