### PR TITLE
Add test for duplicate images with a delay

### DIFF
--- a/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
@@ -415,6 +415,32 @@ public class ShapeCollectionTests : SCTest
         imageParts.Count.Should().Be(1);
     }
     
+    [TestCase("jpeg image-500w.jpg")]
+    [TestCase("png image-1.png")]
+    [TestCase("gif image.gif")]
+    [TestCase("tiff image.tiff")]
+    public void AddPicture_should_not_duplicate_the_image_source_When_the_same_image_is_added_a_second_apart(string fileName)
+    {
+        // Arrange
+        var pres = new Presentation();
+        pres.Slides.AddEmptySlide(SlideLayoutType.Blank);
+        var shapesSlide1 = pres.Slides[0].Shapes;
+        var shapesSlide2 = pres.Slides[1].Shapes;
+
+        var image = TestAsset(fileName);
+
+        // Act
+        shapesSlide1.AddPicture(image);
+        Thread.Sleep(1000);
+        shapesSlide2.AddPicture(image);
+
+        // Assert
+        var sdkPres = SaveAndOpenPresentationAsSdk(pres);
+        var imageParts = sdkPres.PresentationPart!.SlideParts.SelectMany(slidePart => slidePart.ImageParts).Select(imagePart => imagePart.Uri)
+            .ToHashSet();
+        imageParts.Count.Should().Be(1);
+    }
+    
     [Test]
     [Explicit("Should be fixed")]
     public void AddPicture_should_not_duplicate_the_image_source_When_slide_is_copied()

--- a/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
@@ -431,7 +431,7 @@ public class ShapeCollectionTests : SCTest
 
         // Act
         shapesSlide1.AddPicture(image);
-        Thread.Sleep(1000);
+        Task.Delay(1000).Wait();
         shapesSlide2.AddPicture(image);
 
         // Assert


### PR DESCRIPTION
The bug fixed by @jcoliz in #885 is very easy to reimplement without knowing. For the last few PRs `AddPicture_should_not_duplicate_the_image_source_When_the_same_image_is_added_on_two_different_slides` has had to be run 100+ times to gain confidence the bug hasn't been reintroduced. Hence I think this is need.

I know the original argument was that this should be in a separate test library, which I can do in this PR, but I think it is unnecessary. 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new unit test for the `AddPicture` method in the `ShapeCollectionTests` class, ensuring that adding the same image to different slides does not result in duplicate image sources.

### Detailed summary
- Added four `TestCase` attributes for different image formats.
- Implemented `AddPicture_should_not_duplicate_the_image_source_When_the_same_image_is_added_a_second_apart` method.
- The test checks that adding the same image to two slides only creates one image source in the presentation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->