### PR TITLE
Update test

### DIFF
--- a/test/ShapeCrawler.Tests.Unit/FontTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/FontTests.cs
@@ -290,28 +290,6 @@ public class FontTests : SCTest
         // Assert
         font.LatinName.Should().Be("Time New Roman");
     }
-
-    [Test]
-    [Explicit("Fails. Reported as Issue #828")]
-    public void LatinName_Setter_only_sets_current_shape()
-    {
-        // Arrange
-        var pres = new Presentation();
-        var shapes = pres.Slides[0].Shapes;
-        shapes.AddShape(10,20,30,40);
-        var shape1 = shapes.Last();
-        shapes.AddShape(100,20,30,40);
-        var shape2 = shapes.Last();
-        shape1.TextBox!.Text = "Shape 1";
-        shape1.TextBox!.Paragraphs[0].Portions[0].Font.LatinName = "Segoe UI Semibold";
-
-        // Act
-        shape2.TextBox!.Text = "Shape 2";
-        shape2.TextBox!.Paragraphs[0].Portions[0].Font.LatinName = "Aptos";
-
-        // Assert
-        shape1.TextBox!.Paragraphs[0].Portions[0].Font.LatinName.Should().Be("Segoe UI Semibold");
-    }
     
     [Test]
     public void LatinName_Setter_sets_font_for_the_latin_characters_of_table_cell()
@@ -330,6 +308,28 @@ public class FontTests : SCTest
         
         // Assert
         font.LatinName.Should().Be("Arial");
+    }
+    
+    [Test]
+    [Explicit("Fails. Reported as Issue #828")]
+    public void LatinName_Setter_should_sets_font_for_the_latin_characters_only_for_the_specified_shape()
+    {
+        // Arrange
+        var pres = new Presentation();
+        var shapes = pres.Slides[0].Shapes;
+        shapes.AddShape(10,20,30,40);
+        var shape1 = shapes.Last();
+        shapes.AddShape(100,20,30,40);
+        var shape2 = shapes.Last();
+        shape1.TextBox!.Text = "Shape 1";
+        shape1.TextBox!.Paragraphs[0].Portions[0].Font!.LatinName = "Segoe UI Semibold";
+
+        // Act
+        shape2.TextBox!.Text = "Shape 2";
+        shape2.TextBox!.Paragraphs[0].Portions[0].Font!.LatinName = "Aptos";
+
+        // Assert
+        shape1.TextBox!.Paragraphs[0].Portions[0].Font.LatinName.Should().Be("Segoe UI Semibold");
     }
     
     [Test]


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating unit tests related to the `LatinName` property of font objects within shapes, specifically addressing a previously failing test and ensuring that the font is set correctly for specified shapes.

### Detailed summary
- Removed the old test method `LatinName_Setter_only_sets_current_shape`.
- Added a new test method `LatinName_Setter_should_sets_font_for_the_latin_characters_only_for_the_specified_shape` that verifies font setting for specific shapes.
- Both tests check the `LatinName` property for font consistency.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->