### PR TITLE
Minor changes to improve exception handling

### DIFF
--- a/src/ShapeCrawler/ShapeCollection/Shapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/Shapes.cs
@@ -6,6 +6,7 @@ using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using ShapeCrawler.Charts;
 using ShapeCrawler.Drawing;
+using ShapeCrawler.Exceptions;
 using ShapeCrawler.ShapeCollection.GroupShapes;
 using ShapeCrawler.Texts;
 using A = DocumentFormat.OpenXml.Drawing;
@@ -39,7 +40,9 @@ internal sealed class Shapes : IShapes
     public T? TryGetByName<T>(string name) 
         where T : IShape => (T?)this.ShapesCore().FirstOrDefault(shape => shape.Name == name);
 
-    public IShape GetByName(string name) => this.ShapesCore().First(shape => shape.Name == name);
+    public IShape GetByName(string name) => 
+        this.ShapesCore().FirstOrDefault(shape => shape.Name == name)
+        ?? throw new SCException("Shape not found");
 
     public T Last<T>() 
         where T : IShape => (T)this.ShapesCore().Last(shape => shape is T);

--- a/test/ShapeCrawler.Tests.Unit/PictureTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/PictureTests.cs
@@ -159,11 +159,8 @@ public class PictureTests : SCTest
         // Arrange
         var pre = new Presentation(StreamOf("019.pptx"));
 
-        // Act
-        Action act = () => pre.Slides[1].Shapes.Single(x => x.Id == 47);
-        
-        // Assert
-        act.Should().Throw<Exception>();
+        // Act-Assert
+        pre.Slides[1].Shapes.Any(x => x.Id == 47).Should().Be(false);
     }
     
     [Test]

--- a/test/ShapeCrawler.Tests.Unit/ShapeTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeTests.cs
@@ -408,7 +408,7 @@ public class ShapeTests : SCTest
 
         // Assert
         var act = () => pres.Slides[0].Shapes.GetByName("TextBox 3");
-        act.Should().Throw<Exception>();
+        act.Should().Throw<SCException>();
         pres.Validate();
     }
 


### PR DESCRIPTION
Currently, when there are no matching shapes, `Shapes.GetByName()` passes through the `System.Exception` generated by the failing call to `Single()`. Better would be to explicitly state the reason for the failure.

Also cleaned up a test where the test itself was generating an exception and then checking for that exception. Better to explicitly test the condition we're after.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving exception handling in the `ShapeCrawler` library by changing the exception type thrown when a shape is not found and modifying the tests accordingly.

### Detailed summary
- Changed the exception type from `Exception` to `SCException` in `ShapeTests.cs`.
- Updated the test for shape retrieval to check for `SCException`.
- Modified the test in `PictureTests.cs` to assert that a shape with a specific ID does not exist.
- Enhanced the `GetByName` method in `Shapes.cs` to throw `SCException` if a shape is not found.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->