### PR TITLE
Refactor picture fill test to follow normal pattern

### DIFF
--- a/test/ShapeCrawler.Tests.Unit/SlideTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/SlideTests.cs
@@ -83,7 +83,7 @@ public class SlideTests : SCTest
         var pres = new Presentation(StreamOf("009_table.pptx"));
         var slideFill = pres.Slide(2).Fill;
 
-        // Assert
+        // Act-Assert
         slideFill.Picture.Should().BeNull();
     }
 

--- a/test/ShapeCrawler.Tests.Unit/SlideTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/SlideTests.cs
@@ -77,17 +77,14 @@ public class SlideTests : SCTest
     }
 
     [Test]
-    public void Fill_Picture_AsByteArray_throws_exception_slide_doesnt_have_background()
+    public void Fill_Picture_is_null_when_slide_doesnt_have_background()
     {
         // Arrange
         var pres = new Presentation(StreamOf("009_table.pptx"));
-        var slide = pres.Slides[1];
-
-        // Act
-        var act = () => slide.Fill.Picture.AsByteArray();
+        var slideFill = pres.Slide(2).Fill;
 
         // Assert
-        act.Should().Throw<Exception>();
+        slideFill.Picture.Should().BeNull();
     }
 
     [Test]


### PR DESCRIPTION
Fill_Picture_is_null_when_slide_doesnt_have_background test used extra needless steps. Should have been cleaned up in recent refactor.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies a unit test in `SlideTests.cs` to change the focus from checking for an exception when a slide doesn't have a background to verifying that the `Picture` property is `null` when the slide lacks a background.

### Detailed summary
- Renamed the test method from `Fill_Picture_AsByteArray_throws_exception_slide_doesnt_have_background` to `Fill_Picture_is_null_when_slide_doesnt_have_background`.
- Changed the test logic to assert that `slideFill.Picture` is `null` instead of throwing an exception.
- Removed the unused variable `slide` and replaced it with `slideFill`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->