### PR TITLE
Fix variable name for .NET Standard 2.0

### DIFF
--- a/src/ShapeCrawler/Presentations/PresentationCore.cs
+++ b/src/ShapeCrawler/Presentations/PresentationCore.cs
@@ -95,7 +95,7 @@ internal sealed class PresentationCore
         sdkErrors = sdkErrors.Where(errorInfo => !nonCriticalErrorDesc.Contains(errorInfo.Description));
 
 #if NETSTANDARD2_0
-        errors = errors.DistinctBy(x => new { x.Description, x.Path?.XPath }).ToList();
+        sdkErrors = sdkErrors.DistinctBy(x => new { x.Description, x.Path?.XPath }).ToList();
 #else
         sdkErrors = sdkErrors.DistinctBy(x => new { x.Description, x.Path?.XPath }).ToList();
 #endif


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR modifies the handling of error collections in the `src/ShapeCrawler/Presentations/PresentationCore.cs` file by ensuring that the `sdkErrors` variable is consistently used instead of `errors`, regardless of the target framework.

### Detailed summary
- Replaced `errors` with `sdkErrors` in the `#if NETSTANDARD2_0` block.
- Ensured `sdkErrors` is used in both the `#if` and `#else` sections for consistency.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->