### PR TITLE
Refactor TextParagraphPortion

### DIFF
--- a/src/ShapeCrawler/Colors/Color.cs
+++ b/src/ShapeCrawler/Colors/Color.cs
@@ -47,11 +47,6 @@ public struct Color
         this.Alpha = alpha;
     }
 
-    private Color((int r, int g, int b, float a) color)
-        : this(color.r, color.g, color.b, color.a)
-    {
-    }
-
     /// <summary>
     ///     Gets or sets the alpha value.
     /// </summary>
@@ -59,21 +54,6 @@ public struct Color
     /// Values are 0 to 255, where 0 is totally transparent.
     /// </remarks>
     public float Alpha { get; set; }
-
-    /// <summary>
-    ///     Gets the blue value.
-    /// </summary>
-    public int B => this.blue;
-
-    /// <summary>
-    ///     Gets the green value.
-    /// </summary>
-    public int G => this.green;
-
-    /// <summary>
-    ///     Gets the red value.
-    /// </summary>
-    public int R => this.red;
 
     /// <summary>
     ///     Gets hexadecimal code.
@@ -102,16 +82,12 @@ public struct Color
 
         return new(r, g, b, a);
     }
-    
+
     /// <summary>
     ///     Creates color hexadecimal code.
     /// </summary>
-    public override string ToString()
-    {
-        // String representation ignores alpha value
-        return $"{this.R:X2}{this.G:X2}{this.B:X2}";
-    }
-    
+    public override string ToString() => $"{this.red:X2}{this.green:X2}{this.blue:X2}";
+
     /// <summary>
     ///     Returns a color of RGBA.
     /// </summary>

--- a/src/ShapeCrawler/Texts/TextParagraphPortion.cs
+++ b/src/ShapeCrawler/Texts/TextParagraphPortion.cs
@@ -38,15 +38,15 @@ internal sealed class TextParagraphPortion : IParagraphPortion
 
     public Color TextHighlightColor
     {
-        get => this.ParseTextHighlight();
-        set => this.UpdateTextHighlight(value);
+        get => this.GetTextHighlight();
+        set => this.SetTextHighlight(value);
     }
 
     internal A.Text AText { get; }
 
     public void Remove() => this.aRun.Remove();
 
-    private Color ParseTextHighlight()
+    private Color GetTextHighlight()
     {
         var arPr = this.AText.PreviousSibling<A.RunProperties>();
 
@@ -71,7 +71,7 @@ internal sealed class TextParagraphPortion : IParagraphPortion
         return color;
     }
 
-    private void UpdateTextHighlight(Color color)
+    private void SetTextHighlight(Color color)
     {
         var arPr = this.AText.PreviousSibling<A.RunProperties>() ?? this.AText.Parent!.AddRunProperties();
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on refactoring the `TextHighlightColor` property in `TextParagraphPortion.cs` for improved clarity and consistency, along with simplifying the `Color` class by removing unnecessary properties and methods.

### Detailed summary
- Renamed `ParseTextHighlight` to `GetTextHighlight` in `TextParagraphPortion.cs`.
- Renamed `UpdateTextHighlight` to `SetTextHighlight` in `TextParagraphPortion.cs`.
- Removed the private constructor in `Color.cs`.
- Removed properties `B`, `G`, and `R` in `Color.cs`.
- Simplified `ToString()` method in `Color.cs`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->