### PR TITLE
Add table style options

### DIFF
--- a/src/ShapeCrawler/Tables/ITable.cs
+++ b/src/ShapeCrawler/Tables/ITable.cs
@@ -36,9 +36,9 @@ public interface ITable : IShape
     ITableStyle TableStyle { get; set; }
 
     /// <summary>
-    ///    Gets or sets the table style options.
+    ///    Gets the table style options.
     /// </summary>
-    ITableStyleOptions TableStyleOptions { get; set; }
+    ITableStyleOptions TableStyleOptions { get; }
 
     /// <summary>
     ///     Gets cell by row and column indexes.
@@ -81,13 +81,13 @@ internal sealed class Table : CopyableShape, ITable
 {
     private readonly P.GraphicFrame pGraphicFrame;
     private ITableStyle? tableStyle;
-    private ITableStyleOptions? tableStyleOptions;
 
     internal Table(OpenXmlPart sdkTypedOpenXmlPart, OpenXmlCompositeElement pShapeTreeElement)
         : base(sdkTypedOpenXmlPart, pShapeTreeElement)
     {
         this.pGraphicFrame = (P.GraphicFrame)pShapeTreeElement;
         this.Rows = new TableRows(sdkTypedOpenXmlPart, this.pGraphicFrame);
+        this.TableStyleOptions = new TableStyleOptions(this.ATable.TableProperties!);
     }
 
     public override ShapeType ShapeType => ShapeType.Table;
@@ -102,11 +102,7 @@ internal sealed class Table : CopyableShape, ITable
         set => this.SetTableStyle(value);
     }
     
-    public ITableStyleOptions TableStyleOptions
-    {
-        get => this.GetTableStyleOptions();
-        set => this.SetTableStyleOptions(value);
-    }
+    public ITableStyleOptions TableStyleOptions { get; init; }
 
     public override bool Removeable => true;
 
@@ -232,43 +228,6 @@ internal sealed class Table : CopyableShape, ITable
 
         return this.tableStyle;
     }
-    
-    private void SetTableStyleOptions(ITableStyleOptions options)
-    {
-        this.ATable.TableProperties!.FirstRow = new BooleanValue(options.HasHeaderRow);
-        this.ATable.TableProperties!.FirstColumn = new BooleanValue(options.HasFirstColumn);
-        this.ATable.TableProperties!.LastRow = new BooleanValue(options.HasTotalRow);
-        this.ATable.TableProperties!.LastColumn = new BooleanValue(options.HasLastColumn);
-        this.ATable.TableProperties!.BandRow = new BooleanValue(options.HasBandedRows);
-        this.ATable.TableProperties!.BandColumn = new BooleanValue(options.HasBandedColumns);
-        
-        this.tableStyleOptions = options;
-    }
-    
-    private ITableStyleOptions GetTableStyleOptions()
-    {
-        if (this.tableStyleOptions is null)
-        {
-            var tableProperties = this.ATable.TableProperties!;
-            var hasHeaderRow = tableProperties.FirstRow?.Value ?? false;
-            var hasTotalRow = tableProperties.LastRow?.Value ?? false;
-            var hasBandedRows = tableProperties.BandRow?.Value ?? false;
-            var hasFirstColumn = tableProperties.FirstColumn?.Value ?? false;
-            var hasLastColumn = tableProperties.LastColumn?.Value ?? false;
-            var hasBandedColumns = tableProperties.BandColumn?.Value ?? false;
-
-            this.tableStyleOptions = new TableStyleOptions(
-                hasHeaderRow,
-                hasTotalRow,
-                hasBandedRows,
-                hasFirstColumn,
-                hasLastColumn,
-                hasBandedColumns);
-        }
-        
-        return this.tableStyleOptions;
-    }
-    
 
     private void RemoveRowIfNeeded()
     {

--- a/src/ShapeCrawler/Tables/ITable.cs
+++ b/src/ShapeCrawler/Tables/ITable.cs
@@ -36,6 +36,11 @@ public interface ITable : IShape
     ITableStyle TableStyle { get; set; }
 
     /// <summary>
+    ///    Gets or sets the table style options.
+    /// </summary>
+    ITableStyleOptions TableStyleOptions { get; set; }
+
+    /// <summary>
     ///     Gets cell by row and column indexes.
     /// </summary>
     ITableCell this[int rowIndex, int columnIndex] { get; }
@@ -76,6 +81,7 @@ internal sealed class Table : CopyableShape, ITable
 {
     private readonly P.GraphicFrame pGraphicFrame;
     private ITableStyle? tableStyle;
+    private ITableStyleOptions? tableStyleOptions;
 
     internal Table(OpenXmlPart sdkTypedOpenXmlPart, OpenXmlCompositeElement pShapeTreeElement)
         : base(sdkTypedOpenXmlPart, pShapeTreeElement)
@@ -94,6 +100,12 @@ internal sealed class Table : CopyableShape, ITable
     {
         get => this.GetTableStyle();
         set => this.SetTableStyle(value);
+    }
+    
+    public ITableStyleOptions TableStyleOptions
+    {
+        get => this.GetTableStyleOptions();
+        set => this.SetTableStyleOptions(value);
     }
 
     public override bool Removeable => true;
@@ -220,6 +232,43 @@ internal sealed class Table : CopyableShape, ITable
 
         return this.tableStyle;
     }
+    
+    private void SetTableStyleOptions(ITableStyleOptions options)
+    {
+        this.ATable.TableProperties!.FirstRow = new BooleanValue(options.HasHeaderRow);
+        this.ATable.TableProperties!.FirstColumn = new BooleanValue(options.HasFirstColumn);
+        this.ATable.TableProperties!.LastRow = new BooleanValue(options.HasTotalRow);
+        this.ATable.TableProperties!.LastColumn = new BooleanValue(options.HasLastColumn);
+        this.ATable.TableProperties!.BandRow = new BooleanValue(options.HasBandedRows);
+        this.ATable.TableProperties!.BandColumn = new BooleanValue(options.HasBandedColumns);
+        
+        this.tableStyleOptions = options;
+    }
+    
+    private ITableStyleOptions GetTableStyleOptions()
+    {
+        if (this.tableStyleOptions is null)
+        {
+            var tableProperties = this.ATable.TableProperties!;
+            var hasHeaderRow = tableProperties.FirstRow?.Value ?? false;
+            var hasTotalRow = tableProperties.LastRow?.Value ?? false;
+            var hasBandedRows = tableProperties.BandRow?.Value ?? false;
+            var hasFirstColumn = tableProperties.FirstColumn?.Value ?? false;
+            var hasLastColumn = tableProperties.LastColumn?.Value ?? false;
+            var hasBandedColumns = tableProperties.BandColumn?.Value ?? false;
+
+            this.tableStyleOptions = new TableStyleOptions(
+                hasHeaderRow,
+                hasTotalRow,
+                hasBandedRows,
+                hasFirstColumn,
+                hasLastColumn,
+                hasBandedColumns);
+        }
+        
+        return this.tableStyleOptions;
+    }
+    
 
     private void RemoveRowIfNeeded()
     {

--- a/src/ShapeCrawler/Tables/ITableStyleOptions.cs
+++ b/src/ShapeCrawler/Tables/ITableStyleOptions.cs
@@ -1,0 +1,74 @@
+namespace ShapeCrawler.Tables;
+
+/// <summary>
+///     Represents table style options.
+/// </summary>
+public interface ITableStyleOptions
+{
+    /// <summary>
+    ///     Gets a value indicating whether table has header row.
+    /// </summary>
+    public bool HasHeaderRow { get; }
+    
+    /// <summary>
+    ///     Gets a value indicating whether table has total row.
+    /// </summary>
+    public bool HasTotalRow { get; }
+    
+    /// <summary>
+    ///     Gets a value indicating whether table has banded rows.
+    /// </summary>
+    public bool HasBandedRows { get; }
+    
+    /// <summary>
+    ///     Gets a value indicating whether table has first column.
+    /// </summary>
+    public bool HasFirstColumn { get; }
+    
+    /// <summary>
+    ///     Gets a value indicating whether table has last column.
+    /// </summary>
+    public bool HasLastColumn { get; }
+    
+    /// <summary>
+    ///     Gets a value indicating whether table has banded columns.
+    /// </summary>
+    public bool HasBandedColumns { get; }
+}
+
+/// <summary>
+///    Represents table style options.
+/// </summary>
+/// <param name="hasHeaderRow"></param>
+/// <param name="hasTotalRow"></param>
+/// <param name="hasBandedRows"></param>
+/// <param name="hasFirstColumn"></param>
+/// <param name="hasLastColumn"></param>
+/// <param name="hasBandedColumns"></param>
+public class TableStyleOptions(
+    bool hasHeaderRow = false,
+    bool hasTotalRow = false,
+    bool hasBandedRows = false,
+    bool hasFirstColumn = false,
+    bool hasLastColumn = false,
+    bool hasBandedColumns = false)
+    : ITableStyleOptions
+{
+    /// <inheritdoc/>
+    public bool HasHeaderRow { get; } = hasHeaderRow;
+    
+    /// <inheritdoc/>
+    public bool HasTotalRow { get; } = hasTotalRow;
+    
+    /// <inheritdoc/>
+    public bool HasBandedRows { get; } = hasBandedRows;
+    
+    /// <inheritdoc/>
+    public bool HasFirstColumn { get; } = hasFirstColumn;
+    
+    /// <inheritdoc/>
+    public bool HasLastColumn { get; } = hasLastColumn;
+    
+    /// <inheritdoc/>
+    public bool HasBandedColumns { get; } = hasBandedColumns;
+}

--- a/src/ShapeCrawler/Tables/ITableStyleOptions.cs
+++ b/src/ShapeCrawler/Tables/ITableStyleOptions.cs
@@ -1,3 +1,5 @@
+using DocumentFormat.OpenXml.Drawing;
+
 namespace ShapeCrawler.Tables;
 
 /// <summary>
@@ -6,69 +8,81 @@ namespace ShapeCrawler.Tables;
 public interface ITableStyleOptions
 {
     /// <summary>
-    ///     Gets a value indicating whether table has header row.
+    ///     Gets or sets a value indicating whether table has header row.
     /// </summary>
-    public bool HasHeaderRow { get; }
+    public bool HasHeaderRow { get; set; }
     
     /// <summary>
-    ///     Gets a value indicating whether table has total row.
+    ///     Gets or sets a value indicating whether table has total row.
     /// </summary>
-    public bool HasTotalRow { get; }
+    public bool HasTotalRow { get; set; }
     
     /// <summary>
-    ///     Gets a value indicating whether table has banded rows.
+    ///     Gets or sets a value indicating whether table has banded rows.
     /// </summary>
-    public bool HasBandedRows { get; }
+    public bool HasBandedRows { get; set; }
     
     /// <summary>
-    ///     Gets a value indicating whether table has first column.
+    ///     Gets or sets a value indicating whether table has first column.
     /// </summary>
-    public bool HasFirstColumn { get; }
+    public bool HasFirstColumn { get; set; }
     
     /// <summary>
-    ///     Gets a value indicating whether table has last column.
+    ///     Gets or sets a value indicating whether table has last column.
     /// </summary>
-    public bool HasLastColumn { get; }
+    public bool HasLastColumn { get; set; }
     
     /// <summary>
-    ///     Gets a value indicating whether table has banded columns.
+    ///     Gets or sets a value indicating whether table has banded columns.
     /// </summary>
-    public bool HasBandedColumns { get; }
+    public bool HasBandedColumns { get; set; }
 }
 
 /// <summary>
 ///    Represents table style options.
 /// </summary>
-/// <param name="hasHeaderRow"></param>
-/// <param name="hasTotalRow"></param>
-/// <param name="hasBandedRows"></param>
-/// <param name="hasFirstColumn"></param>
-/// <param name="hasLastColumn"></param>
-/// <param name="hasBandedColumns"></param>
-public class TableStyleOptions(
-    bool hasHeaderRow = false,
-    bool hasTotalRow = false,
-    bool hasBandedRows = false,
-    bool hasFirstColumn = false,
-    bool hasLastColumn = false,
-    bool hasBandedColumns = false)
+internal sealed class TableStyleOptions(TableProperties tableProperties)
     : ITableStyleOptions
 {
     /// <inheritdoc/>
-    public bool HasHeaderRow { get; } = hasHeaderRow;
-    
+    public bool HasHeaderRow
+    {
+        get => tableProperties.FirstRow?.Value ?? false;
+        set => tableProperties.FirstRow = value;
+    }
+
     /// <inheritdoc/>
-    public bool HasTotalRow { get; } = hasTotalRow;
-    
+    public bool HasTotalRow
+    {
+        get => tableProperties.LastRow?.Value ?? false;
+        set => tableProperties.LastRow = value;
+    }
+
     /// <inheritdoc/>
-    public bool HasBandedRows { get; } = hasBandedRows;
-    
+    public bool HasBandedRows
+    {
+        get => tableProperties.BandRow?.Value ?? false;
+        set => tableProperties.BandRow = value;
+    }
+
     /// <inheritdoc/>
-    public bool HasFirstColumn { get; } = hasFirstColumn;
-    
+    public bool HasFirstColumn
+    {
+        get => tableProperties.FirstColumn?.Value ?? false;
+        set => tableProperties.FirstColumn = value;
+    }
+
     /// <inheritdoc/>
-    public bool HasLastColumn { get; } = hasLastColumn;
-    
+    public bool HasLastColumn
+    {
+        get => tableProperties.LastColumn?.Value ?? false;
+        set => tableProperties.LastColumn = value;
+    }
+
     /// <inheritdoc/>
-    public bool HasBandedColumns { get; } = hasBandedColumns;
+    public bool HasBandedColumns
+    {
+        get => tableProperties.BandColumn?.Value ?? false;
+        set => tableProperties.BandColumn = value;
+    }
 }

--- a/test/ShapeCrawler.Tests.Unit/TableTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/TableTests.cs
@@ -952,4 +952,25 @@ public class TableTests : SCTest
         table.TableStyleOptions.HasLastColumn.Should().Be(hasLastColumn);
         table.TableStyleOptions.HasBandedColumns.Should().Be(hasBandedColumns);
     }
+    
+    [Test]
+    public void Table_creation_has_tableStyleOptions_default_options()
+    {
+        // Arrange
+        var pres = new Presentation();
+        var slide = pres.Slides[0];
+        slide.Shapes.AddTable(0, 0, 3, 2);
+        var table = slide.Shapes.Last() as ITable;
+
+        // Act
+        var options = table.TableStyleOptions;
+
+        // Assert
+        options.HasHeaderRow.Should().BeTrue();
+        options.HasTotalRow.Should().BeFalse();
+        options.HasBandedRows.Should().BeTrue();
+        options.HasFirstColumn.Should().BeFalse();
+        options.HasLastColumn.Should().BeFalse();
+        options.HasBandedColumns.Should().BeFalse();
+    }
 }

--- a/test/ShapeCrawler.Tests.Unit/TableTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/TableTests.cs
@@ -919,11 +919,11 @@ public class TableTests : SCTest
     
     [Test]
     [TestCase(true, false, false, false, false, false)]
-    [TestCase(true, true, false, false, false, false)]
-    [TestCase(true, false, true, false, false, false)]
-    [TestCase(true, false, false, true, false, false)]
-    [TestCase(true, false, false, false, true, false)]
-    [TestCase(true, false, false, false, true, true)]
+    [TestCase(false, true, false, false, false, false)]
+    [TestCase(false, false, true, false, false, false)]
+    [TestCase(false, false, false, true, false, false)]
+    [TestCase(false, false, false, false, true, false)]
+    [TestCase(false, false, false, false, false, true)]
     public void TableStyleOptions_setter_set_table_style_options(bool hasHeaderRow, bool hasTotalRow, bool hasBandedRows, bool hasFirstColumn, bool hasLastColumn, bool hasBandedColumns)
     {
         // Arrange
@@ -934,7 +934,12 @@ public class TableTests : SCTest
         var table = slide.Shapes.Last() as ITable;
 
         // Act
-        table.TableStyleOptions = new TableStyleOptions(hasHeaderRow, hasTotalRow, hasBandedRows, hasFirstColumn, hasLastColumn, hasBandedColumns);
+        table.TableStyleOptions.HasHeaderRow = hasHeaderRow;
+        table.TableStyleOptions.HasTotalRow = hasTotalRow;
+        table.TableStyleOptions.HasBandedRows = hasBandedRows;
+        table.TableStyleOptions.HasFirstColumn = hasFirstColumn;
+        table.TableStyleOptions.HasLastColumn = hasLastColumn;
+        table.TableStyleOptions.HasBandedColumns = hasBandedColumns;
 
         // Assert
         pres.SaveAs(mStream);

--- a/test/ShapeCrawler.Tests.Unit/TableTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/TableTests.cs
@@ -916,4 +916,35 @@ public class TableTests : SCTest
         table.AltText.Should().Be("Alt text");
         pres.Validate();
     }
+    
+    [Test]
+    [TestCase(true, false, false, false, false, false)]
+    [TestCase(true, true, false, false, false, false)]
+    [TestCase(true, false, true, false, false, false)]
+    [TestCase(true, false, false, true, false, false)]
+    [TestCase(true, false, false, false, true, false)]
+    [TestCase(true, false, false, false, true, true)]
+    public void TableStyleOptions_setter_set_table_style_options(bool hasHeaderRow, bool hasTotalRow, bool hasBandedRows, bool hasFirstColumn, bool hasLastColumn, bool hasBandedColumns)
+    {
+        // Arrange
+        var mStream = new MemoryStream();
+        var pres = new Presentation();
+        var slide = pres.Slides[0];
+        slide.Shapes.AddTable(0, 0, 3, 2);
+        var table = slide.Shapes.Last() as ITable;
+
+        // Act
+        table.TableStyleOptions = new TableStyleOptions(hasHeaderRow, hasTotalRow, hasBandedRows, hasFirstColumn, hasLastColumn, hasBandedColumns);
+
+        // Assert
+        pres.SaveAs(mStream);
+        pres = new Presentation(mStream);
+        table = pres.Slides[0].Shapes.Last() as ITable;
+        table.TableStyleOptions.HasHeaderRow.Should().Be(hasHeaderRow);
+        table.TableStyleOptions.HasTotalRow.Should().Be(hasTotalRow);
+        table.TableStyleOptions.HasBandedRows.Should().Be(hasBandedRows);
+        table.TableStyleOptions.HasFirstColumn.Should().Be(hasFirstColumn);
+        table.TableStyleOptions.HasLastColumn.Should().Be(hasLastColumn);
+        table.TableStyleOptions.HasBandedColumns.Should().Be(hasBandedColumns);
+    }
 }


### PR DESCRIPTION
Implementing table style options to allow for editing of header rows, column rows, etc.

#655

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new feature for managing table style options in the `ShapeCrawler` library, enhancing the `ITable` interface and implementing the `ITableStyleOptions` interface. It includes related tests to ensure correct functionality.

### Detailed summary
- Added `TableStyleOptions` property to `ITable` interface.
- Created `ITableStyleOptions` interface with properties for table style options.
- Implemented `TableStyleOptions` class to manage these options.
- Added unit tests for setting and verifying table style options.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->