### PR TITLE
Remove unused dependencies

### DIFF
--- a/src/ShapeCrawler/ShapeCrawler.csproj
+++ b/src/ShapeCrawler/ShapeCrawler.csproj
@@ -79,6 +79,8 @@ This library provides a simplified object model on top of the Open XML SDK for m
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Resources.Extensions" Version="5.0.0" />
+    <PackageReference Include="System.Text.Json" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ShapeCrawler/ShapeCrawler.csproj
+++ b/src/ShapeCrawler/ShapeCrawler.csproj
@@ -69,6 +69,10 @@ This library provides a simplified object model on top of the Open XML SDK for m
     <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.4.0" />
     <PackageReference Include="Magick.NET.SystemDrawing" Version="8.0.4" />
     <PackageReference Include="DocumentFormat.OpenXml.Linq" Version="3.2.0" />
+    <PackageReference Include="PolySharp" Version="1.15.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="SkiaSharp" Version="3.116.1" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.116.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/src/ShapeCrawler/ShapeCrawler.csproj
+++ b/src/ShapeCrawler/ShapeCrawler.csproj
@@ -66,21 +66,15 @@ This library provides a simplified object model on top of the Open XML SDK for m
 
   <ItemGroup>
     <PackageReference Include="DocumentFormat.OpenXml" Version="3.2.0" />
-    <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.2.0" />
-    <PackageReference Include="Magick.NET.SystemDrawing" Version="8.0.2" />
+    <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.4.0" />
+    <PackageReference Include="Magick.NET.SystemDrawing" Version="8.0.4" />
     <PackageReference Include="DocumentFormat.OpenXml.Linq" Version="3.2.0" />
-    <PackageReference Include="PolySharp" Version="1.15.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="SkiaSharp" Version="3.116.1" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.116.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Resources.Extensions" Version="5.0.0" />
-    <PackageReference Include="System.Text.Json" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/ShapeCrawler.Tests.Integration/PresentationITests.cs
+++ b/test/ShapeCrawler.Tests.Integration/PresentationITests.cs
@@ -1,13 +1,13 @@
 using System.IO;
 using FluentAssertions;
+using NUnit.Framework;
 using ShapeCrawler.Tests.Unit.Helpers;
-using Xunit;
 
 namespace ShapeCrawler.Tests.Integration;
 
 public class PresentationITests : SCTest
 {
-    [Fact]
+    [Test]
     public void Open_should_not_throw_exception()
     {
         // Arrange
@@ -26,7 +26,7 @@ public class PresentationITests : SCTest
         File.Delete(savedAsFilePath);
     }
     
-    [Fact]
+    [Test]
     public void SaveAs_should_not_change_the_Original_Path_when_it_is_saved_to_New_Stream()
     {
         // Arrange
@@ -50,7 +50,7 @@ public class PresentationITests : SCTest
         File.Delete(originalPath);
     }
            
-    [Fact]
+    [Test]
     public void SaveAs_should_not_change_the_Original_Stream_when_it_is_saved_to_New_Path()
     {
         // Arrange

--- a/test/ShapeCrawler.Tests.Integration/ShapeCrawler.Tests.Integration.csproj
+++ b/test/ShapeCrawler.Tests.Integration/ShapeCrawler.Tests.Integration.csproj
@@ -18,14 +18,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.12.0" />
+        <PackageReference Include="FluentAssertions" Version="7.1.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-        <PackageReference Include="NUnit" Version="4.1.0" />
-        <PackageReference Include="xunit" Version="2.6.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
+        <PackageReference Include="NUnit" Version="4.3.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/ShapeCrawler.Tests.Integration/ShapeCrawler.Tests.Integration.csproj
+++ b/test/ShapeCrawler.Tests.Integration/ShapeCrawler.Tests.Integration.csproj
@@ -18,7 +18,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="7.1.0" />
+        <PackageReference Include="FluentAssertions" Version="[7.1.0]" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
         <PackageReference Include="NUnit" Version="4.3.2" />
     </ItemGroup>

--- a/test/ShapeCrawler.Tests.Unit/ShapeCrawler.Tests.Unit.csproj
+++ b/test/ShapeCrawler.Tests.Unit/ShapeCrawler.Tests.Unit.csproj
@@ -18,12 +18,12 @@
 
   <ItemGroup>
     <PackageReference Include="ClosedXML" Version="0.95.4" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.2.0" />
+    <PackageReference Include="FluentAssertions" Version="[7.1.0]" />
+    <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="NUnit" Version="4.1.0" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.2.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating package references in various project files, including version upgrades for `Magick.NET`, `FluentAssertions`, and `NUnit`, as well as transitioning from `xUnit` to `NUnit` in the test files.

### Detailed summary
- Updated `Magick.NET-Q16-AnyCPU` from version `14.2.0` to `14.4.0`.
- Updated `Magick.NET.SystemDrawing` from version `8.0.2` to `8.0.4`.
- Updated `FluentAssertions` from version `6.12.0` to `[7.1.0]`.
- Updated `NUnit` from version `4.1.0` to `4.3.2`.
- Removed `xUnit` references and replaced `[Fact]` attributes with `[Test]` in `PresentationITests`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->