### PR TITLE
Fix copying slides to use the same master layout

### DIFF
--- a/src/ShapeCrawler/Presentations/Slides.cs
+++ b/src/ShapeCrawler/Presentations/Slides.cs
@@ -141,24 +141,24 @@ internal sealed class Slides : ISlides
         this.readOnlySlides[addedSlideIndex].Number = position;
     }
 
-    public void Add(ISlide slide)
+    public void Add(ISlide addingSlide)
     {
-        var addingSlide = (Slide)slide;
+        var internalAddingSlide = (Slide)addingSlide;
         var addingSlidePresStream = new MemoryStream();
         var targetPresDocument = (PresentationDocument)this.presentationPart.OpenXmlPackage;
-        var addingSlidePresDocument = addingSlide.SdkPresentationDocument().Clone(addingSlidePresStream);
+        var addingSlidePresDocument = internalAddingSlide.SdkPresentationDocument().Clone(addingSlidePresStream);
 
         var sourceSlidePresPart = addingSlidePresDocument.PresentationPart!;
         var targetPresPart = targetPresDocument.PresentationPart!;
         var targetPres = targetPresPart.Presentation;
-        var sourceSlideId = (P.SlideId)sourceSlidePresPart.Presentation.SlideIdList!.ChildElements[slide.Number - 1];
+        var sourceSlideId = (P.SlideId)sourceSlidePresPart.Presentation.SlideIdList!.ChildElements[addingSlide.Number - 1];
         var sourceSlidePart = (SlidePart)sourceSlidePresPart.GetPartById(sourceSlideId.RelationshipId!);
 
-        var existingMaster = targetPresPart.SlideMasterParts.FirstOrDefault(master => master.SlideLayouts.Any(layout => layout.SlideLayout == sourceSlidePart.SlideLayoutPart!.SlideLayout));
+        var existingMaster = targetPresPart.SlideMasterParts.FirstOrDefault(masterPart => masterPart.SlideLayoutParts.SelectMany(x=>x.SlideLayout).Any(layout => layout == sourceSlidePart.SlideLayoutPart!.SlideLayout));
         if (existingMaster != null)
         {
-            var existingLayout = existingMaster.SlideLayouts.First(layout => layout.SlideLayout == sourceSlidePart.SlideLayoutPart!.SlideLayout);
-            sourceSlidePart.SlideLayoutPart = existingLayout;
+            var existingLayout = existingMaster.SlideLayoutParts.SelectMany(x=>x.SlideLayout).First(layout => layout == sourceSlidePart.SlideLayoutPart!.SlideLayout);
+            sourceSlidePart.SlideLayoutPart!.SlideLayout = (P.SlideLayout)existingLayout;
         }
         else
         {

--- a/src/ShapeCrawler/Presentations/Slides.cs
+++ b/src/ShapeCrawler/Presentations/Slides.cs
@@ -154,7 +154,16 @@ internal sealed class Slides : ISlides
         var sourceSlideId = (P.SlideId)sourceSlidePresPart.Presentation.SlideIdList!.ChildElements[slide.Number - 1];
         var sourceSlidePart = (SlidePart)sourceSlidePresPart.GetPartById(sourceSlideId.RelationshipId!);
 
-        new WrappedSlideMasterPart(sourceSlidePart.SlideLayoutPart!.SlideMasterPart!).RemoveLayoutsExcept(sourceSlidePart.SlideLayoutPart!);
+        var existingMaster = targetPresPart.SlideMasterParts.FirstOrDefault(master => master.SlideLayouts.Any(layout => layout.SlideLayout == sourceSlidePart.SlideLayoutPart!.SlideLayout));
+        if (existingMaster != null)
+        {
+            var existingLayout = existingMaster.SlideLayouts.First(layout => layout.SlideLayout == sourceSlidePart.SlideLayoutPart!.SlideLayout);
+            sourceSlidePart.SlideLayoutPart = existingLayout;
+        }
+        else
+        {
+            new WrappedSlideMasterPart(sourceSlidePart.SlideLayoutPart!.SlideMasterPart!).RemoveLayoutsExcept(sourceSlidePart.SlideLayoutPart!);
+        }
 
         var wrappedPresentationPart = new WrappedPresentationPart(targetPresPart);
         wrappedPresentationPart.AddSlidePart(sourceSlidePart);

--- a/test/ShapeCrawler.Tests.Unit/SlideTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/SlideTests.cs
@@ -380,4 +380,22 @@ public class SlideTests : SCTest
         notes.Text.Should().Be(expected);
         pres.Validate();
     }
+
+    [Test]
+    public void CopyingSlides_UsesSameMasterLayout()
+    {
+        // Arrange
+        var pres = new Presentation();
+        var slide = pres.Slides[0];
+
+        // Act
+        for (int i = 0; i < 5; i++)
+        {
+            pres.Slides.Add(slide);
+        }
+
+        // Assert
+        var masterLayouts = pres.Slides.Select(s => s.SlideLayout).Distinct().ToList();
+        masterLayouts.Count.Should().Be(1);
+    }
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a unit test for slide copying functionality and modifies the `Add` method in the `Slides` class to ensure that slides maintain the same master layout when copied.

### Detailed summary
- Added a new test method `CopyingSlides_UsesSameMasterLayout` in `SlideTests.cs`.
- Modified the `Add` method in `Slides.cs` to change variable naming for clarity.
- Implemented logic to check for existing master layouts when adding slides.
- Ensured that copied slides use the same layout if available, otherwise, it removes unnecessary layouts.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->