### PR TITLE
Remove timestamps from generated PNGs

### DIFF
--- a/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
@@ -8,6 +8,7 @@ using System.Text.RegularExpressions;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using ImageMagick;
+using ImageMagick.Formats;
 using ShapeCrawler.Exceptions;
 using ShapeCrawler.Extensions;
 using ShapeCrawler.Presentations;
@@ -168,7 +169,7 @@ internal sealed class SlideShapes : ISlideShapes
             }
             
             var rasterStream = new MemoryStream();
-            imageMagick.Write(rasterStream);
+            imageMagick.Write(rasterStream, new PngWriteDefines() { IncludeChunks = PngChunkFlags.None });
             image.Position = 0;
             rasterStream.Position = 0;
             pPicture = this.CreateSvgPPicture(rasterStream, image, "Picture");

--- a/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
@@ -350,7 +350,6 @@ public class ShapeCollectionTests : SCTest
     }
 
     [Test]
-    [Explicit("Fails. Tracked in issue #883")]
     [Category("issue-883")]
     public async Task AddPicture_should_not_duplicate_the_image_source_When_the_same_svg_image_is_added_twice()
     {
@@ -361,7 +360,7 @@ public class ShapeCollectionTests : SCTest
 
         // Act
         shapes.AddPicture(svgImage);
-        Task.Delay(1100).Wait();
+        Task.Delay(1100).Wait(); // See issue #883
         shapes.AddPicture(svgImage);
 
         // Assert
@@ -372,7 +371,6 @@ public class ShapeCollectionTests : SCTest
     }
     
     [Test]
-    [Explicit("Fails. Tracked in issue #883")]
     [Category("issue-883")]
     public void AddPicture_should_not_duplicate_the_image_source_When_the_same_svg_image_is_added_on_two_different_slides()
     {
@@ -385,7 +383,7 @@ public class ShapeCollectionTests : SCTest
 
         // Act
         shapesSlide1.AddPicture(image);
-        Task.Delay(1100).Wait();
+        Task.Delay(1100).Wait(); // See issue #883
         shapesSlide2.AddPicture(image);
 
         // Assert
@@ -956,7 +954,6 @@ public class ShapeCollectionTests : SCTest
     }
     
     [Test]
-    [Explicit("Fails. Tracked in issue #883")]
     [Category("issue-883")]
     public void AddPicture_should_not_duplicate_the_image_source_When_the_same_svg_image_is_added_to_a_loaded_presentation()
     {
@@ -970,7 +967,7 @@ public class ShapeCollectionTests : SCTest
 
         // Act
         shapes = loadedPres.Slides[0].Shapes;
-        Task.Delay(1100).Wait();
+        Task.Delay(1100).Wait(); // See issue #883
         shapes.AddPicture(image);
 
         // Assert

--- a/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
@@ -350,8 +350,9 @@ public class ShapeCollectionTests : SCTest
     }
 
     [Test]
-    [Explicit("A flaky test. Should be fixed")]
-    public void AddPicture_should_not_duplicate_the_image_source_When_the_same_svg_image_is_added_twice()
+    [Explicit("Fails. Tracked in issue #883")]
+    [Category("issue-883")]
+    public async Task AddPicture_should_not_duplicate_the_image_source_When_the_same_svg_image_is_added_twice()
     {
         // Arrange
         var pres = new Presentation();
@@ -360,6 +361,7 @@ public class ShapeCollectionTests : SCTest
 
         // Act
         shapes.AddPicture(svgImage);
+        Task.Delay(1100).Wait();
         shapes.AddPicture(svgImage);
 
         // Assert
@@ -370,7 +372,8 @@ public class ShapeCollectionTests : SCTest
     }
     
     [Test]
-    [Explicit("A flaky test. Should be fixed")]
+    [Explicit("Fails. Tracked in issue #883")]
+    [Category("issue-883")]
     public void AddPicture_should_not_duplicate_the_image_source_When_the_same_svg_image_is_added_on_two_different_slides()
     {
         // Arrange
@@ -382,6 +385,7 @@ public class ShapeCollectionTests : SCTest
 
         // Act
         shapesSlide1.AddPicture(image);
+        Task.Delay(1100).Wait();
         shapesSlide2.AddPicture(image);
 
         // Assert
@@ -952,7 +956,8 @@ public class ShapeCollectionTests : SCTest
     }
     
     [Test]
-    [Explicit("A flaky test, should be fixed")]
+    [Explicit("Fails. Tracked in issue #883")]
+    [Category("issue-883")]
     public void AddPicture_should_not_duplicate_the_image_source_When_the_same_svg_image_is_added_to_a_loaded_presentation()
     {
         // Arrange
@@ -965,6 +970,7 @@ public class ShapeCollectionTests : SCTest
 
         // Act
         shapes = loadedPres.Slides[0].Shapes;
+        Task.Delay(1100).Wait();
         shapes.AddPicture(image);
 
         // Assert

--- a/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
@@ -360,7 +360,6 @@ public class ShapeCollectionTests : SCTest
 
         // Act
         shapes.AddPicture(svgImage);
-        Task.Delay(1100).Wait(); // See issue #883
         shapes.AddPicture(svgImage);
 
         // Assert
@@ -383,7 +382,6 @@ public class ShapeCollectionTests : SCTest
 
         // Act
         shapesSlide1.AddPicture(image);
-        Task.Delay(1100).Wait(); // See issue #883
         shapesSlide2.AddPicture(image);
 
         // Assert
@@ -967,7 +965,6 @@ public class ShapeCollectionTests : SCTest
 
         // Act
         shapes = loadedPres.Slides[0].Shapes;
-        Task.Delay(1100).Wait(); // See issue #883
         shapes.AddPicture(image);
 
         // Assert

--- a/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
@@ -351,7 +351,7 @@ public class ShapeCollectionTests : SCTest
 
     [Test]
     [Category("issue-883")]
-    public async Task AddPicture_should_not_duplicate_the_image_source_When_the_same_svg_image_is_added_twice()
+    public void AddPicture_should_not_duplicate_the_image_source_When_the_same_svg_image_is_added_twice()
     {
         // Arrange
         var pres = new Presentation();


### PR DESCRIPTION
This fixes a bug introduced in PR #830. When adding SVGs, the rasterized PNG was being created with a timestamp. This interfered with the logic to de-duplicate image assets in a single presentation.

@ashahabov Couple things to consider. Adding delay to these tests was required to make them reliably fail. Leaving it in will increase test execution time. Second, I added categories on these test to make them easy to run repeatedly. Could remove this if you consider it clutter.

Fixes #883

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates image handling in the `ShapeCollection` and modifies test attributes for better categorization.

### Detailed summary
- In `SlideShapes.cs`, changed the `Write` method call on `imageMagick` to include `PngWriteDefines` with `IncludeChunks` set to `PngChunkFlags.None`.
- In `ShapeCollectionTests.cs`, replaced `[Explicit]` attributes with `[Category("issue-883")]` for three test methods to categorize them under a specific issue.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->