### PR TITLE
Revert test

### DIFF
--- a/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
@@ -169,6 +169,7 @@ internal sealed class SlideShapes : ISlideShapes
             }
             
             var rasterStream = new MemoryStream();
+            imageMagick.Density = new Density(384, 384, DensityUnit.PixelsPerInch);
             imageMagick.Write(rasterStream, new PngWriteDefines() { IncludeChunks = PngChunkFlags.None });
             image.Position = 0;
             rasterStream.Position = 0;

--- a/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
@@ -169,7 +169,6 @@ internal sealed class SlideShapes : ISlideShapes
             }
             
             var rasterStream = new MemoryStream();
-            imageMagick.Density = new Density(384, 384, DensityUnit.PixelsPerInch);
             imageMagick.Write(rasterStream, new PngWriteDefines() { IncludeChunks = PngChunkFlags.None });
             image.Position = 0;
             rasterStream.Position = 0;

--- a/test/ShapeCrawler.Tests.Unit/Helpers/SCTest.cs
+++ b/test/ShapeCrawler.Tests.Unit/Helpers/SCTest.cs
@@ -31,6 +31,7 @@ public abstract class SCTest
         var stream = assembly.GetResourceStream(file);
         var mStream = new MemoryStream();
         stream!.CopyTo(mStream);
+        mStream.Position = 0;
 
         return mStream;
     }

--- a/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
@@ -993,4 +993,24 @@ public class ShapeCollectionTests : SCTest
         var imageParts = checkXml.PresentationPart!.SlideParts.SelectMany(slidePart => slidePart.ImageParts).ToArray();
         imageParts.Length.Should().Be(1);
     }
+    
+    [Test]
+    [Explicit("Should be implemented with https://github.com/ShapeCrawler/ShapeCrawler/issues/696")]
+    public void AddPicture_sets_384_ppi_resolution_for_svg_picture()
+    {
+        // Arrange
+        var pres = new Presentation();
+        var shapes = pres.Slides[0].Shapes;
+        var svg = TestAsset("063 vector image.svg");
+        
+        // Act
+        shapes.AddPicture(svg);
+        
+        // Assert
+        var addedPicture = shapes.Last<IPicture>();
+        var addedPictureInfo = new MagickImageInfo(addedPicture.Image!.AsByteArray());
+        var addedPictureResolution = addedPictureInfo.Density!.ChangeUnits(DensityUnit.PixelsPerInch);
+        addedPictureResolution.X.Should().BeApproximately(384, 0.1);
+        addedPictureResolution.Y.Should().BeApproximately(384, 0.1);
+    }
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing unit tests in the `ShapeCrawler` project, particularly for the handling of SVG images and ensuring they are added with the correct resolution.

### Detailed summary
- In `SCTest.cs`, added a line to reset the `Position` of `mStream` to 0 after copying data.
- In `ShapeCollectionTests.cs`, introduced a new test method `AddPicture_sets_384_ppi_resolution_for_svg_picture` to verify that SVG images are added with a resolution of 384 ppi.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->