### PR TITLE
Add test SetPicture_should_not_break_presentation

### DIFF
--- a/src/ShapeCrawler/Drawing/IShapeFill.cs
+++ b/src/ShapeCrawler/Drawing/IShapeFill.cs
@@ -42,9 +42,6 @@ public interface IShapeFill
     /// <summary>
     ///     Fills the shape with picture.
     /// </summary>
-    /// <remarks>
-    ///     Only PNG mimetype supported.
-    /// </remarks>
     void SetPicture(Stream image);
 
     /// <summary>

--- a/test/ShapeCrawler.Tests.Unit/ShapeFillTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeFillTests.cs
@@ -171,6 +171,43 @@ public class ShapeFillTests : SCTest
         pres.Validate();
     }
 
+    [Test]
+    [TestCase("009_table.pptx", 2, "AutoShape 2")]
+    public void SetColor_replaces_picture_with_solid_color(string file, int slideNumber, string shapeName)
+    {
+        // Arrange
+        var pres = new Presentation(StreamOf(file));
+        var shape = pres.Slide(slideNumber).Shapes.GetByName(shapeName);
+        var shapeFill = shape.Fill;
+        var image = StreamOf("png image-1.png");
+        var greenColor = "32a852";
+
+        // Act
+        shapeFill.SetPicture(image);
+        shapeFill.SetColor(greenColor);
+
+        // Assert
+        shapeFill.Color.Should().Be(greenColor);
+        pres.Validate();
+    }
+
+    [Test]
+    [Explicit]
+    public void SetPicture_should_not_break_presentation()
+    {
+        // Arrange
+        var pres = new Presentation(StreamOf("009_table.pptx"));
+        var shape = pres.Slide(2).Shape("AutoShape 2");
+        var shapeFill = shape.Fill;
+        var image = StreamOf("png image-1.png");
+
+        // Act
+        shapeFill.SetPicture(image);
+
+        // Assert
+        pres.Validate();
+    }
+
     [TestCase("autoshape-case005_text-frame.pptx", 1, "AutoShape 1")]
     [TestCase("autoshape-case005_text-frame.pptx", 1, "AutoShape 2")]
     [TestCase("autoshape-grouping.pptx", 1, "AutoShape 1")]
@@ -222,29 +259,6 @@ public class ShapeFillTests : SCTest
         pres.Validate();
     }
 
-    [Test]
-    [TestCase("009_table.pptx", 2, "AutoShape 2")]
-    public void SetFill_sets_as(
-        string file,
-        int slideNumber,
-        string shapeName
-    )
-    {
-        // Arrange
-        var pres = new Presentation(StreamOf(file));
-        var shape = pres.Slides[slideNumber - 1].Shapes.GetByName(shapeName);
-        var shapeFill = shape.Fill;
-        var imageStream = StreamOf("png image-1.png");
-
-        // Act
-        shapeFill.SetPicture(imageStream);
-        shapeFill.SetColor("32a852");
-
-        // Assert
-        shapeFill.Color.Should().Be("32a852");
-        pres.Validate();
-    }
-    
     [Theory]
     [SlideShape("008.pptx", slideNumber: 1, shapeName: "AutoShape 1")]
     [SlideShape("autoshape-case009.pptx", slideNumber: 1, shapeName: "AutoShape 1")]
@@ -264,7 +278,7 @@ public class ShapeFillTests : SCTest
         var imageBytes = imageStream.ToArray();
         pictureBytes.SequenceEqual(imageBytes).Should().BeTrue();
     }
-    
+
     [Test]
     [SlideShape("009_table.pptx", 2, 6, FillType.NoFill)]
     [SlideShape("009_table.pptx", 2, 2, FillType.Solid)]
@@ -279,7 +293,7 @@ public class ShapeFillTests : SCTest
         // Assert
         fillType.Should().Be(expectedFill);
     }
-    
+
     [Test]
     public void Type_returns_Gradient_fill_type()
     {

--- a/test/ShapeCrawler.Tests.Unit/SlideTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/SlideTests.cs
@@ -61,21 +61,22 @@ public class SlideTests : SCTest
     }
 
     [Test]
-    public void Fill_SetPicture_sets_background_of_new_slide()
+    public void Fill_SetPicture_sets_image_background()
     {
         // Arrange
         var pres = new Presentation();
         pres.Slides.AddEmptySlide(SlideLayoutType.Blank);
         var slide = pres.Slides[0];
-        var bgImage = StreamOf("png image-2.png");
+        var image = StreamOf("png image-2.png");
 
         // Act
-        slide.Fill.SetPicture(bgImage);
+        slide.Fill.SetPicture(image);
 
         // Assert
         slide.Fill.Picture.Should().NotBeNull();
+        pres.Validate();
     }
-
+    
     [Test]
     public void Fill_Picture_is_null_when_slide_doesnt_have_background()
     {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `SetPicture` method in the `IShapeFill` interface and its related tests. It enhances the functionality by ensuring the picture can be replaced with a solid color and adds new tests for validating these behaviors.

### Detailed summary
- Removed remarks about PNG support from `IShapeFill.SetPicture`.
- Renamed variable `bgImage` to `image` in `Fill_SetPicture_sets_image_background` test.
- Added new tests for `SetColor` and `SetPicture` methods in `ShapeFillTests`.
- Removed an obsolete test that was commented out.
- Updated assertions to validate that the presentation remains intact after setting a picture.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->