### PR TITLE
Refactor tests

### DIFF
--- a/test/ShapeCrawler.Tests.Unit/Helpers/SCTest.cs
+++ b/test/ShapeCrawler.Tests.Unit/Helpers/SCTest.cs
@@ -63,7 +63,7 @@ public abstract class SCTest
         return new Presentation(stream);
     }
 
-    protected static PresentationDocument SaveAndOpenPresentationAsXml(IPresentation presentation)
+    protected static PresentationDocument SaveAndOpenPresentationAsSdk(IPresentation presentation)
     {
         var stream = new MemoryStream();
         presentation.SaveAs(stream);

--- a/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
@@ -608,8 +608,6 @@ public class ShapeCollectionTests : SCTest
         var checkXml = SaveAndOpenPresentationAsSdk(pres);
         var imageParts = checkXml.PresentationPart!.SlideParts.SelectMany(slidePart => slidePart.ImageParts).ToArray();
         imageParts.Length.Should().Be(1);
-        
-        pres.SaveAs(@"c:\temp\test.pptx");
     }
 
     [Test]


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving the testing for adding images to presentations, specifically ensuring that SVG images do not duplicate when added multiple times or across different slides. It also refactors some method names for clarity and updates assertions for better accuracy.

### Detailed summary
- Renamed method from `SaveAndOpenPresentationAsXml` to `SaveAndOpenPresentationAsSdk`.
- Improved assertions to check for image duplication when adding SVG images.
- Consolidated tests for adding pictures to reduce redundancy.
- Updated test cases to ensure accurate image part counts.
- Enhanced readability by formatting assertions and method calls.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->