### PR TITLE
Fix font Latin name setting for individual shapes

### DIFF
--- a/src/ShapeCrawler/Fonts/TextPortionFont.cs
+++ b/src/ShapeCrawler/Fonts/TextPortionFont.cs
@@ -308,5 +308,22 @@ internal sealed class TextPortionFont : ITextPortionFont
         }
     }
 
-    private void UpdateLatinName(string latinFont) => this.ALatinFont().Typeface = latinFont;
+    private void UpdateLatinName(string latinFont)
+    {
+        var aRunProperties = this.aText.Parent!.GetFirstChild<A.RunProperties>();
+        var aLatinFont = aRunProperties?.GetFirstChild<A.LatinFont>();
+
+        if (aLatinFont != null)
+        {
+            aLatinFont = new A.LatinFont { Typeface = latinFont };
+            aRunProperties!.InsertAt(aLatinFont, 0);
+        }
+        else
+        {
+            aLatinFont = new A.LatinFont { Typeface = latinFont };
+            aRunProperties = new A.RunProperties();
+            aRunProperties.Append(aLatinFont);
+            this.aText.Parent.InsertAt(aRunProperties, 0);
+        }
+    }
 }

--- a/test/ShapeCrawler.Tests.Unit/FontTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/FontTests.cs
@@ -311,7 +311,6 @@ public class FontTests : SCTest
     }
     
     [Test]
-    [Explicit("Fails. Reported as Issue #828")]
     public void LatinName_Setter_should_sets_font_for_the_latin_characters_only_for_the_specified_shape()
     {
         // Arrange


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the `UpdateLatinName` method in `TextPortionFont` to properly handle the insertion of a new `A.LatinFont` into the document structure, ensuring that it correctly manages both existing and new `A.RunProperties`.

### Detailed summary
- Removed the `Explicit` attribute from the `LatinName_Setter_should_sets_font_for_the_latin_characters_only_for_the_specified_shape` test.
- Refactored the `UpdateLatinName` method:
  - Added logic to check for existing `A.RunProperties`.
  - Created a new `A.LatinFont` and inserted it into `A.RunProperties` if it exists.
  - Handled cases where `A.RunProperties` does not exist by creating a new one and appending the `A.LatinFont`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->