### PR TITLE
Update README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog  
 
-## Version 0.59.1 - 2025-01-07
+## Version 0.60.0 - 2025-01-07
 🐞Fixed trim warning `IL2104` [#708](https://github.com/ShapeCrawler/ShapeCrawler/issues/708)  
 🐞Fixed duplication of image source [#809](https://github.com/ShapeCrawler/ShapeCrawler/issues/809)  
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,6 @@ Pull Requests are welcome! Please read the [Contribution Guide](https://github.c
 
 ## Changelog  
 
-### Version 0.59.1 - 2025-01-07
+### Version 0.60.0 - 2025-01-07
 🐞Fixed trim warning `IL2104` [#708](https://github.com/ShapeCrawler/ShapeCrawler/issues/708)  
 🐞Fixed duplication of image source [#809](https://github.com/ShapeCrawler/ShapeCrawler/issues/809)  


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the version number in both the `CHANGELOG.md` and `README.md` files from `0.59.1` to `0.60.0`. It also documents two bug fixes related to a trim warning and image source duplication.

### Detailed summary
- Updated version from `0.59.1` to `0.60.0` in `CHANGELOG.md`
- Updated version from `0.59.1` to `0.60.0` in `README.md`
- Fixed trim warning `IL2104` 
- Fixed duplication of image source

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->