### PR TITLE
Rename color Transparent

### DIFF
--- a/src/ShapeCrawler/Colors/Color.cs
+++ b/src/ShapeCrawler/Colors/Color.cs
@@ -18,7 +18,7 @@ public struct Color
     /// <summary>
     ///     Predefined transparent color.
     /// </summary>
-    public static readonly Color Transparent = new(0, 0, 0, 0);
+    public static readonly Color NoColor = new(0, 0, 0, 0);
 
     /// <summary>
     ///     Predefined white color.

--- a/src/ShapeCrawler/Texts/Field.cs
+++ b/src/ShapeCrawler/Texts/Field.cs
@@ -57,7 +57,7 @@ internal sealed class Field : IParagraphPortion
         if (arPr?.GetFirstChild<A.Highlight>()?.RgbColorModelHex is not A.RgbColorModelHex aSrgbClr
             || aSrgbClr.Val is null)
         {
-            return Color.Transparent;
+            return Color.NoColor;
         }
 
         // Gets node value.

--- a/src/ShapeCrawler/Texts/TextParagraphPortion.cs
+++ b/src/ShapeCrawler/Texts/TextParagraphPortion.cs
@@ -58,7 +58,7 @@ internal sealed class TextParagraphPortion : IParagraphPortion
         if (arPr?.GetFirstChild<A.Highlight>()?.RgbColorModelHex is not A.RgbColorModelHex aSrgbClr
             || aSrgbClr.Val is null)
         {
-            return Color.Transparent;
+            return Color.NoColor;
         }
 
         // TODO: Check if DocumentFormat.OpenXml.StringValue is necessary.


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on changing the representation of a transparent color to a "no color" designation within the `ShapeCrawler` codebase, enhancing clarity in color handling.

### Detailed summary
- In `src/ShapeCrawler/Texts/Field.cs`, replaced `Color.Transparent` with `Color.NoColor`.
- In `src/ShapeCrawler/Texts/TextParagraphPortion.cs`, replaced `Color.Transparent` with `Color.NoColor`.
- In `src/ShapeCrawler/Colors/Color.cs`, changed the static readonly field name from `Transparent` to `NoColor`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->