### PR TITLE
Add name setter to IShape.cs fixing #802

### DIFF
--- a/src/ShapeCrawler/ShapeCollection/GroupShapes/GroupedShape.cs
+++ b/src/ShapeCrawler/ShapeCollection/GroupShapes/GroupedShape.cs
@@ -119,7 +119,11 @@ internal sealed class GroupedShape : IShape
 
     public int Id => this.decoratedShape.Id;
 
-    public string Name => this.decoratedShape.Name;
+    public string Name
+    {
+        get => this.decoratedShape.Name;
+        set => this.decoratedShape.Name = value;
+    }
 
     public string AltText
     {

--- a/src/ShapeCrawler/ShapeCollection/IShape.cs
+++ b/src/ShapeCrawler/ShapeCollection/IShape.cs
@@ -23,11 +23,11 @@ public interface IShape : IPosition
     ///     Gets identifier of the shape.
     /// </summary>
     int Id { get; }
-
+    
     /// <summary>
-    ///     Gets name of the shape.
+    ///    Gets or sets the name of the shape.
     /// </summary>
-    string Name { get; }
+    string Name { get; set; }
 
     /// <summary>
     ///     Gets or sets the alternative text for the shape.

--- a/src/ShapeCrawler/ShapeCollection/Shape.cs
+++ b/src/ShapeCrawler/ShapeCollection/Shape.cs
@@ -55,8 +55,12 @@ internal abstract class Shape : IShape
 
     public int Id => this.shapeId.Value();
 
-    public string Name => this.PShapeTreeElement.NonVisualDrawingProperties().Name!.Value!;
-    
+    public string Name
+    {
+        get => this.PShapeTreeElement.NonVisualDrawingProperties().Name!.Value!;
+        set => this.PShapeTreeElement.NonVisualDrawingProperties().Name = new StringValue(value);
+    }
+
     public string AltText
     {
         get => this.PShapeTreeElement.NonVisualDrawingProperties().Description?.Value ?? string.Empty;

--- a/test/ShapeCrawler.Tests.Unit/ShapeTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeTests.cs
@@ -672,4 +672,50 @@ public class ShapeTests : SCTest
         shape.CornerSize.Should().Be(expected);
         pres.Validate();
     }
+    
+    [Test]
+    public void Name_Setter_sets_shape_name()
+    {
+        // Arrange
+        var pptx = StreamOf("006_1 slides.pptx");
+        var pres = new Presentation(pptx);
+        var stream = new MemoryStream();
+        var shape = pres.Slides[0].Shapes.GetByName("Shape 1");
+
+        // Act
+        shape.Name = "New Name";
+
+        // Assert
+        pres.SaveAs(stream);
+        pres = new Presentation(stream);
+        shape = pres.Slides[0].Shapes.GetByName("New Name");
+        shape.Name.Should().Be("New Name");
+        pres.Validate();
+    }
+    
+    [Test]
+    public void Name_Setter_sets_grouped_shape_name()
+    {
+        // Arrange
+        var pptx = StreamOf("autoshape-grouping.pptx");
+        var pres = new Presentation(pptx);
+        var stream = new MemoryStream();
+        var groupShape = pres.Slides[0].Shapes.GetByName<IGroupShape>("Group 2");
+        var shape1 = groupShape.Shapes.GetByName("Shape 1");
+        var shape2 = groupShape.Shapes.GetByName("Shape 2");
+
+        // Act
+        groupShape.Name = "New Group Name";
+
+        // Assert
+        pres.SaveAs(stream);
+        pres = new Presentation(stream);
+        groupShape = pres.Slides[0].Shapes.GetByName<IGroupShape>("New Group Name");
+        shape1 = groupShape.Shapes.GetByName("Shape 1");
+        shape2 = groupShape.Shapes.GetByName("Shape 2");
+        groupShape.Name.Should().Be("New Group Name");
+        shape1.Name.Should().Be("Shape 1");
+        shape2.Name.Should().Be("Shape 2");
+        pres.Validate();
+    }
 }

--- a/test/ShapeCrawler.Tests.Unit/ShapeTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeTests.cs
@@ -701,8 +701,6 @@ public class ShapeTests : SCTest
         var pres = new Presentation(pptx);
         var stream = new MemoryStream();
         var groupShape = pres.Slides[0].Shapes.GetByName<IGroupShape>("Group 2");
-        var shape1 = groupShape.Shapes.GetByName("Shape 1");
-        var shape2 = groupShape.Shapes.GetByName("Shape 2");
 
         // Act
         groupShape.Name = "New Group Name";
@@ -711,11 +709,7 @@ public class ShapeTests : SCTest
         pres.SaveAs(stream);
         pres = new Presentation(stream);
         groupShape = pres.Slides[0].Shapes.GetByName<IGroupShape>("New Group Name");
-        shape1 = groupShape.Shapes.GetByName("Shape 1");
-        shape2 = groupShape.Shapes.GetByName("Shape 2");
         groupShape.Name.Should().Be("New Group Name");
-        shape1.Name.Should().Be("Shape 1");
-        shape2.Name.Should().Be("Shape 2");
         pres.Validate();
     }
 }


### PR DESCRIPTION
Added a setter to the name prop on IShape, implemented this in the Shape and GroupedShape classes and added tests. This should fix #802.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a property setter for the `Name` property in various classes, allowing the name of shapes and grouped shapes to be modified. It also adds unit tests to verify that setting the name works correctly.

### Detailed summary
- Changed `Name` property in `GroupedShape` from a getter-only to a getter and setter.
- Updated `Name` property in `IShape` to be a getter and setter.
- Modified `Name` property in `Shape` to include a setter.
- Added unit tests to validate the functionality of the `Name` setter for shapes and grouped shapes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->