### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog  
 
-## Version 0.59.0 - Unreleased
+## Version 0.59.0 - 2024-12-29
 🍀Added `ITable.TableStyleOptions` [#817](https://github.com/ShapeCrawler/ShapeCrawler/issues/655)  
+🍀Added exposing metadata `IPresentation.FileProperties.Title`, `IPresentation.FileProperties.Created` etc.  
+🐞Fixed updating the font color of the master shape [#793](https://github.com/ShapeCrawler/ShapeCrawler/issues/793)  
+🐞Fixed displaying constant maintainer'name for the created presentation [#812](https://github.com/ShapeCrawler/ShapeCrawler/issues/812)  
 
 ## Version 0.58.0 - 2024-12-18
 🍀Added `IHyperlink.AddFile()` [#724](https://github.com/ShapeCrawler/ShapeCrawler/issues/724)  

--- a/README.md
+++ b/README.md
@@ -95,10 +95,8 @@ Pull Requests are welcome! Please read the [Contribution Guide](https://github.c
 
 ## Changelog  
 
-### Version 0.58.0 - 2024-12-18
-🍀Added `IHyperlink.AddFile()` [#724](https://github.com/ShapeCrawler/ShapeCrawler/issues/724)  
-🍀Added `IPicture.CornerSize` [#707](https://github.com/ShapeCrawler/ShapeCrawler/issues/707)  
-🍀Added `ISlide.Fill` [#797](https://github.com/ShapeCrawler/ShapeCrawler/issues/797)  
-🍀Added setter for `IShape.Name` [#802](https://github.com/ShapeCrawler/ShapeCrawler/issues/802)  
-
-Visit [CHANGELOG.md](https://github.com/ShapeCrawler/ShapeCrawler/blob/master/CHANGELOG.md) to see the full log.
+### Version 0.59.0 - 2024-12-29
+🍀Added `ITable.TableStyleOptions` [#817](https://github.com/ShapeCrawler/ShapeCrawler/issues/655)  
+🍀Added exposing metadata `IPresentation.FileProperties.Title`, `IPresentation.FileProperties.Created` etc.  
+🐞Fixed updating the font color of the master shape [#793](https://github.com/ShapeCrawler/ShapeCrawler/issues/793)  
+🐞Fixed displaying constant maintainer'name for the created presentation [#812](https://github.com/ShapeCrawler/ShapeCrawler/issues/812)  

--- a/src/ShapeCrawler/ShapeCrawler.csproj
+++ b/src/ShapeCrawler/ShapeCrawler.csproj
@@ -10,10 +10,10 @@ This library provides a simplified object model on top of the Open XML SDK for m
     <PackageTags>ShapeCrawler Presentation PPTX  PowerPoint Slides OpenXml OOXML</PackageTags>
     <NeutralLanguage>en</NeutralLanguage>
     <LangVersion>latest</LangVersion>
-    <PackageReleaseNotes>🍀Added `IHyperlink.AddFile()` [#724](https://github.com/ShapeCrawler/ShapeCrawler/issues/724)  
-🍀Added `IPicture.CornerSize` [#707](https://github.com/ShapeCrawler/ShapeCrawler/issues/707)  
-🍀Added `ISlide.Fill` [#797](https://github.com/ShapeCrawler/ShapeCrawler/issues/797)  
-🍀Added setter for `IShape.Name` [#802](https://github.com/ShapeCrawler/ShapeCrawler/issues/802)  </PackageReleaseNotes>
+    <PackageReleaseNotes>🍀Added `ITable.TableStyleOptions` [#817](https://github.com/ShapeCrawler/ShapeCrawler/issues/655)  
+🍀Added exposing metadata `IPresentation.FileProperties.Title`, `IPresentation.FileProperties.Created` etc.  
+🐞Fixed updating the font color of the master shape [#793](https://github.com/ShapeCrawler/ShapeCrawler/issues/793)  
+🐞Fixed displaying constant maintainer'name for the created presentation [#812](https://github.com/ShapeCrawler/ShapeCrawler/issues/812)  </PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/ShapeCrawler/ShapeCrawler</PackageProjectUrl>
     <RepositoryType>Git</RepositoryType>
     <RepositoryUrl>https://github.com/ShapeCrawler/ShapeCrawler</RepositoryUrl>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `CHANGELOG.md` and `README.md` to include the details of version `0.59.0`, released on `2024-12-29`. It adds new features and fixes, notably for `ITable`, `IPresentation`, and master shape font color.

### Detailed summary
- Updated version from `Unreleased` to `2024-12-29` in `CHANGELOG.md`.
- Added `ITable.TableStyleOptions`.
- Exposed metadata: `IPresentation.FileProperties.Title`, `IPresentation.FileProperties.Created`.
- Fixed font color update for master shape.
- Fixed constant maintainer's name display for created presentations.
- Updated `README.md` with new version details.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->