### PR TITLE
Enable trimming

### DIFF
--- a/src/ShapeCrawler/ShapeCrawler.csproj
+++ b/src/ShapeCrawler/ShapeCrawler.csproj
@@ -26,6 +26,7 @@ This library provides a simplified object model on top of the Open XML SDK for m
     <PackageIcon>package-icon.jpg</PackageIcon>
     <Nullable>enable</Nullable>
     <NoWarn>NU1608</NoWarn>
+    <IsTrimmable Condition="'$(TargetFramework)' == 'net9.0'">true</IsTrimmable> 
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Here's how you can test this:

1. Create a new console app
2. Add this to your `PropertyGroup`: `<PublishTrimmed>true</PublishTrimmed>`
3. Add ShapeCrawler as a reference
4. Do something simple, e.g. create and save an empty presentation

Then:

```dotnetcli
dotnet publish -r win-x64 --self-contained
ls .\bin\Release\net9.0\win-x64\publish\ShapeCrawler.dll

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a----          1/2/2025  11:49 AM         152576 ShapeCrawler.dll
```
So smol! Now: Change to:  `<PublishTrimmed>false</PublishTrimmed>`

```dotnetcli
dotnet publish -r win-x64 --self-contained
ls .\bin\Release\net9.0\win-x64\publish\ShapeCrawler.dll

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a----          1/2/2025  11:50 AM         315392 ShapeCrawler.dll
```

See also: [Trim self-contained deployments and executables](https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-self-contained)

Fixes #708

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the project file for `ShapeCrawler` to enable trimmability for the `net9.0` target framework.

### Detailed summary
- Added the property `<IsTrimmable Condition="'$(TargetFramework)' == 'net9.0'">true</IsTrimmable>` to the `src/ShapeCrawler/ShapeCrawler.csproj` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->