### PR TITLE
Remove nullable text

### DIFF
--- a/src/ShapeCrawler/Texts/Field.cs
+++ b/src/ShapeCrawler/Texts/Field.cs
@@ -30,7 +30,7 @@ internal sealed class Field : IParagraphPortion
     }
 
     /// <inheritdoc/>
-    public string? Text
+    public string Text
     {
         get => this.portionText.Text();
         set => this.portionText.Update(value!);

--- a/src/ShapeCrawler/Texts/IParagraphPortion.cs
+++ b/src/ShapeCrawler/Texts/IParagraphPortion.cs
@@ -9,11 +9,14 @@ public interface IParagraphPortion
     /// <summary>
     ///     Gets or sets text.
     /// </summary>
-    string? Text { get; set; }
+    string Text { get; set; }
 
     /// <summary>
     ///     Gets font.
     /// </summary>
+    /// <remarks>
+    ///     Returns <see langword="null"/> if the portion type doesn't support font, e.g., when it is a Line Break.
+    /// </remarks>
     ITextPortionFont? Font { get; }
 
     /// <summary>

--- a/src/ShapeCrawler/Texts/ParagraphLineBreak.cs
+++ b/src/ShapeCrawler/Texts/ParagraphLineBreak.cs
@@ -13,7 +13,7 @@ internal sealed record ParagraphLineBreak : IParagraphPortion
         this.aBreak = aBreak;
     }
 
-    public string? Text { get; set; } = Environment.NewLine;
+    public string Text { get; set; } = Environment.NewLine;
 
     public ITextPortionFont? Font { get; }
 

--- a/src/ShapeCrawler/Texts/TextParagraphPortion.cs
+++ b/src/ShapeCrawler/Texts/TextParagraphPortion.cs
@@ -22,7 +22,7 @@ internal sealed class TextParagraphPortion : IParagraphPortion
         this.hyperlink = new Lazy<Hyperlink>(() => new Hyperlink(this.aRun.RunProperties!));
     }
 
-    public string? Text
+    public string Text
     {
         get => this.AText.Text;
         set

--- a/src/ShapeCrawler/Texts/TextParagraphPortion.cs
+++ b/src/ShapeCrawler/Texts/TextParagraphPortion.cs
@@ -25,20 +25,12 @@ internal sealed class TextParagraphPortion : IParagraphPortion
     public string Text
     {
         get => this.AText.Text;
-        set
-        {
-            if (value == null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
-
-            this.AText.Text = value;
-        }
+        set => this.AText.Text = value;
     }
 
     public ITextPortionFont Font => this.font.Value;
 
-    public IHyperlink? Link => this.hyperlink.Value;
+    public IHyperlink Link => this.hyperlink.Value;
 
     public Color TextHighlightColor
     {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `Text` property in several classes to remove nullable types, ensuring that `Text` must always have a value. It also includes some adjustments to property accessors and documentation comments.

### Detailed summary
- Changed `Text` property in `Field.cs` from `string?` to `string`.
- Changed `Text` property in `ParagraphLineBreak.cs` from `string?` to `string`.
- Updated `Text` property in `IParagraphPortion.cs` from `string?` to `string`.
- Modified `Text` property in `TextParagraphPortion.cs` to simplify the setter.
- Changed `Link` property in `TextParagraphPortion.cs` from `IHyperlink?` to `IHyperlink`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->