### PR TITLE
Adjust test SetPicture_should_not_break_presentation

### DIFF
--- a/test/ShapeCrawler.Tests.Unit/ShapeFillTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeFillTests.cs
@@ -206,7 +206,6 @@ public class ShapeFillTests : SCTest
 
         // Assert
         pres.Validate();
-        SaveResult(pres); // this statement should be removed after fixing the issue
     }
 
     [TestCase("autoshape-case005_text-frame.pptx", 1, "AutoShape 1")]

--- a/test/ShapeCrawler.Tests.Unit/ShapeFillTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeFillTests.cs
@@ -192,7 +192,7 @@ public class ShapeFillTests : SCTest
     }
 
     [Test]
-    [Explicit]
+    [Explicit("A bug")] // this attribute should be removed after fixing the issue
     public void SetPicture_should_not_break_presentation()
     {
         // Arrange
@@ -206,6 +206,7 @@ public class ShapeFillTests : SCTest
 
         // Assert
         pres.Validate();
+        SaveResult(pres); // this statement should be removed after fixing the issue
     }
 
     [TestCase("autoshape-case005_text-frame.pptx", 1, "AutoShape 1")]


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR addresses a specific bug in the `SetPicture_should_not_break_presentation` test method by adding explicit notes regarding temporary statements that should be removed after the issue is resolved.

### Detailed summary
- Modified the `Explicit` attribute to include a message: `"A bug"` indicating a temporary fix.
- Added a comment to the `SaveResult(pres);` statement indicating it should be removed after fixing the issue.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->