### PR TITLE
Add alt text

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Test on .NET 8
-        run: dotnet test -c Release -f net8.0 --verbosity normal
+      - name: Test on .NET 9
+        run: dotnet test -c Release -f net9.0 --verbosity normal
       - name: Create the package
         run: dotnet pack --configuration Release /p:Version=${{ vars.VERSION }}
       - name: Publish the package to nuget.org

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    name: Test on .NET 8.0
+    name: Test on .NET 9.0
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4      

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,4 +12,4 @@ jobs:
       - uses: actions/checkout@v4      
       
       - name: Test
-        run: dotnet test -c Release -f net8.0
+        run: dotnet test -c Release -f net9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog  
 
-## Version 0.56.1 - Unreleased
+## Version 0.57.0 - Unreleased
+🍀Added `IShape.AltText` [#13](https://github.com/ShapeCrawler/ShapeCrawler/issues/13)  
 🐞Fixed `Shape.Rotation` [#9](https://github.com/ShapeCrawler/ShapeCrawler/issues/9)  
 
 ## Version 0.56.0 - 2024-11-22

--- a/src/ShapeCrawler/Charts/BarChartType.cs
+++ b/src/ShapeCrawler/Charts/BarChartType.cs
@@ -1,5 +1,6 @@
-﻿// ReSharper disable CheckNamespace
+﻿#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning restore IDE0130
 
 /// <summary>
 ///     Bar chart type.

--- a/src/ShapeCrawler/Charts/ChartPoints.cs
+++ b/src/ShapeCrawler/Charts/ChartPoints.cs
@@ -6,12 +6,10 @@ using System.Text.RegularExpressions;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Drawing.Charts;
 using DocumentFormat.OpenXml.Packaging;
-using ShapeCrawler.Charts;
 using ShapeCrawler.Excel;
 using C = DocumentFormat.OpenXml.Drawing.Charts;
 
-// ReSharper disable once CheckNamespace
-namespace ShapeCrawler;
+namespace ShapeCrawler.Charts;
 
 internal sealed class ChartPoints : IReadOnlyList<IChartPoint>
 {

--- a/src/ShapeCrawler/Charts/ChartType.cs
+++ b/src/ShapeCrawler/Charts/ChartType.cs
@@ -1,6 +1,6 @@
-﻿// ReSharper disable CheckNamespace
-
+﻿#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning restore IDE0130
 
 /// <summary>
 ///     Chart types.

--- a/src/ShapeCrawler/Charts/IAxesManager.cs
+++ b/src/ShapeCrawler/Charts/IAxesManager.cs
@@ -1,5 +1,6 @@
-﻿// ReSharper disable once CheckNamespace
+﻿#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning restore IDE0130
 
 using C = DocumentFormat.OpenXml.Drawing.Charts;
 

--- a/src/ShapeCrawler/Charts/IAxis.cs
+++ b/src/ShapeCrawler/Charts/IAxis.cs
@@ -1,5 +1,6 @@
-﻿// ReSharper disable once CheckNamespace
+﻿#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning restore IDE0130
 
 using C = DocumentFormat.OpenXml.Drawing.Charts;
 

--- a/src/ShapeCrawler/Charts/ICategories.cs
+++ b/src/ShapeCrawler/Charts/ICategories.cs
@@ -5,13 +5,10 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
-using ShapeCrawler.Charts;
 using ShapeCrawler.Excel;
 using C = DocumentFormat.OpenXml.Drawing.Charts;
 
-// ReSharper disable PossibleMultipleEnumeration
-// ReSharper disable once CheckNamespace
-namespace ShapeCrawler;
+namespace ShapeCrawler.Charts;
 
 internal sealed class Categories : IReadOnlyList<ICategory>
 {
@@ -43,7 +40,7 @@ internal sealed class Categories : IReadOnlyList<ICategory>
             if (indexToCategory.Any())
             {
                 List<KeyValuePair<uint, ICategory>> descOrderedMains =
-                    indexToCategory.OrderByDescending(kvp => kvp.Key).ToList();
+                    [.. indexToCategory.OrderByDescending(kvp => kvp.Key)];
                 foreach (C.StringPoint cStrPoint in cStringPoints)
                 {
                     var index = cStrPoint.Index!.Value;

--- a/src/ShapeCrawler/Charts/ICategory.cs
+++ b/src/ShapeCrawler/Charts/ICategory.cs
@@ -1,5 +1,6 @@
-﻿// ReSharper disable once CheckNamespace
+﻿#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning restore IDE0130
 
 /// <summary>
 ///     Represents a chart category.

--- a/src/ShapeCrawler/Charts/IChartPoint.cs
+++ b/src/ShapeCrawler/Charts/IChartPoint.cs
@@ -1,5 +1,6 @@
-﻿// ReSharper disable once CheckNamespace
+﻿#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning restore IDE0130
 
 /// <summary>
 ///     Represents a chart point.

--- a/src/ShapeCrawler/Charts/ISeries.cs
+++ b/src/ShapeCrawler/Charts/ISeries.cs
@@ -6,9 +6,9 @@ using ShapeCrawler.Excel;
 using ShapeCrawler.Exceptions;
 using C = DocumentFormat.OpenXml.Drawing.Charts;
 
-// ReSharper disable PossibleMultipleEnumeration
-// ReSharper disable once CheckNamespace
+#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning restore IDE0130
 
 /// <summary>
 ///     Represents a chart series.
@@ -59,12 +59,7 @@ internal sealed class Series : ISeries
 
     private string ParseName()
     {
-        var cStrRef = this.cSer.GetFirstChild<C.SeriesText>()?.StringReference;
-        if (cStrRef == null)
-        {
-            throw new SCException($"Series does not have name. Use {nameof(this.HasName)} property to check if series has name.");
-        }
-
+        var cStrRef = (this.cSer.GetFirstChild<C.SeriesText>()?.StringReference) ?? throw new SCException($"Series does not have name. Use {nameof(this.HasName)} property to check if series has name.");
         var fromCache = cStrRef.StringCache?.GetFirstChild<C.StringPoint>() !.Single().InnerText;
 
         return fromCache ?? new ExcelBook(this.sdkChartPart).FormulaValues(cStrRef.Formula!.Text)[0].ToString();

--- a/src/ShapeCrawler/Charts/ISeries.cs
+++ b/src/ShapeCrawler/Charts/ISeries.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
+using ShapeCrawler.Charts;
 using ShapeCrawler.Excel;
 using ShapeCrawler.Exceptions;
 using C = DocumentFormat.OpenXml.Drawing.Charts;

--- a/src/ShapeCrawler/Charts/ISeriesList.cs
+++ b/src/ShapeCrawler/Charts/ISeriesList.cs
@@ -5,8 +5,9 @@ using System.Linq;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 
-// ReSharper disable CheckNamespace
+#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning restore IDE0130
 
 /// <summary>
 ///     Represents a collection of chart series.

--- a/src/ShapeCrawler/Colors/Color.cs
+++ b/src/ShapeCrawler/Colors/Color.cs
@@ -110,7 +110,7 @@ public struct Color
         // 3 or 6 chars without an alpha (rgb): F01, FF0011,
         // 4 or 8 chars with alpha (rgba): F01F, FF0011FF 
         // Ignores hex values starting with "#" character.
-        var value = hex.StartsWith("#", StringComparison.Ordinal) ? hex.Substring(1) : hex;
+        var value = hex.StartsWith("#", StringComparison.Ordinal) ? hex[1..] : hex;
 
         // Parse value.
         (int r, int g, int b, float a) = ParseHexValue(value);

--- a/src/ShapeCrawler/Colors/Color.cs
+++ b/src/ShapeCrawler/Colors/Color.cs
@@ -38,7 +38,7 @@ public struct Color
         : this(red, green, blue, 255)
     {
     }
-    
+
     private Color(int red, int green, int blue, float alpha)
     {
         this.red = red;
@@ -47,7 +47,7 @@ public struct Color
         this.Alpha = alpha;
     }
 
-    private Color((int r, int g, int b, float a) color) 
+    private Color((int r, int g, int b, float a) color)
         : this(color.r, color.g, color.b, color.a)
     {
     }
@@ -74,12 +74,12 @@ public struct Color
     ///     Gets the red value.
     /// </summary>
     public int R => this.red;
-    
+
     /// <summary>
     ///     Gets hexadecimal code.
     /// </summary>
     public string Hex => this.ToString();
-    
+
     /// <summary>
     ///     Gets a value indicating whether the color is solid.
     /// </summary>
@@ -89,7 +89,7 @@ public struct Color
     ///     Gets a value indicating whether the color is transparent.
     /// </summary>
     internal bool IsTransparent => this.Alpha == 0;
-    
+
     /// <summary>
     ///     Creates color hexadecimal code.
     /// </summary>
@@ -106,24 +106,22 @@ public struct Color
     /// <returns>Returns <see langword="true" /> if hex is a valid value. </returns>
     internal static Color FromHex(string hex)
     {
-        // We can try to parse:
-        // 3 or 6 chars without an alpha (rgb): F01, FF0011,
-        // 4 or 8 chars with alpha (rgba): F01F, FF0011FF 
-        // Ignores hex values starting with "#" character.
+#if NETSTANDARD2_0
+        var value = hex.StartsWith("#", StringComparison.Ordinal) ? hex.Substring(1) : hex;
+#else
         var value = hex.StartsWith("#", StringComparison.Ordinal) ? hex[1..] : hex;
+#endif
 
-        // Parse value.
         (int r, int g, int b, float a) = ParseHexValue(value);
 
-        // Creates a new instance
         return new(r, g, b, a);
     }
-    
+
     /// <summary>
     ///     Returns a color of RGBA.
     /// </summary>
     /// <param name="hex">Hex value.</param>
-    /// <returns>A RGBA color.</returns>
+    /// <returns>An RGBA color.</returns>
     private static (int, int, int, float) ParseHexValue(string hex)
     {
         int r;

--- a/src/ShapeCrawler/Colors/ColorType.cs
+++ b/src/ShapeCrawler/Colors/ColorType.cs
@@ -1,6 +1,6 @@
-// ReSharper disable InconsistentNaming
-// ReSharper disable CheckNamespace
+#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning restore IDE0130
 
 /// <summary>
 ///     Color source.

--- a/src/ShapeCrawler/Colors/FontColor.cs
+++ b/src/ShapeCrawler/Colors/FontColor.cs
@@ -160,8 +160,12 @@ internal sealed class FontColor : IFontColor
         var aSolidFill = aRunProperties.SdkASolidFill();
         aSolidFill?.Remove();
 
-        // All hex values are expected to be without hashtag.
-        hex = hex.StartsWith("#", System.StringComparison.Ordinal) ? hex.Substring(1) : hex; // to skip '#'
+#if NETSTANDARD2_0
+        hex = hex.StartsWith("#", System.StringComparison.Ordinal) ? hex.Substring(1) : hex;
+#else
+        hex = hex.StartsWith("#", System.StringComparison.Ordinal) ? hex[1..] : hex; // to skip '#'
+#endif
+      
         var rgbColorModelHex = new A.RgbColorModelHex { Val = hex };
         aSolidFill = new A.SolidFill();
         aSolidFill.Append(rgbColorModelHex);

--- a/src/ShapeCrawler/Colors/FontColor.cs
+++ b/src/ShapeCrawler/Colors/FontColor.cs
@@ -1,6 +1,5 @@
 ﻿using System.Linq;
 using DocumentFormat.OpenXml.Packaging;
-using ShapeCrawler.Colors;
 using ShapeCrawler.Drawing;
 using ShapeCrawler.Extensions;
 using ShapeCrawler.Fonts;
@@ -10,8 +9,7 @@ using ShapeCrawler.Texts;
 using A = DocumentFormat.OpenXml.Drawing;
 using P = DocumentFormat.OpenXml.Presentation;
 
-// ReSharper disable once CheckNamespace
-namespace ShapeCrawler;
+namespace ShapeCrawler.Colors;
 
 internal sealed class FontColor : IFontColor
 {

--- a/src/ShapeCrawler/Colors/IFontColor.cs
+++ b/src/ShapeCrawler/Colors/IFontColor.cs
@@ -1,5 +1,6 @@
-﻿// ReSharper disable once CheckNamespace
+﻿#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning restore IDE0130
 
 /// <summary>
 ///     Represents a color format.

--- a/src/ShapeCrawler/Drawing/FillType.cs
+++ b/src/ShapeCrawler/Drawing/FillType.cs
@@ -1,5 +1,6 @@
-﻿// ReSharper disable once CheckNamespace
+﻿#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning restore IDE0130
 
 /// <summary>
 ///     Fill type.

--- a/src/ShapeCrawler/Drawing/HexParser.cs
+++ b/src/ShapeCrawler/Drawing/HexParser.cs
@@ -56,12 +56,7 @@ internal static class HexParser
 
     private static string? GetByThemeColorScheme(string schemeColor, P.SlideMaster pSlideMaster)
     {
-        var hex = GetThemeColorByString(schemeColor, pSlideMaster);
-
-        if (hex == null)
-        {
-            hex = GetThemeMappedColor(schemeColor, pSlideMaster);
-        }
+        var hex = GetThemeColorByString(schemeColor, pSlideMaster) ?? GetThemeMappedColor(schemeColor, pSlideMaster);
 
         return hex ?? null;
     }

--- a/src/ShapeCrawler/Drawing/IPicture.cs
+++ b/src/ShapeCrawler/Drawing/IPicture.cs
@@ -1,6 +1,6 @@
-﻿// ReSharper disable CheckNamespace
-
+﻿#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning restore IDE0130
 
 /// <summary>
 ///     Represents a picture shape.

--- a/src/ShapeCrawler/Drawing/IShapeFill.cs
+++ b/src/ShapeCrawler/Drawing/IShapeFill.cs
@@ -1,7 +1,8 @@
 ﻿using System.IO;
 
-// ReSharper disable once CheckNamespace
+#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning restore IDE0130
 
 /// <summary>
 ///     Represents a shape fill.

--- a/src/ShapeCrawler/Drawing/IShapeOutline.cs
+++ b/src/ShapeCrawler/Drawing/IShapeOutline.cs
@@ -1,5 +1,6 @@
-﻿// ReSharper disable once CheckNamespace
+﻿#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning restore IDE0130
 
 /// <summary>
 ///     Represents a shape outline.

--- a/src/ShapeCrawler/Drawing/RelationshipId.cs
+++ b/src/ShapeCrawler/Drawing/RelationshipId.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace ShapeCrawler.Drawing;
+
+internal struct RelationshipId
+{
+    public string New()
+    {
+#if NETSTANDARD2_0
+        return $"rId-{Guid.NewGuid().ToString("N").Substring(0, 5)}";
+#else
+        return $"rId-{Guid.NewGuid().ToString("N")[..5]}";
+#endif
+    }
+}

--- a/src/ShapeCrawler/Drawing/ShapeFillImage.cs
+++ b/src/ShapeCrawler/Drawing/ShapeFillImage.cs
@@ -29,7 +29,11 @@ internal sealed class ShapeFillImage : IImage
             this.sdkTypedOpenXmlPart.GetPartsOfType<ImagePart>().Count(x => x == this.sdkImagePart) > 1;
         if (isSharedImagePart)
         {
+#if NETSTANDARD2_0
             var rId = $"rId-{Guid.NewGuid().ToString("N").Substring(0, 5)}";
+#else
+            var rId = $"rId-{Guid.NewGuid().ToString("N")[..5]}";
+#endif
             this.sdkImagePart = this.sdkTypedOpenXmlPart.AddNewPart<ImagePart>("image/png", rId);
             this.aBlip.Embed!.Value = rId;
         }

--- a/src/ShapeCrawler/Drawing/ShapeFillImage.cs
+++ b/src/ShapeCrawler/Drawing/ShapeFillImage.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using DocumentFormat.OpenXml.Packaging;
 using A = DocumentFormat.OpenXml.Drawing;
@@ -29,11 +28,7 @@ internal sealed class ShapeFillImage : IImage
             this.sdkTypedOpenXmlPart.GetPartsOfType<ImagePart>().Count(x => x == this.sdkImagePart) > 1;
         if (isSharedImagePart)
         {
-#if NETSTANDARD2_0
-            var rId = $"rId-{Guid.NewGuid().ToString("N").Substring(0, 5)}";
-#else
-            var rId = $"rId-{Guid.NewGuid().ToString("N")[..5]}";
-#endif
+            var rId = new RelationshipId().New();
             this.sdkImagePart = this.sdkTypedOpenXmlPart.AddNewPart<ImagePart>("image/png", rId);
             this.aBlip.Embed!.Value = rId;
         }

--- a/src/ShapeCrawler/Drawing/SlideBgImage.cs
+++ b/src/ShapeCrawler/Drawing/SlideBgImage.cs
@@ -35,7 +35,12 @@ internal sealed class SlideBgImage : ISlideBgImage
         var isSharedImagePart = imageParts.Count(x => x == sdkImagePart) > 1;
         if (isSharedImagePart)
         {
+#if NETSTANDARD2_0
             var rId = $"rId-{Guid.NewGuid().ToString("N").Substring(0, 5)}";
+#else
+            var rId = $"rId-{Guid.NewGuid().ToString("N")[..5]}";
+#endif
+            
             sdkImagePart = this.sdkSlidePart.AddNewPart<ImagePart>("image/png", rId);
             aBlip.Embed!.Value = rId;
         }
@@ -88,8 +93,12 @@ internal sealed class SlideBgImage : ISlideBgImage
         {
             return pBg.BackgroundProperties!.Descendants<A.Blip>().First();    
         }
-        
-        var rId = $"rId-{Guid.NewGuid().ToString("N").Substring(0, 5)}";
+#if NETSTANDARD2_0
+        var rId = $"rId-{Guid.NewGuid().ToString("N").Substring(0,5)}";    
+#else
+        var rId = $"rId-{Guid.NewGuid().ToString("N")[..5]}";
+#endif
+      
         var aBlip = new A.Blip { Embed = rId };
         var pBackground = new P.Background(
             new P.BackgroundProperties(

--- a/src/ShapeCrawler/Drawing/SlideBgImage.cs
+++ b/src/ShapeCrawler/Drawing/SlideBgImage.cs
@@ -15,16 +15,16 @@ internal sealed class SlideBgImage : ISlideBgImage
 {
     private const string NotPresentedErrorMessage =
         $"Background image is not presented. Use {nameof(ISlideBgImage.Present)} to check.";
-    
+
     private readonly SlidePart sdkSlidePart;
-    
+
     internal SlideBgImage(SlidePart sdkSlidePart)
     {
         this.sdkSlidePart = sdkSlidePart;
     }
 
     public string Mime => this.ParseMime();
-    
+
     public string Name => this.ParseName();
 
     public void Update(Stream stream)
@@ -35,12 +35,7 @@ internal sealed class SlideBgImage : ISlideBgImage
         var isSharedImagePart = imageParts.Count(x => x == sdkImagePart) > 1;
         if (isSharedImagePart)
         {
-#if NETSTANDARD2_0
-            var rId = $"rId-{Guid.NewGuid().ToString("N").Substring(0, 5)}";
-#else
-            var rId = $"rId-{Guid.NewGuid().ToString("N")[..5]}";
-#endif
-            
+            var rId = new RelationshipId().New();
             sdkImagePart = this.sdkSlidePart.AddNewPart<ImagePart>("image/png", rId);
             aBlip.Embed!.Value = rId;
         }
@@ -61,7 +56,7 @@ internal sealed class SlideBgImage : ISlideBgImage
         byte[] sourceBytes = File.ReadAllBytes(file);
         this.Update(sourceBytes);
     }
-    
+
     public byte[] AsByteArray()
     {
         var sdkImagePart = this.SdkImagePartOrNull() ?? throw new SCException(NotPresentedErrorMessage);
@@ -91,14 +86,10 @@ internal sealed class SlideBgImage : ISlideBgImage
         var pBg = this.sdkSlidePart.Slide.CommonSlideData!.Background!;
         if (pBg != null)
         {
-            return pBg.BackgroundProperties!.Descendants<A.Blip>().First();    
+            return pBg.BackgroundProperties!.Descendants<A.Blip>().First();
         }
-#if NETSTANDARD2_0
-        var rId = $"rId-{Guid.NewGuid().ToString("N").Substring(0,5)}";    
-#else
-        var rId = $"rId-{Guid.NewGuid().ToString("N")[..5]}";
-#endif
-      
+
+        var rId = new RelationshipId().New();
         var aBlip = new A.Blip { Embed = rId };
         var pBackground = new P.Background(
             new P.BackgroundProperties(
@@ -111,7 +102,7 @@ internal sealed class SlideBgImage : ISlideBgImage
     private string ParseMime()
     {
         var sdkImagePart = this.SdkImagePartOrNull() ?? throw new SCException(
-                $"Background image is not presented. Use {nameof(ISlideBgImage.Present)} to check.");
+            $"Background image is not presented. Use {nameof(ISlideBgImage.Present)} to check.");
         return sdkImagePart.ContentType;
     }
 
@@ -122,7 +113,7 @@ internal sealed class SlideBgImage : ISlideBgImage
         {
             return null;
         }
-        
+
         var aBlip = pBg.BackgroundProperties!.Descendants<A.Blip>().First();
 
         return (ImagePart)this.sdkSlidePart.GetPartById(aBlip.Embed!.Value!);

--- a/src/ShapeCrawler/Drawing/SlidePictureImage.cs
+++ b/src/ShapeCrawler/Drawing/SlidePictureImage.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using DocumentFormat.OpenXml.Packaging;
 using A = DocumentFormat.OpenXml.Drawing;
@@ -31,12 +30,7 @@ internal sealed class SlidePictureImage : IImage
         var isSharedImagePart = allABlip.Count(x => x.Embed!.Value == this.aBlip.Embed!.Value) > 1;
         if (isSharedImagePart)
         {
-#if NETSTANDARD2_0
-            var rId = $"rId-{Guid.NewGuid().ToString("N").Substring(0,5)}";
-#else
-            var rId = $"rId-{Guid.NewGuid().ToString("N")[..5]}";
-#endif
-            
+            var rId = new RelationshipId().New();
             this.sdkImagePart = this.sdkTypedOpenXmlPart.AddNewPart<ImagePart>("image/png", rId);
             this.aBlip.Embed!.Value = rId;
         }

--- a/src/ShapeCrawler/Drawing/SlidePictureImage.cs
+++ b/src/ShapeCrawler/Drawing/SlidePictureImage.cs
@@ -31,7 +31,12 @@ internal sealed class SlidePictureImage : IImage
         var isSharedImagePart = allABlip.Count(x => x.Embed!.Value == this.aBlip.Embed!.Value) > 1;
         if (isSharedImagePart)
         {
-            var rId = $"rId-{Guid.NewGuid().ToString("N").Substring(0, 5)}";
+#if NETSTANDARD2_0
+            var rId = $"rId-{Guid.NewGuid().ToString("N").Substring(0,5)}";
+#else
+            var rId = $"rId-{Guid.NewGuid().ToString("N")[..5]}";
+#endif
+            
             this.sdkImagePart = this.sdkTypedOpenXmlPart.AddNewPart<ImagePart>("image/png", rId);
             this.aBlip.Embed!.Value = rId;
         }

--- a/src/ShapeCrawler/Drawing/TableCellFill.cs
+++ b/src/ShapeCrawler/Drawing/TableCellFill.cs
@@ -128,11 +128,6 @@ internal class TableCellFill : IShapeFill
                 var hexColor = aRgbColorModelHex.Val!.ToString();
                 this.hexSolidColor = hexColor;
             }
-            else
-            {
-                // TODO: get hex color from scheme
-                var schemeColor = this.sdkASolidFill.SchemeColor;
-            }
 
             this.fillType = FillType.Solid;
         }

--- a/src/ShapeCrawler/Excel/ExcelCellsRange.cs
+++ b/src/ShapeCrawler/Excel/ExcelCellsRange.cs
@@ -29,15 +29,22 @@ internal readonly record struct ExcelCellsRange
     internal List<string> Addresses()
     {
         this.Letter();
-
-        return this.tempList.ToList();
+#if NETSTANDARD2_0
+        return this.tempList.ToList();      
+#else
+        return [.. this.tempList];
+#endif
     }
 
     #region Private Methods
 
     private void Letter(int startIndex = 0)
     {
-        var letterCharacters = this.range.Substring(startIndex).TakeWhile(char.IsLetter);
+#if NETSTANDARD2_0
+        var letterCharacters = this.range.Substring(startIndex).TakeWhile(char.IsLetter);      
+#else
+        var letterCharacters = this.range[startIndex..].TakeWhile(char.IsLetter);
+#endif
         var letterStr = string.Concat(letterCharacters);
         var nextStart = startIndex + letterCharacters.Count();
 
@@ -86,7 +93,11 @@ internal readonly record struct ExcelCellsRange
 
     private int Digit(int startIndex)
     {
-        var digitChars = this.range.Substring(startIndex).TakeWhile(char.IsDigit);
+#if NETSTANDARD2_0
+        var digitChars = this.range.Substring(startIndex).TakeWhile(char.IsDigit);      
+#else
+        var digitChars = this.range[startIndex..].TakeWhile(char.IsDigit);
+#endif
         return int.Parse(string.Concat(digitChars), CultureInfo.CurrentCulture);
     }
 

--- a/src/ShapeCrawler/Excel/ExcelSheet.cs
+++ b/src/ShapeCrawler/Excel/ExcelSheet.cs
@@ -47,10 +47,8 @@ internal record ExcelSheet
             var xRow = xSheetData.Elements<X.Row>().First(r => r.RowIndex! == rowNumber);
             var newXCell = new X.Cell
             {
-                CellReference = address
+                CellReference = address, DataType = new EnumValue<X.CellValues>(type), CellValue = new X.CellValue(value)
             };
-            newXCell.DataType = new EnumValue<X.CellValues>(type);
-            newXCell.CellValue = new X.CellValue(value);
 
             // Cells must be in sequential order according to CellReference. Determine where to insert the new cell.
             X.Cell? refCell = null;

--- a/src/ShapeCrawler/Fonts/IFont.cs
+++ b/src/ShapeCrawler/Fonts/IFont.cs
@@ -1,5 +1,6 @@
-﻿// ReSharper disable CheckNamespace
+﻿#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning restore IDE0130
 
 /// <summary>
 ///    Represents a font.

--- a/src/ShapeCrawler/Fonts/ITextPortionFont.cs
+++ b/src/ShapeCrawler/Fonts/ITextPortionFont.cs
@@ -1,7 +1,8 @@
 ﻿using A = DocumentFormat.OpenXml.Drawing;
 
-// ReSharper disable once CheckNamespace
+#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning restore IDE0130
 
 /// <summary>
 ///     Represents font of a text portion.

--- a/src/ShapeCrawler/Fonts/TextPortionFont.cs
+++ b/src/ShapeCrawler/Fonts/TextPortionFont.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
+using ShapeCrawler.Colors;
 using ShapeCrawler.Extensions;
 using ShapeCrawler.ShapeCollection;
 using ShapeCrawler.Texts;

--- a/src/ShapeCrawler/Positions/IPosition.cs
+++ b/src/ShapeCrawler/Positions/IPosition.cs
@@ -1,5 +1,6 @@
-﻿// ReSharper disable CheckNamespace
+﻿#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning restore IDE0130
 
 /// <summary>
 ///     Represents location of a shape.

--- a/src/ShapeCrawler/Positions/Point.cs
+++ b/src/ShapeCrawler/Positions/Point.cs
@@ -1,5 +1,6 @@
-﻿// ReSharper disable once CheckNamespace
+﻿#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning restore IDE0130
 
 /// <summary>
 ///     Represents a point.

--- a/src/ShapeCrawler/Presentations/PathPresentation.cs
+++ b/src/ShapeCrawler/Presentations/PathPresentation.cs
@@ -1,7 +1,6 @@
 ﻿using System.IO;
-using ShapeCrawler.Presentations;
 
-namespace ShapeCrawler;
+namespace ShapeCrawler.Presentations;
 
 internal sealed record PathPresentation : IValidateable
 {

--- a/src/ShapeCrawler/Presentations/Slide.cs
+++ b/src/ShapeCrawler/Presentations/Slide.cs
@@ -323,7 +323,7 @@ internal sealed class Slide : ISlide
         var customXmlPartStream = this.sdkCustomXmlPart.Value.GetStream();
         using var customXmlStreamReader = new StreamReader(customXmlPartStream);
         var raw = customXmlStreamReader.ReadToEnd();
-#if NET7_0
+#if NET9_0
         return raw[Constants.CustomDataElementName.Length..];
 #else
         return raw.Substring(Constants.CustomDataElementName.Length);

--- a/src/ShapeCrawler/Presentations/Slides.cs
+++ b/src/ShapeCrawler/Presentations/Slides.cs
@@ -6,12 +6,11 @@ using System.Linq;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using ShapeCrawler.Extensions;
-using ShapeCrawler.Presentations;
 using A = DocumentFormat.OpenXml.Drawing;
 using P = DocumentFormat.OpenXml.Presentation;
 using P14 = DocumentFormat.OpenXml.Office2010.PowerPoint;
 
-namespace ShapeCrawler;
+namespace ShapeCrawler.Presentations;
 
 internal sealed class Slides : ISlides
 {

--- a/src/ShapeCrawler/Presentations/Slides.cs
+++ b/src/ShapeCrawler/Presentations/Slides.cs
@@ -138,7 +138,6 @@ internal sealed class Slides : ISlides
 
         this.Add(slide);
         int addedSlideIndex = this.Count - 1;
-        var d = this.readOnlySlides[addedSlideIndex];
         this.readOnlySlides[addedSlideIndex].Number = position;
     }
 
@@ -172,10 +171,7 @@ internal sealed class Slides : ISlides
         // Creates a new TextBody
         if (shape.TextBody is null)
         {
-            return new P.TextBody(new OpenXmlElement[]
-            {
-                new DocumentFormat.OpenXml.Drawing.Paragraph([new DocumentFormat.OpenXml.Drawing.EndParagraphRunProperties()])
-            })
+            return new P.TextBody(new DocumentFormat.OpenXml.Drawing.Paragraph([new DocumentFormat.OpenXml.Drawing.EndParagraphRunProperties()]))
             {
                 BodyProperties = new DocumentFormat.OpenXml.Drawing.BodyProperties(),
                 ListStyle = new DocumentFormat.OpenXml.Drawing.ListStyle(),

--- a/src/ShapeCrawler/SectionCollection/ISection.cs
+++ b/src/ShapeCrawler/SectionCollection/ISection.cs
@@ -4,8 +4,9 @@ using ShapeCrawler.SectionCollection;
 using ShapeCrawler.ShapeCollection;
 using P14 = DocumentFormat.OpenXml.Office2010.PowerPoint;
 
-// ReSharper disable once CheckNamespace
+#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning restore IDE0130
 
 /// <summary>
 ///     Represents a presentation section.

--- a/src/ShapeCrawler/SectionCollection/ISections.cs
+++ b/src/ShapeCrawler/SectionCollection/ISections.cs
@@ -6,8 +6,9 @@ using ShapeCrawler.Exceptions;
 using ShapeCrawler.ShapeCollection;
 using P14 = DocumentFormat.OpenXml.Office2010.PowerPoint;
 
-// ReSharper disable once CheckNamespace
+#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning restore IDE0130
 
 /// <summary>
 ///     Represents a collection of presentation sections.

--- a/src/ShapeCrawler/ShapeCollection/AudioType.cs
+++ b/src/ShapeCrawler/ShapeCollection/AudioType.cs
@@ -1,5 +1,6 @@
-﻿// ReSharper disable once CheckNamespace
+﻿#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning restore IDE0130
 
 /// <summary>
 ///     Represents MIME type.

--- a/src/ShapeCrawler/ShapeCollection/AutofitType.cs
+++ b/src/ShapeCrawler/ShapeCollection/AutofitType.cs
@@ -1,5 +1,6 @@
-﻿// ReSharper disable CheckNamespace
+﻿#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning restore IDE0130
 
 /// <summary>
 ///     Autofit type.

--- a/src/ShapeCrawler/ShapeCollection/Geometry.cs
+++ b/src/ShapeCrawler/ShapeCollection/Geometry.cs
@@ -1,5 +1,6 @@
-﻿// ReSharper disable once CheckNamespace
+﻿#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning restore IDE0130
 
 /// <summary>
 ///     Geometry type.

--- a/src/ShapeCrawler/ShapeCollection/GroupShapes/GroupedShape.cs
+++ b/src/ShapeCrawler/ShapeCollection/GroupShapes/GroupedShape.cs
@@ -1,6 +1,5 @@
 ﻿using System.Linq;
 using DocumentFormat.OpenXml;
-using DocumentFormat.OpenXml.Packaging;
 using ShapeCrawler.Shared;
 using P = DocumentFormat.OpenXml.Presentation;
 
@@ -11,7 +10,7 @@ internal sealed class GroupedShape : IShape
     private readonly P.Shape pShape;
     private readonly AutoShape decoratedShape;
 
-    internal GroupedShape(OpenXmlPart sdkTypedOpenXmlPart, P.Shape pShape, AutoShape decoratedShape)
+    internal GroupedShape(P.Shape pShape, AutoShape decoratedShape)
     {
         this.pShape = pShape;
         this.decoratedShape = decoratedShape;
@@ -120,7 +119,13 @@ internal sealed class GroupedShape : IShape
     public int Id => this.decoratedShape.Id;
 
     public string Name => this.decoratedShape.Name;
-    
+
+    public string AltText
+    {
+        get => this.decoratedShape.AltText;
+        set => this.decoratedShape.AltText = value;
+    }
+
     public bool Hidden => this.decoratedShape.Hidden;
     
     public bool IsPlaceholder => this.decoratedShape.IsPlaceholder;

--- a/src/ShapeCrawler/ShapeCollection/GroupShapes/GroupedShapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/GroupShapes/GroupedShapes.cs
@@ -62,7 +62,6 @@ internal sealed record GroupedShapes : IShapes
                 if (pShape.TextBody is not null)
                 {
                     shape = new GroupedShape(
-                        this.sdkTypedOpenXmlPart,
                         pShape,
                         new AutoShape(
                             this.sdkTypedOpenXmlPart,
@@ -72,7 +71,6 @@ internal sealed record GroupedShapes : IShapes
                 else
                 {
                     shape = new GroupedShape(
-                        this.sdkTypedOpenXmlPart,
                         pShape,
                         new AutoShape(this.sdkTypedOpenXmlPart, pShape));
                 }

--- a/src/ShapeCrawler/ShapeCollection/GroupShapes/IGroupShape.cs
+++ b/src/ShapeCrawler/ShapeCollection/GroupShapes/IGroupShape.cs
@@ -1,5 +1,6 @@
-﻿// ReSharper disable CheckNamespace
+﻿#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning restore IDE0130
 
 /// <summary>
 ///     Represents a group shape on a slide.

--- a/src/ShapeCrawler/ShapeCollection/ILine.cs
+++ b/src/ShapeCrawler/ShapeCollection/ILine.cs
@@ -2,8 +2,9 @@
 using ShapeCrawler.ShapeCollection;
 using P = DocumentFormat.OpenXml.Presentation;
 
-// ReSharper disable CheckNamespace
+#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning restore IDE0130
 
 /// <summary>
 ///     Represents a line shape.

--- a/src/ShapeCrawler/ShapeCollection/IMediaShape.cs
+++ b/src/ShapeCrawler/ShapeCollection/IMediaShape.cs
@@ -5,8 +5,9 @@ using ShapeCrawler.Drawing;
 using ShapeCrawler.ShapeCollection;
 using P = DocumentFormat.OpenXml.Presentation;
 
-// ReSharper disable once CheckNamespace
+#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning restore IDE0130
 
 /// <summary>
 ///     Represents a shape containing video content.

--- a/src/ShapeCrawler/ShapeCollection/IShape.cs
+++ b/src/ShapeCrawler/ShapeCollection/IShape.cs
@@ -1,9 +1,8 @@
-﻿// ReSharper disable once CheckNamespace
+﻿using DocumentFormat.OpenXml;
 
-using DocumentFormat.OpenXml;
-
-// ReSharper disable once CheckNamespace
+#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning restore IDE0130
 
 /// <summary>
 ///     Represents a shape.

--- a/src/ShapeCrawler/ShapeCollection/IShape.cs
+++ b/src/ShapeCrawler/ShapeCollection/IShape.cs
@@ -31,6 +31,11 @@ public interface IShape : IPosition
     string Name { get; }
 
     /// <summary>
+    ///     Gets or sets the alternative text for the shape.
+    /// </summary>
+    string AltText { get; set; }
+
+    /// <summary>
     ///     Gets a value indicating whether the shape is hidden.
     /// </summary>
     bool Hidden { get; }

--- a/src/ShapeCrawler/ShapeCollection/IShapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/IShapes.cs
@@ -1,7 +1,8 @@
 ﻿using System.Collections.Generic;
 
-// ReSharper disable once CheckNamespace
+#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning restore IDE0130
 
 /// <summary>
 ///     Represents a collection of shapes.

--- a/src/ShapeCrawler/ShapeCollection/ISlideShapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/ISlideShapes.cs
@@ -1,8 +1,9 @@
 ﻿using System.IO;
 using ShapeCrawler.Tables;
 
-// ReSharper disable once CheckNamespace
+#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning restore IDE0130
 
 /// <summary>
 ///     Represents a shape collection.

--- a/src/ShapeCrawler/ShapeCollection/ISpacing.cs
+++ b/src/ShapeCrawler/ShapeCollection/ISpacing.cs
@@ -20,16 +20,9 @@ public interface ISpacing
     double? LineSpacingPoints { get; }
 }
 
-internal sealed class Spacing : ISpacing
+internal sealed class Spacing(Paragraph paragraph, A.Paragraph aParagraph): ISpacing
 {
-    private readonly Paragraph paragraph;
-    private readonly A.Paragraph aParagraph;
-
-    public Spacing(Paragraph paragraph, A.Paragraph aParagraph)
-    {
-        this.paragraph = paragraph;
-        this.aParagraph = aParagraph;
-    }
+    private readonly Paragraph paragraph = paragraph;
 
     public double? LineSpacingLines => this.GetLineSpacingLines();
 
@@ -37,7 +30,7 @@ internal sealed class Spacing : ISpacing
 
     private double? GetLineSpacingLines()
     {
-        var aLnSpc = this.aParagraph.ParagraphProperties!.LineSpacing;
+        var aLnSpc = aParagraph.ParagraphProperties!.LineSpacing;
         if (aLnSpc == null)
         {
             return 1;
@@ -54,7 +47,7 @@ internal sealed class Spacing : ISpacing
 
     private double? GetLineSpacingPoints()
     {
-        var aLnSpc = this.aParagraph.ParagraphProperties!.LineSpacing;
+        var aLnSpc = aParagraph.ParagraphProperties!.LineSpacing;
 
         var aSpcPts = aLnSpc?.SpacingPoints;
         if (aSpcPts != null)

--- a/src/ShapeCrawler/ShapeCollection/ISpacing.cs
+++ b/src/ShapeCrawler/ShapeCollection/ISpacing.cs
@@ -1,7 +1,8 @@
 ﻿using A = DocumentFormat.OpenXml.Drawing;
 
-// ReSharper disable once CheckNamespace
+#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning restore IDE0130
 
 /// <summary>
 ///     Represents a spacing of paragraph.

--- a/src/ShapeCrawler/ShapeCollection/Shape.cs
+++ b/src/ShapeCrawler/ShapeCollection/Shape.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Text.RegularExpressions;
 using DocumentFormat.OpenXml;
@@ -55,6 +55,12 @@ internal abstract class Shape : IShape
     public int Id => this.shapeId.Value();
 
     public string Name => this.PShapeTreeElement.NonVisualDrawingProperties().Name!.Value!;
+    
+    public string AltText
+    {
+        get => this.PShapeTreeElement.NonVisualDrawingProperties().Description?.Value ?? string.Empty;
+        set => this.PShapeTreeElement.NonVisualDrawingProperties().Description = new StringValue(value);
+    }
 
     public bool Hidden
     {
@@ -71,13 +77,8 @@ internal abstract class Shape : IShape
     {
         get
         {
-            var pPlaceholderShape = this.PShapeTreeElement.Descendants<P.PlaceholderShape>().FirstOrDefault();
-            if (pPlaceholderShape == null)
-            {
-                throw new SCException(
+            var pPlaceholderShape = this.PShapeTreeElement.Descendants<P.PlaceholderShape>().FirstOrDefault() ?? throw new SCException(
                     $"The shape is not a placeholder. Use {nameof(IShape.IsPlaceholder)} property to check if shape is a placeholder.");
-            }
-            
             var pPlaceholderValue = pPlaceholderShape.Type;
             if (pPlaceholderValue == null)
             {
@@ -140,7 +141,6 @@ internal abstract class Shape : IShape
         }
     } 
         
-
     public virtual Geometry GeometryType => Geometry.Rectangle;
 
     public string? CustomData

--- a/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
@@ -185,7 +185,11 @@ internal sealed class SlideShapes : ISlideShapes
 
         stream.Position = 0;
         mediaDataPart.FeedData(stream);
-        var imgPartRId = $"rId{Guid.NewGuid().ToString().Replace("-", string.Empty).Substring(0, 5)}";
+#if NETSTANDARD2_0
+        var imgPartRId = $"rId{Guid.NewGuid().ToString().Replace("-", string.Empty).Substring(0, 5)}";      
+#else
+        var imgPartRId = $"rId{Guid.NewGuid().ToString().Replace("-", string.Empty)[..5]}";
+#endif
         var imagePart = this.sdkSlidePart.AddNewPart<ImagePart>("image/png", imgPartRId);
         var imageStream = new Assets(Assembly.GetExecutingAssembly()).StreamOf("video-image.bmp");
         imagePart.FeedData(imageStream);

--- a/src/ShapeCrawler/ShapeCollection/WrappedPShapeTree.cs
+++ b/src/ShapeCrawler/ShapeCollection/WrappedPShapeTree.cs
@@ -28,7 +28,12 @@ internal readonly ref struct WrappedPShapeTree
         {
             var currentShapeCollectionSuffixes = existingShapeNames
                 .Where(c => c.StartsWith(copyName, StringComparison.InvariantCulture))
+#if NETSTANDARD2_0
                 .Select(c => c.Substring(copyName.Length))
+#else
+                .Select(c => c[copyName.Length..])
+#endif
+                
                 .ToArray();
 
             // We will try to check numeric suffixes only.

--- a/src/ShapeCrawler/ShapeCrawler.csproj
+++ b/src/ShapeCrawler/ShapeCrawler.csproj
@@ -33,13 +33,13 @@ This library provides a simplified object model on top of the Open XML SDK for m
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <DefineConstants>TRACE</DefineConstants>
     <DocumentationFile>bin\Debug\ShapeCrawler.xml</DocumentationFile>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RunAnalyzers>false</RunAnalyzers>
   </PropertyGroup>  
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DocumentationFile>bin\Release\ShapeCrawler.xml</DocumentationFile>
-    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -66,7 +66,7 @@ This library provides a simplified object model on top of the Open XML SDK for m
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DocumentFormat.OpenXml" Version="3.1.1" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="3.2.0" />
     <PackageReference Include="DocumentFormat.OpenXml.Linq" Version="3.1.1" />
     <PackageReference Include="SkiaSharp" Version="3.0.0-preview.4.1" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.0.0-preview.4.1" />

--- a/src/ShapeCrawler/Shared/IsExternalInit.cs
+++ b/src/ShapeCrawler/Shared/IsExternalInit.cs
@@ -1,6 +1,6 @@
-﻿// ReSharper disable once CheckNamespace
-
-namespace System.Runtime.CompilerServices;
+﻿#pragma warning disable IDE0130
+namespace System.Runtime.CompilerServices; // TODO: This class is still needed?
+#pragma warning restore IDE0130
 
 /// <summary>
 ///     Represents a workaround-class to support 'init' for property in framework older .NET 5.0 (https://bit.ly/2MUL4Wr).

--- a/src/ShapeCrawler/SlideMasters/IMasterSlideNumber.cs
+++ b/src/ShapeCrawler/SlideMasters/IMasterSlideNumber.cs
@@ -3,8 +3,9 @@ using ShapeCrawler.Positions;
 using A = DocumentFormat.OpenXml.Drawing;
 using P = DocumentFormat.OpenXml.Presentation;
 
-// ReSharper disable once CheckNamespace
+#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning restore IDE0130
 
 /// <summary>
 ///     Represents a slide number.

--- a/src/ShapeCrawler/SlideMasters/ISlideMaster.cs
+++ b/src/ShapeCrawler/SlideMasters/ISlideMaster.cs
@@ -6,8 +6,9 @@ using ShapeCrawler.Shared;
 using ShapeCrawler.SlideMasters;
 using P = DocumentFormat.OpenXml.Presentation;
 
-// ReSharper disable CheckNamespace
+#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning restore IDE0130
 
 /// <summary>
 ///     Represents a Slide Master.

--- a/src/ShapeCrawler/SlideMasters/ISlideMasterCollection.cs
+++ b/src/ShapeCrawler/SlideMasters/ISlideMasterCollection.cs
@@ -3,8 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using DocumentFormat.OpenXml.Packaging;
 
-// ReSharper disable once CheckNamespace
+#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning restore IDE0130
 
 /// <summary>
 ///     Represents a collections of Slide Masters.

--- a/src/ShapeCrawler/SlideMasters/ISlideNumberFont.cs
+++ b/src/ShapeCrawler/SlideMasters/ISlideNumberFont.cs
@@ -1,8 +1,9 @@
 ﻿using ShapeCrawler.Texts;
 using A = DocumentFormat.OpenXml.Drawing;
 
-// ReSharper disable CheckNamespace
+#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning restore IDE0130
 
 /// <summary>
 ///     Represents a slide number font.

--- a/src/ShapeCrawler/SlideMasters/ITheme.cs
+++ b/src/ShapeCrawler/SlideMasters/ITheme.cs
@@ -1,7 +1,8 @@
 ﻿using DocumentFormat.OpenXml.Packaging;
 
-// ReSharper disable once CheckNamespace
+#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning restore IDE0130
 
 using A = DocumentFormat.OpenXml.Drawing;
 

--- a/src/ShapeCrawler/SlideMasters/IThemeColorScheme.cs
+++ b/src/ShapeCrawler/SlideMasters/IThemeColorScheme.cs
@@ -1,9 +1,9 @@
-﻿using System.Linq;
-using ShapeCrawler.Drawing;
-
-// ReSharper disable once CheckNamespace
+﻿#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning disable IDE0130
 
+using System.Linq;
+using ShapeCrawler.Drawing;
 using A = DocumentFormat.OpenXml.Drawing;
 
 /// <summary>

--- a/src/ShapeCrawler/SlideMasters/IThemeFontScheme.cs
+++ b/src/ShapeCrawler/SlideMasters/IThemeFontScheme.cs
@@ -1,8 +1,9 @@
 ﻿using DocumentFormat.OpenXml.Packaging;
 using A = DocumentFormat.OpenXml.Drawing;
 
-// ReSharper disable CheckNamespace
+#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning disable IDE0130
 
 /// <summary>
 ///     Represents a settings of theme font.

--- a/src/ShapeCrawler/Tables/IBorder.cs
+++ b/src/ShapeCrawler/Tables/IBorder.cs
@@ -1,5 +1,6 @@
-﻿// ReSharper disable once CheckNamespace
+﻿#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning disable IDE0130
 
 /// <summary>
 ///     Represents a top border of a table cell.

--- a/src/ShapeCrawler/Tables/IColumn.cs
+++ b/src/ShapeCrawler/Tables/IColumn.cs
@@ -2,8 +2,9 @@
 using ShapeCrawler.Units;
 using A = DocumentFormat.OpenXml.Drawing;
 
-// ReSharper disable CheckNamespace
+#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning disable IDE0130
 
 /// <summary>
 ///     Represents a table column.

--- a/src/ShapeCrawler/Tables/ITable.cs
+++ b/src/ShapeCrawler/Tables/ITable.cs
@@ -11,8 +11,9 @@ using SkiaSharp;
 using A = DocumentFormat.OpenXml.Drawing;
 using P = DocumentFormat.OpenXml.Presentation;
 
-// ReSharper disable CheckNamespace
+#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning disable IDE0130
 
 /// <summary>
 ///     Represents a table on a slide.

--- a/src/ShapeCrawler/Tables/ITableCell.cs
+++ b/src/ShapeCrawler/Tables/ITableCell.cs
@@ -4,8 +4,9 @@ using ShapeCrawler.Tables;
 using ShapeCrawler.Texts;
 using A = DocumentFormat.OpenXml.Drawing;
 
-// ReSharper disable once CheckNamespace
+#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning disable IDE0130
 
 /// <summary>
 ///     Represents a table cell.

--- a/src/ShapeCrawler/Tables/ITableRow.cs
+++ b/src/ShapeCrawler/Tables/ITableRow.cs
@@ -5,8 +5,9 @@ using ShapeCrawler.Shared;
 using A = DocumentFormat.OpenXml.Drawing;
 using P = DocumentFormat.OpenXml.Presentation;
 
-// ReSharper disable CheckNamespace
+#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning disable IDE0130
 
 /// <summary>
 ///     Represents table row.

--- a/src/ShapeCrawler/Tables/ITableRows.cs
+++ b/src/ShapeCrawler/Tables/ITableRows.cs
@@ -7,8 +7,9 @@ using ShapeCrawler.Extensions;
 using A = DocumentFormat.OpenXml.Drawing;
 using P = DocumentFormat.OpenXml.Presentation;
 
-// ReSharper disable once CheckNamespace
+#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning disable IDE0130
 
 /// <summary>
 ///     Represents a table row collection.

--- a/src/ShapeCrawler/Texts/Bullet.cs
+++ b/src/ShapeCrawler/Texts/Bullet.cs
@@ -5,8 +5,9 @@ using DocumentFormat.OpenXml.Drawing;
 using ShapeCrawler.Exceptions;
 using A = DocumentFormat.OpenXml.Drawing;
 
-// ReSharper disable once CheckNamespace
+#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning restore IDE0130
 
 /// <summary>
 ///     Represents a paragraph bullet.
@@ -211,12 +212,7 @@ public sealed class Bullet // TODO: extract interface
             return null;
         }
 
-        A.CharacterBullet? aCharBullet = this.aParagraphProperties.GetFirstChild<A.CharacterBullet>();
-        if (aCharBullet == null)
-        {
-            throw new RuntimeDefinedPropertyException($"This is not {nameof(BulletType.Character)} type bullet.");
-        }
-
+        A.CharacterBullet? aCharBullet = this.aParagraphProperties.GetFirstChild<A.CharacterBullet>() ?? throw new RuntimeDefinedPropertyException($"This is not {nameof(BulletType.Character)} type bullet.");
         return aCharBullet.Char?.Value;
     }
 

--- a/src/ShapeCrawler/Texts/BulletType.cs
+++ b/src/ShapeCrawler/Texts/BulletType.cs
@@ -1,5 +1,6 @@
-﻿// ReSharper disable once CheckNamespace
+﻿#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning disable IDE0130
 
 /// <summary>
 ///     Paragraph bullet type.

--- a/src/ShapeCrawler/Texts/Field.cs
+++ b/src/ShapeCrawler/Texts/Field.cs
@@ -107,11 +107,7 @@ internal sealed class Field : IParagraphPortion
 
     private void SetHyperlink(string? url)
     {
-        var runProperties = this.aText!.PreviousSibling<A.RunProperties>();
-        if (runProperties == null)
-        {
-            runProperties = new A.RunProperties();
-        }
+        var runProperties = this.aText!.PreviousSibling<A.RunProperties>() ?? new A.RunProperties();
 
         var hyperlink = runProperties.GetFirstChild<A.HyperlinkOnClick>();
         if (hyperlink == null)

--- a/src/ShapeCrawler/Texts/IParagraph.cs
+++ b/src/ShapeCrawler/Texts/IParagraph.cs
@@ -7,8 +7,9 @@ using ShapeCrawler.Texts;
 using A = DocumentFormat.OpenXml.Drawing;
 using P = DocumentFormat.OpenXml.Presentation;
 
-// ReSharper disable CheckNamespace
+#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning disable IDE0130
 
 /// <summary>
 ///     Represents a paragraph.

--- a/src/ShapeCrawler/Texts/IParagraph.cs
+++ b/src/ShapeCrawler/Texts/IParagraph.cs
@@ -107,8 +107,7 @@ internal sealed class Paragraph : IParagraph
             var textLines = value.Split(Environment.NewLine);
 #endif
 
-            var basePortion = new TextParagraphPortion(this.sdkTypedOpenXmlPart, baseARun);
-            basePortion.Text = textLines.First();
+            var basePortion = new TextParagraphPortion(this.sdkTypedOpenXmlPart, baseARun) { Text = textLines.First() };
 
             foreach (var textLine in textLines.Skip(1))
             {

--- a/src/ShapeCrawler/Texts/IParagraphPortion.cs
+++ b/src/ShapeCrawler/Texts/IParagraphPortion.cs
@@ -1,5 +1,6 @@
-﻿// ReSharper disable CheckNamespace
+﻿#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning disable IDE0130
 
 /// <summary>
 ///     Represents a portion of a paragraph.

--- a/src/ShapeCrawler/Texts/IParagraphPortions.cs
+++ b/src/ShapeCrawler/Texts/IParagraphPortions.cs
@@ -8,8 +8,9 @@ using ShapeCrawler.Exceptions;
 using ShapeCrawler.Texts;
 using A = DocumentFormat.OpenXml.Drawing;
 
-// ReSharper disable once CheckNamespace
+#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning disable IDE0130
 
 /// <summary>
 ///     Represents collection of paragraph text portions.

--- a/src/ShapeCrawler/Texts/IParagraphs.cs
+++ b/src/ShapeCrawler/Texts/IParagraphs.cs
@@ -5,8 +5,9 @@ using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using A = DocumentFormat.OpenXml.Drawing;
 
-// ReSharper disable CheckNamespace
+#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning disable IDE0130
 
 /// <summary>
 ///     Represents a collection of paragraphs.

--- a/src/ShapeCrawler/Texts/TextParagraphPortion.cs
+++ b/src/ShapeCrawler/Texts/TextParagraphPortion.cs
@@ -118,11 +118,7 @@ internal sealed class TextParagraphPortion : IParagraphPortion
 
     private void SetHyperlink(string? url)
     {
-        var runProperties = this.AText.PreviousSibling<A.RunProperties>();
-        if (runProperties == null)
-        {
-            runProperties = new A.RunProperties();
-        }
+        var runProperties = this.AText.PreviousSibling<A.RunProperties>() ?? new A.RunProperties();
 
         var hyperlink = runProperties.GetFirstChild<A.HyperlinkOnClick>();
         if (hyperlink == null)

--- a/src/ShapeCrawler/Texts/TextVerticalAlignment.cs
+++ b/src/ShapeCrawler/Texts/TextVerticalAlignment.cs
@@ -1,6 +1,6 @@
-﻿// ReSharper disable once CheckNamespace
-
+﻿#pragma warning disable IDE0130
 namespace ShapeCrawler;
+#pragma warning disable IDE0130
 
 /// <summary>
 ///     Text Vertical alignment.

--- a/test/ShapeCrawler.Tests.Integration/ShapeCrawler.Tests.Integration.csproj
+++ b/test/ShapeCrawler.Tests.Integration/ShapeCrawler.Tests.Integration.csproj
@@ -5,6 +5,7 @@
         <Configurations>Debug;Release</Configurations>
         <Platforms>AnyCPU</Platforms>
         <OutputType>Library</OutputType>
+        <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)' == 'Debug'">

--- a/test/ShapeCrawler.Tests.Integration/ShapeCrawler.Tests.Integration.csproj
+++ b/test/ShapeCrawler.Tests.Integration/ShapeCrawler.Tests.Integration.csproj
@@ -1,23 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-
         <IsPackable>false</IsPackable>
-
         <Configurations>Debug;Release</Configurations>
-
         <Platforms>AnyCPU</Platforms>
-
         <OutputType>Library</OutputType>
-        <LangVersion>11</LangVersion>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-      <TargetFramework>net8.0</TargetFramework>
+      <TargetFramework>net9.0</TargetFramework>
     </PropertyGroup>
   
     <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-      <TargetFrameworks>net8.0;net472;net48</TargetFrameworks>
+      <TargetFrameworks>net9.0;net472;net48</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/ShapeCrawler.Tests.Unit/ShapeCrawler.Tests.Unit.csproj
+++ b/test/ShapeCrawler.Tests.Unit/ShapeCrawler.Tests.Unit.csproj
@@ -4,6 +4,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">

--- a/test/ShapeCrawler.Tests.Unit/ShapeCrawler.Tests.Unit.csproj
+++ b/test/ShapeCrawler.Tests.Unit/ShapeCrawler.Tests.Unit.csproj
@@ -2,18 +2,17 @@
 
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>10</LangVersion>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <WarningLevel>0</WarningLevel>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-    <TargetFrameworks>net8.0;net472;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net472;net48</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/ShapeCrawler.Tests.Unit/TableTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/TableTests.cs
@@ -869,4 +869,19 @@ public class TableTests : SCTest
         table[rowIdx1, colIdx1].IsMergedCell.Should().BeTrue();
         table[rowIdx2, colIdx2].IsMergedCell.Should().BeTrue();
     }
+    
+    [Test]
+    public void AltText_Setter_sets_alternative_text()
+    {
+        // Arrange
+        var pres = new Presentation(StreamOf("table-case001.pptx"));
+        var table = pres.Slide(1).Table("Table 1");
+
+        // Act
+        table.AltText = "Alt text";
+
+        // Assert
+        table.AltText.Should().Be("Alt text");
+        pres.Validate();
+    }
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR primarily focuses on code refactoring and updates across various files in the `ShapeCrawler` project. It includes namespace adjustments, the introduction of alternative text for shapes, and updates to the test framework.

### Detailed summary
- Added `AltText` property to `IShape` interface and its implementations.
- Updated namespaces to follow a consistent format.
- Changed target framework from `.NET 8.0` to `.NET 9.0`.
- Refactored hex color handling for consistency.
- Introduced new `RelationshipId` struct for generating relationship IDs.
- Added tests for `AltText` functionality.
- Updated the changelog for versioning.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->