### PR TITLE
Fix Color.FromHex()

### DIFF
--- a/src/ShapeCrawler/Colors/Color.cs
+++ b/src/ShapeCrawler/Colors/Color.cs
@@ -104,7 +104,7 @@ public struct Color
     /// </summary>
     /// <param name="hex">Hex value.</param>
     /// <returns>Returns <see langword="true" /> if hex is a valid value. </returns>
-    internal static Color FromHex(string hex)
+    public static Color FromHex(string hex)
     {
 #if NETSTANDARD2_0
         var value = hex.StartsWith("#", StringComparison.Ordinal) ? hex.Substring(1) : hex;

--- a/src/ShapeCrawler/Colors/Color.cs
+++ b/src/ShapeCrawler/Colors/Color.cs
@@ -91,15 +91,6 @@ public struct Color
     internal bool IsTransparent => this.Alpha == 0;
 
     /// <summary>
-    ///     Creates color hexadecimal code.
-    /// </summary>
-    public override string ToString()
-    {
-        // String representation ignores alpha value
-        return $"{this.R:X2}{this.G:X2}{this.B:X2}";
-    }
-
-    /// <summary>
     ///     Creates color from Hex value.
     /// </summary>
     /// <param name="hex">Hex value.</param>
@@ -116,7 +107,16 @@ public struct Color
 
         return new(r, g, b, a);
     }
-
+    
+    /// <summary>
+    ///     Creates color hexadecimal code.
+    /// </summary>
+    public override string ToString()
+    {
+        // String representation ignores alpha value
+        return $"{this.R:X2}{this.G:X2}{this.B:X2}";
+    }
+    
     /// <summary>
     ///     Returns a color of RGBA.
     /// </summary>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on modifying the `Color` class in `src/ShapeCrawler/Colors/Color.cs` by changing the access modifier of the `FromHex` method, reordering the `ToString` method, and adding XML documentation for clarity.

### Detailed summary
- Changed access modifier of `FromHex` from `internal` to `public`.
- Moved the `ToString` method to a later position in the class.
- Added XML documentation for the `ToString` method.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->