### PR TITLE
Refactor tests

### DIFF
--- a/src/ShapeCrawler/Presentations/IFileProperties.cs
+++ b/src/ShapeCrawler/Presentations/IFileProperties.cs
@@ -31,8 +31,11 @@ public interface IFileProperties
     DateTime? Created { get; set; }
 
     /// <summary>
-    ///     Gets or sets the primary creator. The identification is environment-specific and can consist of a name, email address, employee ID, etc. It is recommended that this value be only as verbose as necessary to identify the individual.
+    ///     Gets or sets the primary creator.
     /// </summary>
+    /// <remarks>
+    ///     The identification is environment-specific and can consist of a name, email address, employee ID, etc. It is recommended that this value be only as verbose as necessary to identify the individual.     
+    /// </remarks>
     string? Author { get; set; }
 
     /// <summary>
@@ -41,24 +44,27 @@ public interface IFileProperties
     string? Comments { get; set; }
 
     /// <summary>
-    ///     Gets or sets a delimited set of keywords (tags) to support searching and indexing. This is typically a list of terms that are not available elsewhere in the properties.
+    ///     Gets or sets a delimited set of keywords (tags) to support searching and indexing.
     /// </summary>
     /// <remarks>
-    ///     The delimeter to use is not specified.
+    ///      This is typically a list of terms that are not available elsewhere in the properties. The delimiter to use is not specified.
     /// </remarks>
     string? Tags { get; set; }
 
     /// <summary>
-    ///     Gets or sets the primary language of the package content. The language tag is composed of one or more parts: A primary language subtag and a (possibly empty) series of subsequent subtags, for example, "EN-US". These values MUST follow the convention specified in RFC 3066.
+    ///     Gets or sets the primary language of the package content.
     /// </summary>
     /// <remarks>
-    ///     Show in File Explorer, but not in PowerPoint client.
+    ///     The language tag is composed of one or more parts: A primary language subtag and a (possibly empty) series of subsequent subtags, for example, "EN-US". These values MUST follow the convention specified in RFC 3066. Show in File Explorer, but not in PowerPoint client.
     /// </remarks>
     string? Language { get; set; }
 
     /// <summary>
-    ///     Gets or sets the user who performed the last modification. The identification is environment-specific and can consist of a name, email address, employee ID, etc. It is recommended that this value be only as verbose as necessary to identify the individual.
+    ///     Gets or sets the user who performed the last modification.
     /// </summary>
+    /// <remarks>
+    ///     The identification is environment-specific and can consist of a name, email address, employee ID, etc. It is recommended that this value be only as verbose as necessary to identify the individual.
+    /// </remarks>
     string? LastModifiedBy { get; set; }
 
     /// <summary>
@@ -72,15 +78,15 @@ public interface IFileProperties
     DateTime? Modified { get; set; }
 
     /// <summary>
-    ///     Gets or sets the revision number. This value indicates the number of saves or revisions. The application is responsible for updating this value after each revision.
+    ///     Gets or sets the revision number.
     /// </summary>
     /// <remarks>
-    ///     Show in File Explorer, but not in PowerPoint client.
+    ///      This value indicates the number of saves or revisions. The application is responsible for updating this value after each revision. Show in File Explorer, but not in PowerPoint client.
     /// </remarks>
     int? RevisionNumber { get; set; }
 
     /// <summary>
-    ///     Gets or sets the topic of the contents.
+    ///     Gets or sets the topic of the content.
     /// </summary>
     string? Subject { get; set; }
 
@@ -90,7 +96,10 @@ public interface IFileProperties
     string? Title { get; set; }
 
     /// <summary>
-    ///     Gets or sets the version number. This value is set by the user or by the application.
+    ///     Gets or sets the version number.
     /// </summary>
+    /// <remarks>
+    ///     This value is set by the user or by the application.
+    /// </remarks>
     string? Version { get; set; }
 }

--- a/src/ShapeCrawler/Presentations/IPresentationProperties.cs
+++ b/src/ShapeCrawler/Presentations/IPresentationProperties.cs
@@ -38,7 +38,7 @@ public interface IPresentationProperties
     IFooter Footer { get; }
 
     /// <summary>
-    ///     Gets the proeprties of the file.
+    ///     Gets the properties (meta-data) of the file.
     /// </summary>
     /// <remarks>
     ///     These properties are not presentation-specific.

--- a/src/ShapeCrawler/Presentations/Presentation.cs
+++ b/src/ShapeCrawler/Presentations/Presentation.cs
@@ -37,7 +37,7 @@ public sealed class Presentation : IPresentation
         var stream = assets.StreamOf("new-presentation.pptx");
         this.validateable = new StreamPresentation(stream);
         this.validateable.FileProperties.Modified =
-            this.validateable.FileProperties.Created = ShapeCrawlerInternal.TimeProvider.UtcNow;
+            this.validateable.FileProperties.Created = SCSettings.TimeProvider.UtcNow;
     }
 
     /// <inheritdoc />

--- a/src/ShapeCrawler/Presentations/Presentation.cs
+++ b/src/ShapeCrawler/Presentations/Presentation.cs
@@ -13,7 +13,7 @@ public sealed class Presentation : IPresentation
     private IValidateable validateable;
 
     /// <summary>
-    ///     Initializes a new instance of the <see cref="Presentation"/> class.
+    ///     Opens existing presentation from specified path.
     /// </summary>
     public Presentation(string path)
     {
@@ -21,7 +21,7 @@ public sealed class Presentation : IPresentation
     }
 
     /// <summary>
-    ///     Initializes a new instance of the <see cref="Presentation"/> class.
+    ///     Opens existing presentation from specified stream.
     /// </summary>
     public Presentation(Stream stream)
     {
@@ -29,7 +29,7 @@ public sealed class Presentation : IPresentation
     }
 
     /// <summary>
-    ///     Initializes a new instance of the <see cref="Presentation"/> class.
+    ///     Creates a new presentation.
     /// </summary>
     public Presentation()
     {

--- a/src/ShapeCrawler/Presentations/PresentationCore.cs
+++ b/src/ShapeCrawler/Presentations/PresentationCore.cs
@@ -71,14 +71,14 @@ internal sealed class PresentationCore
 
     internal void CopyTo(string path)
     {
-        this.FileProperties.Modified = ShapeCrawlerInternal.TimeProvider.UtcNow;
+        this.FileProperties.Modified = SCSettings.TimeProvider.UtcNow;
         var cloned = this.sdkPresDocument.Clone(path);
         cloned.Dispose();
     }
 
     internal void CopyTo(Stream stream)
     {
-        this.FileProperties.Modified = ShapeCrawlerInternal.TimeProvider.UtcNow;
+        this.FileProperties.Modified = SCSettings.TimeProvider.UtcNow;
         this.sdkPresDocument.Clone(stream);
     }
 

--- a/src/ShapeCrawler/Shared/SCSettings.cs
+++ b/src/ShapeCrawler/Shared/SCSettings.cs
@@ -1,6 +1,6 @@
 namespace ShapeCrawler.Shared;
 
-internal static class ShapeCrawlerInternal
+internal static class SCSettings
 {
     internal static ITimeProvider TimeProvider { get; set; } = new SystemTimeProvider();
 }

--- a/src/ShapeCrawler/Shared/TimeProvider.cs
+++ b/src/ShapeCrawler/Shared/TimeProvider.cs
@@ -3,19 +3,16 @@ using System;
 namespace ShapeCrawler.Shared;
 
 /// <summary>
-/// Provides the current date and time.
+///     Provides the current date and time.
 /// </summary>
 internal interface ITimeProvider
 {
     /// <summary>
-    /// Gets current date and time.
+    ///     Gets the current date and time.
     /// </summary>
     DateTime UtcNow { get; }
 }
 
-/// <summary>
-/// Provides the actual real current date and time.
-/// </summary>
 internal class SystemTimeProvider: ITimeProvider
 {
     DateTime ITimeProvider.UtcNow => DateTime.UtcNow;

--- a/src/ShapeCrawler/Tables/ITable.cs
+++ b/src/ShapeCrawler/Tables/ITable.cs
@@ -102,7 +102,7 @@ internal sealed class Table : CopyableShape, ITable
         set => this.SetTableStyle(value);
     }
 
-    public ITableStyleOptions TableStyleOptions { get; init; }
+    public ITableStyleOptions TableStyleOptions { get; }
 
     public override bool Removeable => true;
 

--- a/src/ShapeCrawler/Tables/ITableStyleOptions.cs
+++ b/src/ShapeCrawler/Tables/ITableStyleOptions.cs
@@ -3,83 +3,74 @@ using DocumentFormat.OpenXml.Drawing;
 namespace ShapeCrawler.Tables;
 
 /// <summary>
-///     Represents table style options.
+///     Represents a table style options.
 /// </summary>
 public interface ITableStyleOptions
 {
     /// <summary>
-    ///     Gets or sets a value indicating whether table has header row.
+    ///     Gets or sets a value indicating whether the table has header row.
     /// </summary>
     public bool HasHeaderRow { get; set; }
     
     /// <summary>
-    ///     Gets or sets a value indicating whether table has total row.
+    ///     Gets or sets a value indicating whether the table has total row.
     /// </summary>
     public bool HasTotalRow { get; set; }
     
     /// <summary>
-    ///     Gets or sets a value indicating whether table has banded rows.
+    ///     Gets or sets a value indicating whether the table has banded rows.
     /// </summary>
     public bool HasBandedRows { get; set; }
     
     /// <summary>
-    ///     Gets or sets a value indicating whether table has first column.
+    ///     Gets or sets a value indicating whether the table has first column.
     /// </summary>
     public bool HasFirstColumn { get; set; }
     
     /// <summary>
-    ///     Gets or sets a value indicating whether table has last column.
+    ///     Gets or sets a value indicating whether the table has last column.
     /// </summary>
     public bool HasLastColumn { get; set; }
     
     /// <summary>
-    ///     Gets or sets a value indicating whether table has banded columns.
+    ///     Gets or sets a value indicating whether the table has banded columns.
     /// </summary>
     public bool HasBandedColumns { get; set; }
 }
 
-/// <summary>
-///    Represents table style options.
-/// </summary>
 internal sealed class TableStyleOptions(TableProperties tableProperties)
     : ITableStyleOptions
 {
-    /// <inheritdoc/>
     public bool HasHeaderRow
     {
         get => tableProperties.FirstRow?.Value ?? false;
         set => tableProperties.FirstRow = value;
     }
 
-    /// <inheritdoc/>
     public bool HasTotalRow
     {
         get => tableProperties.LastRow?.Value ?? false;
         set => tableProperties.LastRow = value;
     }
 
-    /// <inheritdoc/>
     public bool HasBandedRows
     {
         get => tableProperties.BandRow?.Value ?? false;
         set => tableProperties.BandRow = value;
     }
 
-    /// <inheritdoc/>
     public bool HasFirstColumn
     {
         get => tableProperties.FirstColumn?.Value ?? false;
         set => tableProperties.FirstColumn = value;
     }
 
-    /// <inheritdoc/>
     public bool HasLastColumn
     {
         get => tableProperties.LastColumn?.Value ?? false;
         set => tableProperties.LastColumn = value;
     }
 
-    /// <inheritdoc/>
     public bool HasBandedColumns
     {
         get => tableProperties.BandColumn?.Value ?? false;

--- a/test/ShapeCrawler.Tests.Unit/Helpers/FakeTimeProvider.cs
+++ b/test/ShapeCrawler.Tests.Unit/Helpers/FakeTimeProvider.cs
@@ -2,11 +2,7 @@ using ShapeCrawler.Shared;
 
 namespace ShapeCrawler.Tests.Unit.Helpers;
 
-/// <summary>
-/// Provides a faked time which can be controlled by unit tests.
-/// </summary>
-/// <param name="fakeTime">Fake time to return when asked.</param>
-internal class FakeTimeProvider(DateTime fakeTime): ITimeProvider
+internal class FakeTimeProvider(DateTime date): ITimeProvider
 {
-    DateTime ITimeProvider.UtcNow => fakeTime;
+    DateTime ITimeProvider.UtcNow => date;
 }

--- a/test/ShapeCrawler.Tests.Unit/PresentationTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/PresentationTests.cs
@@ -364,7 +364,45 @@ public class PresentationTests : SCTest
         // Assert
         autoShapeText.Should().BeEquivalentTo(originalText);
     }
+    
+    [Test]
+    public void SaveAs_sets_the_creation_date()
+    {
+        // Arrange
+        var expectedCreated = DateTime.Parse("2024-01-01T12:34:56Z", CultureInfo.InvariantCulture);
+        SCSettings.TimeProvider = new FakeTimeProvider(expectedCreated);
+        var stream = new MemoryStream();
 
+        // Act
+        var pres = new Presentation();
+        pres.SaveAs(stream);
+
+        // Assert
+        stream.Position = 0;
+        var updatedPres = new Presentation(stream);
+        updatedPres.FileProperties.Created.Should().Be(expectedCreated);
+    }
+    
+    [Test]
+    public void SaveAs_sets_the_date_of_the_last_modification()
+    {
+        // Arrange
+        var expectedCreated = DateTime.Parse("2024-01-01T12:34:56Z", CultureInfo.InvariantCulture);
+        SCSettings.TimeProvider = new FakeTimeProvider(expectedCreated);
+        var pres = new Presentation();
+        var expectedModified = DateTime.Parse("2024-02-02T15:30:45Z", CultureInfo.InvariantCulture);
+        SCSettings.TimeProvider = new FakeTimeProvider(expectedModified);
+        var stream = new MemoryStream();
+
+        // Act
+        pres.SaveAs(stream);
+
+        // Assert
+        stream.Position = 0;
+        var updatedPres = new Presentation(stream);
+        updatedPres.FileProperties.Modified.Should().Be(expectedModified);
+    } 
+    
     [Test]
     public void BinaryData_returns_presentation_binary_content_After_updating_series()
     {
@@ -503,7 +541,7 @@ public class PresentationTests : SCTest
     }
 
     [Test]
-    public void FileProperties_setter_sets_Title()
+    public void FileProperties_Title_Setter_sets_title()
     {
         // Arrange
         var pres = new Presentation();
@@ -519,33 +557,31 @@ public class PresentationTests : SCTest
     }
 
     [Test]
-    public void FileProperties_setter_survives_round_trip()
+    public void FileProperties_getters_return_valid_values_after_saving_presentation()
     {
         // Arrange
         var pres = new Presentation();
         var expectedCreated = new DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Local);
+        var stream = new MemoryStream();
+
+        // Act
         pres.FileProperties.Title = "Properties_setter_survives_round_trip";
         pres.FileProperties.Created = expectedCreated;
         pres.FileProperties.RevisionNumber = 100;
-
-        // Act
-        var stream = new MemoryStream();
         pres.SaveAs(stream);
+        
+        // Assert
         stream.Position = 0;
         var updatePres = new Presentation(stream);
-
-        // Assert
-        updatePres.FileProperties.Created.Should().Be(expectedCreated);
         updatePres.FileProperties.Title.Should().Be("Properties_setter_survives_round_trip");
+        updatePres.FileProperties.Created.Should().Be(expectedCreated);
         pres.FileProperties.RevisionNumber.Should().Be(100);
     }
 
     [Test]
-    public void Properties_from_stream_getter_returns_values()
+    public void FileProperties_Modified_Getter_returns_date_of_the_last_modification()
     {
-        var pptx = TestAsset("059_crop-images.pptx");
-        var pres = new Presentation(pptx);
-
+        var pres = new Presentation(TestAsset("059_crop-images.pptx"));
         var expectedModified = DateTime.Parse("2024-12-16T17:11:58Z", CultureInfo.InvariantCulture);
 
         // Act-Assert
@@ -554,27 +590,9 @@ public class PresentationTests : SCTest
         pres.FileProperties.RevisionNumber.Should().Be(7);
         pres.FileProperties.Comments.Should().BeNull();
     }
-
+    
     [Test]
-    public void Create_sets_created_date()
-    {
-        // Arrange
-        var expectedCreated = DateTime.Parse("2024-01-01T12:34:56Z", CultureInfo.InvariantCulture);
-        SCSettings.TimeProvider = new FakeTimeProvider(expectedCreated);
-
-        // Act
-        var pres = new Presentation();
-        var stream = new MemoryStream();
-        pres.SaveAs(stream);
-        stream.Position = 0;
-        var loadedPres = new Presentation(stream);
-
-        // Assert
-        loadedPres.FileProperties.Created.Should().Be(expectedCreated);
-    }
-
-    [Test]
-    public void Create_sets_modified_date()
+    public void Non_parameter_constructor_sets_the_date_of_the_last_modification()
     {
         // Arrange
         var expectedModified = DateTime.Parse("2024-01-01T12:34:56Z", CultureInfo.InvariantCulture);
@@ -586,25 +604,4 @@ public class PresentationTests : SCTest
         // Assert
         pres.FileProperties.Modified.Should().Be(expectedModified);
     }
-
-    [Test]
-    public void SaveAs_sets_file_property_Modified()
-    {
-        // Arrange
-        var expectedCreated = DateTime.Parse("2024-01-01T12:34:56Z", CultureInfo.InvariantCulture);
-        SCSettings.TimeProvider = new FakeTimeProvider(expectedCreated);
-        var pres = new Presentation();
-
-        var expectedModified = DateTime.Parse("2024-02-02T15:30:45Z", CultureInfo.InvariantCulture);
-        SCSettings.TimeProvider = new FakeTimeProvider(expectedModified);
-        var stream = new MemoryStream();
-
-        // Act
-        pres.SaveAs(stream);
-        stream.Position = 0;
-        var loadedPres = new Presentation(stream);
-
-        // Assert
-        loadedPres.FileProperties.Modified.Should().Be(expectedModified);
-    } 
 }

--- a/test/ShapeCrawler.Tests.Unit/PresentationTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/PresentationTests.cs
@@ -503,7 +503,7 @@ public class PresentationTests : SCTest
     }
 
     [Test]
-    public void Properties_setter_sets_values()
+    public void FileProperties_setter_sets_Title()
     {
         // Arrange
         var pres = new Presentation();
@@ -514,12 +514,12 @@ public class PresentationTests : SCTest
         pres.FileProperties.Created = expectedCreated;
         
         // Assert
-        pres.FileProperties.Created.Should().Be(expectedCreated);
         pres.FileProperties.Title.Should().Be("Properties_setter_sets_values");
+        pres.FileProperties.Created.Should().Be(expectedCreated);
     }
 
     [Test]
-    public void Properties_setter_survives_round_trip()
+    public void FileProperties_setter_survives_round_trip()
     {
         // Arrange
         var pres = new Presentation();
@@ -532,11 +532,11 @@ public class PresentationTests : SCTest
         var stream = new MemoryStream();
         pres.SaveAs(stream);
         stream.Position = 0;
-        var loadedPres = new Presentation(stream);
+        var updatePres = new Presentation(stream);
 
         // Assert
-        loadedPres.FileProperties.Created.Should().Be(expectedCreated);
-        loadedPres.FileProperties.Title.Should().Be("Properties_setter_survives_round_trip");
+        updatePres.FileProperties.Created.Should().Be(expectedCreated);
+        updatePres.FileProperties.Title.Should().Be("Properties_setter_survives_round_trip");
         pres.FileProperties.RevisionNumber.Should().Be(100);
     }
 
@@ -560,7 +560,7 @@ public class PresentationTests : SCTest
     {
         // Arrange
         var expectedCreated = DateTime.Parse("2024-01-01T12:34:56Z", CultureInfo.InvariantCulture);
-        ShapeCrawlerInternal.TimeProvider = new FakeTimeProvider(expectedCreated);
+        SCSettings.TimeProvider = new FakeTimeProvider(expectedCreated);
 
         // Act
         var pres = new Presentation();
@@ -578,7 +578,7 @@ public class PresentationTests : SCTest
     {
         // Arrange
         var expectedModified = DateTime.Parse("2024-01-01T12:34:56Z", CultureInfo.InvariantCulture);
-        ShapeCrawlerInternal.TimeProvider = new FakeTimeProvider(expectedModified);
+        SCSettings.TimeProvider = new FakeTimeProvider(expectedModified);
 
         // Act
         var pres = new Presentation();
@@ -592,11 +592,11 @@ public class PresentationTests : SCTest
     {
         // Arrange
         var expectedCreated = DateTime.Parse("2024-01-01T12:34:56Z", CultureInfo.InvariantCulture);
-        ShapeCrawlerInternal.TimeProvider = new FakeTimeProvider(expectedCreated);
+        SCSettings.TimeProvider = new FakeTimeProvider(expectedCreated);
         var pres = new Presentation();
 
         var expectedModified = DateTime.Parse("2024-02-02T15:30:45Z", CultureInfo.InvariantCulture);
-        ShapeCrawlerInternal.TimeProvider = new FakeTimeProvider(expectedModified);
+        SCSettings.TimeProvider = new FakeTimeProvider(expectedModified);
         var stream = new MemoryStream();
 
         // Act

--- a/test/ShapeCrawler.Tests.Unit/TableTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/TableTests.cs
@@ -924,14 +924,20 @@ public class TableTests : SCTest
     [TestCase(false, false, false, true, false, false)]
     [TestCase(false, false, false, false, true, false)]
     [TestCase(false, false, false, false, false, true)]
-    public void TableStyleOptions_setter_set_table_style_options(bool hasHeaderRow, bool hasTotalRow, bool hasBandedRows, bool hasFirstColumn, bool hasLastColumn, bool hasBandedColumns)
+    public void TableStyleOptions_property_setters_set_table_style_options(
+        bool hasHeaderRow, 
+        bool hasTotalRow, 
+        bool hasBandedRows, 
+        bool hasFirstColumn, 
+        bool hasLastColumn, 
+        bool hasBandedColumns)
     {
         // Arrange
         var mStream = new MemoryStream();
         var pres = new Presentation();
         var slide = pres.Slides[0];
         slide.Shapes.AddTable(0, 0, 3, 2);
-        var table = slide.Shapes.Last() as ITable;
+        var table = slide.Shapes.Last<ITable>();
 
         // Act
         table.TableStyleOptions.HasHeaderRow = hasHeaderRow;
@@ -944,7 +950,7 @@ public class TableTests : SCTest
         // Assert
         pres.SaveAs(mStream);
         pres = new Presentation(mStream);
-        table = pres.Slides[0].Shapes.Last() as ITable;
+        table = pres.Slides[0].Shapes.Last<ITable>();
         table.TableStyleOptions.HasHeaderRow.Should().Be(hasHeaderRow);
         table.TableStyleOptions.HasTotalRow.Should().Be(hasTotalRow);
         table.TableStyleOptions.HasBandedRows.Should().Be(hasBandedRows);
@@ -954,13 +960,13 @@ public class TableTests : SCTest
     }
     
     [Test]
-    public void Table_creation_has_tableStyleOptions_default_options()
+    public void TableStyleOptions_property_getters_return_table_style_options()
     {
         // Arrange
         var pres = new Presentation();
         var slide = pres.Slides[0];
         slide.Shapes.AddTable(0, 0, 3, 2);
-        var table = slide.Shapes.Last() as ITable;
+        var table = slide.Shapes.Last<ITable>();
 
         // Act
         var options = table.TableStyleOptions;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR primarily focuses on improving the clarity and consistency of comments, refactoring some internal class names, and updating the handling of `TableStyleOptions` and file properties in the `Presentation` class. It also adds new unit tests for better coverage.

### Detailed summary
- Changed `TableStyleOptions` property from `get; init;` to `get;` in `ITable`.
- Updated comments for clarity in multiple files.
- Renamed `ShapeCrawlerInternal` to `SCSettings`.
- Updated `FakeTimeProvider` constructor parameter name from `fakeTime` to `date`.
- Refactored `Presentation` class methods to use `SCSettings.TimeProvider`.
- Improved unit test method names for clarity and consistency.
- Added new unit tests for creation and modification dates in `Presentation`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->