### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog  
 
-## Version 0.60.1 - Unreleased
+## Version 0.61.0 - Unreleased
 🐞Fixed updating font [#828](https://github.com/ShapeCrawler/ShapeCrawler/issues/828)  
+🍀Added support macOS ARM [D823](https://github.com/ShapeCrawler/ShapeCrawler/discussions/823)  
 
 ## Version 0.60.0 - 2025-01-07
 🐞Fixed trim warning `IL2104` [#708](https://github.com/ShapeCrawler/ShapeCrawler/issues/708)  


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `CHANGELOG.md` to reflect changes for version `0.61.0`. It includes a fix for font updating and adds support for macOS ARM.

### Detailed summary
- Updated version from `0.60.1` to `0.61.0`.
- Fixed updating font (issue #828).
- Added support for macOS ARM (discussion D823).
- Retained details for version `0.60.0` dated `2025-01-07`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->