### PR TITLE
Fix powerpoint not load correctly (Issue #828)

### DIFF
--- a/src/ShapeCrawler/Colors/ColorTranslator.cs
+++ b/src/ShapeCrawler/Colors/ColorTranslator.cs
@@ -16,7 +16,7 @@ internal static class ColorTranslator
 
     internal static string HexFromName(string coloName)
     {
-        if (coloName.ToLower() == "white")
+        if (coloName.Equals("white", StringComparison.CurrentCultureIgnoreCase))
         {
             return "FFFFFF";
         }

--- a/src/ShapeCrawler/Fonts/TextPortionFont.cs
+++ b/src/ShapeCrawler/Fonts/TextPortionFont.cs
@@ -311,19 +311,35 @@ internal sealed class TextPortionFont : ITextPortionFont
     private void UpdateLatinName(string latinFont)
     {
         var aRunProperties = this.aText.Parent!.GetFirstChild<A.RunProperties>();
-        var aLatinFont = aRunProperties?.GetFirstChild<A.LatinFont>();
 
-        if (aLatinFont != null)
+        A.TextCharacterPropertiesType aCurrentProperties; 
+
+        if (aRunProperties is not null)
         {
-            aLatinFont = new A.LatinFont { Typeface = latinFont };
-            aRunProperties!.InsertAt(aLatinFont, 0);
+            aCurrentProperties = aRunProperties;
         }
         else
         {
-            aLatinFont = new A.LatinFont { Typeface = latinFont };
-            aRunProperties = new A.RunProperties();
-            aRunProperties.Append(aLatinFont);
-            this.aText.Parent.InsertAt(aRunProperties, 0);
+            var aEndParaRunProperties = this.aText.Parent!.GetFirstChild<A.EndParagraphRunProperties>();
+
+            if (aEndParaRunProperties is not null)
+            {
+                aCurrentProperties = aEndParaRunProperties;   
+            }
+            else
+            {
+                aCurrentProperties = this.aText.Parent!.AddRunProperties();
+            }
         }
+
+        var aLatinFont = aCurrentProperties.GetFirstChild<A.LatinFont>();
+
+        if (aLatinFont is null)
+        {
+            aLatinFont = new A.LatinFont();
+            aCurrentProperties.Append(aLatinFont); // we need to append it otherwise, the text will ignore color etc
+        }
+        
+        aLatinFont.Typeface = latinFont;
     }
 }

--- a/src/ShapeCrawler/Shared/Assets.cs
+++ b/src/ShapeCrawler/Shared/Assets.cs
@@ -11,7 +11,7 @@ internal readonly ref struct Assets
     
     internal MemoryStream StreamOf(string file)
     {
-        var stream = this.assembly.GetManifestResourceStream($"ShapeCrawler.Resources.{file}") !;
+        using var stream = this.assembly.GetManifestResourceStream($"ShapeCrawler.Resources.{file}") !;
         var asset = new MemoryStream();
         stream.CopyTo(asset);
         asset.Position = 0;

--- a/src/ShapeCrawler/Shared/Assets.cs
+++ b/src/ShapeCrawler/Shared/Assets.cs
@@ -11,7 +11,7 @@ internal readonly ref struct Assets
     
     internal MemoryStream StreamOf(string file)
     {
-        using var stream = this.assembly.GetManifestResourceStream($"ShapeCrawler.Resources.{file}") !;
+        var stream = this.assembly.GetManifestResourceStream($"ShapeCrawler.Resources.{file}") !;
         var asset = new MemoryStream();
         stream.CopyTo(asset);
         asset.Position = 0;


### PR DESCRIPTION
The reason it fails to load the powerpoint correctly was because another LatinName was created in the text RunProperty. Also, some text don't have RunProperties bur EndParagraphRunProperties, we should use it instead.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of strings, color names, and font properties in the codebase. It enhances the robustness of string comparisons, refines font property assignments, and ensures proper initialization of font-related objects.

### Detailed summary
- Modified `StringOf` method in `Assets.cs` to read a file's content.
- Changed string comparison in `HexFromName` method from `ToLower()` to `Equals()` with `StringComparison.CurrentCultureIgnoreCase`.
- Improved font property handling in `TextPortionFont.cs` by checking for null values and appending `LatinFont` correctly.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->