### PR TITLE
Add SOpenXmlPart

### DIFF
--- a/src/ShapeCrawler/Colors/FontColor.cs
+++ b/src/ShapeCrawler/Colors/FontColor.cs
@@ -43,7 +43,7 @@ internal sealed class FontColor : IFontColor
 
             // TryFromTextBody()
             var aParagraph = this.aText.Ancestors<A.Paragraph>().First();
-            var indentLevel = new WrappedAParagraph(aParagraph).IndentLevel();
+            var indentLevel = new SAParagraph(aParagraph).IndentLevel();
             var pTextBody = aParagraph.Ancestors<P.TextBody>().First();
             var aListStyle = pTextBody.GetFirstChild<A.ListStyle>() !;
             var textBodyStyleFont = new IndentFonts(aListStyle).FontOrNull(indentLevel);
@@ -96,7 +96,7 @@ internal sealed class FontColor : IFontColor
 
             // From TextBody
             var aParagraph = this.aText.Ancestors<A.Paragraph>().First();
-            var indentLevel = new WrappedAParagraph(aParagraph).IndentLevel();
+            var indentLevel = new SAParagraph(aParagraph).IndentLevel();
             var pTextBody = aParagraph.Ancestors<P.TextBody>().First();
             var textBodyStyleFont = new IndentFonts(pTextBody.GetFirstChild<A.ListStyle>()
                 !).FontOrNull(indentLevel);
@@ -129,7 +129,7 @@ internal sealed class FontColor : IFontColor
 
             // From Common Placeholder
             var pSlideMasterWrap =
-                new WrappedPSlideMaster(pSlideMaster);
+                new SPSlideMaster(pSlideMaster);
             var masterIndentFont = pSlideMasterWrap.BodyStyleFontOrNull(indentLevel);
             if (this.TryFromIndentFont(masterIndentFont, out var masterColor))
             {

--- a/src/ShapeCrawler/Drawing/Picture.cs
+++ b/src/ShapeCrawler/Drawing/Picture.cs
@@ -6,8 +6,8 @@ using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Office2019.Drawing.SVG;
 using DocumentFormat.OpenXml.Packaging;
 using ShapeCrawler.Exceptions;
-using ShapeCrawler.Extensions;
 using ShapeCrawler.ShapeCollection;
+using ShapeCrawler.Shared;
 using A = DocumentFormat.OpenXml.Drawing;
 using P = DocumentFormat.OpenXml.Presentation;
 

--- a/src/ShapeCrawler/Drawing/Picture.cs
+++ b/src/ShapeCrawler/Drawing/Picture.cs
@@ -137,7 +137,7 @@ internal sealed class Picture : CopyableShape, IPicture
         var sourceImagePart = (ImagePart)sourceSdkSlidePart.GetPartById(this.blipEmbed.Value!);
 
         // Creates a new part in this slide with a new Id...
-        var targetImagePartRId = this.SdkTypedOpenXmlPart.NextRelationshipId();
+        var targetImagePartRId = new SOpenXmlPart(this.SdkTypedOpenXmlPart).NextRelationshipId();
 
         // Adds to current slide parts and update relation id.
         var targetImagePart = this.SdkTypedOpenXmlPart.AddNewPart<ImagePart>(sourceImagePart.ContentType, targetImagePartRId);

--- a/src/ShapeCrawler/Drawing/SImagePart.cs
+++ b/src/ShapeCrawler/Drawing/SImagePart.cs
@@ -3,11 +3,11 @@ using DocumentFormat.OpenXml.Packaging;
 
 namespace ShapeCrawler.Drawing;
 
-internal readonly ref struct WrappedImagePart
+internal readonly ref struct SImagePart
 {
     private readonly ImagePart imagePart;
 
-    internal WrappedImagePart(ImagePart imagePart)
+    internal SImagePart(ImagePart imagePart)
     {
         this.imagePart = imagePart;
     }

--- a/src/ShapeCrawler/Drawing/ShapeFillImage.cs
+++ b/src/ShapeCrawler/Drawing/ShapeFillImage.cs
@@ -36,5 +36,5 @@ internal sealed class ShapeFillImage : IImage
         this.sdkImagePart.FeedData(stream);
     }
 
-    public byte[] AsByteArray() => new WrappedImagePart(this.sdkImagePart).AsBytes(); 
+    public byte[] AsByteArray() => new SImagePart(this.sdkImagePart).AsBytes(); 
 }

--- a/src/ShapeCrawler/Drawing/SlidePictureImage.cs
+++ b/src/ShapeCrawler/Drawing/SlidePictureImage.cs
@@ -40,5 +40,5 @@ internal sealed class SlidePictureImage : IImage
         this.sdkImagePart.FeedData(stream);
     }
 
-    public byte[] AsByteArray() => new WrappedImagePart(this.sdkImagePart).AsBytes();
+    public byte[] AsByteArray() => new SImagePart(this.sdkImagePart).AsBytes();
 }

--- a/src/ShapeCrawler/Extensions/TypedOpenXmlPartExtensions.cs
+++ b/src/ShapeCrawler/Extensions/TypedOpenXmlPartExtensions.cs
@@ -1,45 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Text.RegularExpressions;
+﻿using System.IO;
 using DocumentFormat.OpenXml.Packaging;
 
 namespace ShapeCrawler.Extensions;
 
 internal static class TypedOpenXmlPartExtensions
 {
-    internal static string NextRelationshipId(this OpenXmlPart openXmlPart)
-    {
-        var idNums = new List<long>();
-        var relationships = openXmlPart.ExternalRelationships.Select(r => r.Id)
-            .Union(openXmlPart.HyperlinkRelationships.Select(r => r.Id))
-            .Union(openXmlPart.DataPartReferenceRelationships.Select(r => r.Id))
-            .Union(openXmlPart.Parts.Select(p => p.RelationshipId));
-        foreach (var relationship in relationships)
-        {
-            var match = Regex.Match(relationship, @"\d+", RegexOptions.None, TimeSpan.FromMilliseconds(1000));
-            if (match.Success)
-            {
-                var id = long.Parse(match.Value, NumberStyles.None, NumberFormatInfo.CurrentInfo);
-                idNums.Add(id);
-            }
-        }
-
-        var nextId = 1L;
-        if (idNums.Any())
-        {
-            nextId = idNums.Max() + 1;
-        }
-        
-        return $"rId{nextId}";        
-    }
-    
     internal static (string, ImagePart) AddImagePart(this OpenXmlPart typedOpenXmlPart, Stream stream, string mimeType)
     {
-        var rId = typedOpenXmlPart.NextRelationshipId();
-        
+        var rId = new SOpenXmlPart(typedOpenXmlPart).NextRelationshipId();
+
         var imagePart = typedOpenXmlPart.AddNewPart<ImagePart>(mimeType, rId);
         stream.Position = 0;
         imagePart.FeedData(stream);

--- a/src/ShapeCrawler/Extensions/TypedOpenXmlPartExtensions.cs
+++ b/src/ShapeCrawler/Extensions/TypedOpenXmlPartExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using DocumentFormat.OpenXml.Packaging;
+using ShapeCrawler.Shared;
 
 namespace ShapeCrawler.Extensions;
 

--- a/src/ShapeCrawler/Fonts/PortionFontSize.cs
+++ b/src/ShapeCrawler/Fonts/PortionFontSize.cs
@@ -34,7 +34,7 @@ internal class PortionFontSize : IFontSize
             return size.Value / HalfPointsInPoint;
         }
 
-        var indentLevel = new WrappedAParagraph(this.aText.Ancestors<A.Paragraph>().First()).IndentLevel();
+        var indentLevel = new SAParagraph(this.aText.Ancestors<A.Paragraph>().First()).IndentLevel();
         SlideMasterPart sdkSlideMasterPart;
         if (this.sdkTypedOpenXmlPart is SlideMasterPart)
         {

--- a/src/ShapeCrawler/Fonts/TextPortionFont.cs
+++ b/src/ShapeCrawler/Fonts/TextPortionFont.cs
@@ -16,7 +16,7 @@ internal sealed class TextPortionFont : ITextPortionFont
     private readonly Lazy<FontColor> fontColor;
     private readonly IFontSize size;
     private readonly ThemeFontScheme themeFontScheme;
-    private readonly WrappedAText sdkWrappedAText;
+    private readonly SAText sdkSaText;
 
     internal TextPortionFont(
         OpenXmlPart sdkTypedOpenXmlPart,
@@ -41,7 +41,7 @@ internal sealed class TextPortionFont : ITextPortionFont
         this.fontColor = new Lazy<FontColor>(() => new FontColor(sdkTypedOpenXmlPart, this.aText));
         this.size = size;
         this.themeFontScheme = themeFontScheme;
-        this.sdkWrappedAText = new WrappedAText(sdkTypedOpenXmlPart, aText);
+        this.sdkSaText = new SAText(sdkTypedOpenXmlPart, aText);
     }
 
     #region Public APIs
@@ -68,8 +68,8 @@ internal sealed class TextPortionFont : ITextPortionFont
 
     public string EastAsianName
     {
-        get => this.sdkWrappedAText.EastAsianName();
-        set => this.sdkWrappedAText.UpdateEastAsianName(value);
+        get => this.sdkSaText.EastAsianName();
+        set => this.sdkSaText.UpdateEastAsianName(value);
     }
 
     public bool IsBold

--- a/src/ShapeCrawler/Presentations/SPPresentation.cs
+++ b/src/ShapeCrawler/Presentations/SPPresentation.cs
@@ -3,11 +3,12 @@ using P = DocumentFormat.OpenXml.Presentation;
 
 namespace ShapeCrawler.Presentations;
 
-internal readonly ref struct WrappedPPresentation
+// ReSharper disable once InconsistentNaming
+internal readonly ref struct SPPresentation
 {
     private readonly P.Presentation pPresentation;
 
-    internal WrappedPPresentation(P.Presentation pPresentation)
+    internal SPPresentation(P.Presentation pPresentation)
     {
         this.pPresentation = pPresentation;
     }

--- a/src/ShapeCrawler/Presentations/SPresentationPart.cs
+++ b/src/ShapeCrawler/Presentations/SPresentationPart.cs
@@ -5,11 +5,11 @@ using P = DocumentFormat.OpenXml.Presentation;
 
 namespace ShapeCrawler.Presentations;
 
-internal readonly ref struct WrappedPresentationPart
+internal readonly ref struct SPresentationPart
 {
     private readonly PresentationPart presentationPart;
 
-    internal WrappedPresentationPart(PresentationPart presentationPart)
+    internal SPresentationPart(PresentationPart presentationPart)
     {
         this.presentationPart = presentationPart;
     }

--- a/src/ShapeCrawler/Presentations/SPresentationPart.cs
+++ b/src/ShapeCrawler/Presentations/SPresentationPart.cs
@@ -1,6 +1,6 @@
 ﻿using System.Linq;
 using DocumentFormat.OpenXml.Packaging;
-using ShapeCrawler.Extensions;
+using ShapeCrawler.Shared;
 using P = DocumentFormat.OpenXml.Presentation;
 
 namespace ShapeCrawler.Presentations;

--- a/src/ShapeCrawler/Presentations/SPresentationPart.cs
+++ b/src/ShapeCrawler/Presentations/SPresentationPart.cs
@@ -16,13 +16,13 @@ internal readonly ref struct SPresentationPart
 
     internal void AddSlidePart(SlidePart slidePart)
     {
-        var rId = this.presentationPart.NextRelationshipId();
+        var rId = new SOpenXmlPart(this.presentationPart).NextRelationshipId();
         var addedSlidePart = this.presentationPart.AddPart(slidePart, rId);
 
         var notesSlidePartAddedSlidePart = addedSlidePart.GetPartsOfType<NotesSlidePart>().FirstOrDefault();
         notesSlidePartAddedSlidePart?.DeletePart(notesSlidePartAddedSlidePart.NotesMasterPart!);
 
-        rId = this.presentationPart.NextRelationshipId();
+        rId = new SOpenXmlPart(this.presentationPart).NextRelationshipId();
         var addedSlideMasterPart = this.presentationPart.AddPart(addedSlidePart.SlideLayoutPart!.SlideMasterPart!, rId);
         var layoutIdList = addedSlideMasterPart.SlideMaster.SlideLayoutIdList!.OfType<P.SlideLayoutId>();
         foreach (var layoutId in layoutIdList.ToList())

--- a/src/ShapeCrawler/Presentations/SSlideMasterPart.cs
+++ b/src/ShapeCrawler/Presentations/SSlideMasterPart.cs
@@ -3,11 +3,11 @@ using DocumentFormat.OpenXml.Packaging;
 
 namespace ShapeCrawler.Presentations;
 
-internal readonly ref struct WrappedSlideMasterPart
+internal readonly ref struct SSlideMasterPart
 {
     private readonly SlideMasterPart slideMasterPart;
 
-    internal WrappedSlideMasterPart(SlideMasterPart slideMasterPart)
+    internal SSlideMasterPart(SlideMasterPart slideMasterPart)
     {
         this.slideMasterPart = slideMasterPart;
     }

--- a/src/ShapeCrawler/Presentations/Slide.cs
+++ b/src/ShapeCrawler/Presentations/Slide.cs
@@ -8,7 +8,6 @@ using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Presentation;
 using ShapeCrawler.Drawing;
 using ShapeCrawler.Exceptions;
-using ShapeCrawler.Extensions;
 using ShapeCrawler.ShapeCollection;
 using ShapeCrawler.Shared;
 using A = DocumentFormat.OpenXml.Drawing;

--- a/src/ShapeCrawler/Presentations/Slide.cs
+++ b/src/ShapeCrawler/Presentations/Slide.cs
@@ -226,7 +226,7 @@ internal sealed class Slide : ISlide
         }
 
         // https://learn.microsoft.com/en-us/office/open-xml/presentation/working-with-notes-slides
-        var rid = this.SdkSlidePart.NextRelationshipId();
+        var rid = new SOpenXmlPart(this.SdkSlidePart).NextRelationshipId();
         var notesSlidePart1 = this.SdkSlidePart.AddNewPart<NotesSlidePart>(rid);
         var notesSlide = new NotesSlide(
             new CommonSlideData(

--- a/src/ShapeCrawler/Presentations/Slides.cs
+++ b/src/ShapeCrawler/Presentations/Slides.cs
@@ -73,7 +73,7 @@ internal sealed class Slides : ISlides
     {
         var sdkPresDocument = (PresentationDocument)this.presentationPart.OpenXmlPackage;
         var sdkPresPart = sdkPresDocument.PresentationPart!;
-        var rId = sdkPresPart.NextRelationshipId();
+        var rId = new SOpenXmlPart(sdkPresPart).NextRelationshipId();
         var sdkSlidePart = sdkPresPart.AddNewPart<SlidePart>(rId);
         sdkSlidePart.Slide = new P.Slide(
             new P.CommonSlideData(
@@ -86,8 +86,9 @@ internal sealed class Slides : ISlides
             new P.ColorMapOverride(new A.MasterColorMapping()));
         var layoutInternal = (SlideLayout)layout;
         sdkSlidePart.AddPart(layoutInternal.SdkSlideLayoutPart(), "rId1");
-        
-        if (layoutInternal.SdkSlideLayoutPart().SlideLayout.CommonSlideData is P.CommonSlideData commonSlideData && commonSlideData.ShapeTree is P.ShapeTree shapeTree) 
+
+        if (layoutInternal.SdkSlideLayoutPart().SlideLayout.CommonSlideData is P.CommonSlideData commonSlideData &&
+            commonSlideData.ShapeTree is P.ShapeTree shapeTree)
         {
             var placeholderShapes = shapeTree.ChildElements
                 .OfType<P.Shape>()
@@ -153,7 +154,8 @@ internal sealed class Slides : ISlides
         var sourceSlideId = (P.SlideId)sourceSlidePresPart.Presentation.SlideIdList!.ChildElements[slide.Number - 1];
         var sourceSlidePart = (SlidePart)sourceSlidePresPart.GetPartById(sourceSlideId.RelationshipId!);
 
-        new SSlideMasterPart(sourceSlidePart.SlideLayoutPart!.SlideMasterPart!).RemoveLayoutsExcept(sourceSlidePart.SlideLayoutPart!);
+        new SSlideMasterPart(sourceSlidePart.SlideLayoutPart!.SlideMasterPart!).RemoveLayoutsExcept(sourceSlidePart
+            .SlideLayoutPart!);
 
         var wrappedPresentationPart = new SPresentationPart(targetPresPart);
         wrappedPresentationPart.AddSlidePart(sourceSlidePart);
@@ -170,7 +172,9 @@ internal sealed class Slides : ISlides
         // Creates a new TextBody
         if (shape.TextBody is null)
         {
-            return new P.TextBody(new DocumentFormat.OpenXml.Drawing.Paragraph([new DocumentFormat.OpenXml.Drawing.EndParagraphRunProperties()]))
+            return new P.TextBody(new DocumentFormat.OpenXml.Drawing.Paragraph([
+                new DocumentFormat.OpenXml.Drawing.EndParagraphRunProperties()
+            ]))
             {
                 BodyProperties = new DocumentFormat.OpenXml.Drawing.BodyProperties(),
                 ListStyle = new DocumentFormat.OpenXml.Drawing.ListStyle(),
@@ -179,7 +183,7 @@ internal sealed class Slides : ISlides
 
         return (P.TextBody)shape.TextBody.CloneNode(true);
     }
-    
+
     private static void AdjustLayoutIds(PresentationDocument sdkPresDocDest, uint masterId)
     {
         foreach (var slideMasterPart in sdkPresDocDest.PresentationPart!.SlideMasterParts)
@@ -203,8 +207,7 @@ internal sealed class Slides : ISlides
         var masterId = CreateId(sdkPresDest.SlideMasterIdList!);
         P.SlideMasterId slideMaterId = new()
         {
-            Id = masterId,
-            RelationshipId = sdkPresDocDest.PresentationPart!.GetIdOfPart(addedSlideMasterPart!)
+            Id = masterId, RelationshipId = sdkPresDocDest.PresentationPart!.GetIdOfPart(addedSlideMasterPart!)
         };
         sdkPresDocDest.PresentationPart.Presentation.SlideMasterIdList!.Append(slideMaterId);
         sdkPresDocDest.PresentationPart.Presentation.Save();
@@ -234,7 +237,7 @@ internal sealed class Slides : ISlides
 
         return ++currentId;
     }
-    
+
     private static uint CreateId(P.SlideMasterIdList slideMasterIdList)
     {
         uint currentId = 0;

--- a/src/ShapeCrawler/Presentations/Slides.cs
+++ b/src/ShapeCrawler/Presentations/Slides.cs
@@ -5,7 +5,7 @@ using System.IO;
 using System.Linq;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
-using ShapeCrawler.Extensions;
+using ShapeCrawler.Shared;
 using A = DocumentFormat.OpenXml.Drawing;
 using P = DocumentFormat.OpenXml.Presentation;
 using P14 = DocumentFormat.OpenXml.Office2010.PowerPoint;

--- a/src/ShapeCrawler/Presentations/Slides.cs
+++ b/src/ShapeCrawler/Presentations/Slides.cs
@@ -52,7 +52,7 @@ internal sealed class Slides : ISlides
         pPresentation.Save();
 
         var removingSlideIdRelationshipId = removingPSlideId.RelationshipId!;
-        new WrappedPPresentation(pPresentation).RemoveSlideIdFromCustomShow(removingSlideIdRelationshipId.Value!);
+        new SPPresentation(pPresentation).RemoveSlideIdFromCustomShow(removingSlideIdRelationshipId.Value!);
 
         var removingSlidePart = (SlidePart)presPart.GetPartById(removingSlideIdRelationshipId!);
         presPart.DeletePart(removingSlidePart);
@@ -153,9 +153,9 @@ internal sealed class Slides : ISlides
         var sourceSlideId = (P.SlideId)sourceSlidePresPart.Presentation.SlideIdList!.ChildElements[slide.Number - 1];
         var sourceSlidePart = (SlidePart)sourceSlidePresPart.GetPartById(sourceSlideId.RelationshipId!);
 
-        new WrappedSlideMasterPart(sourceSlidePart.SlideLayoutPart!.SlideMasterPart!).RemoveLayoutsExcept(sourceSlidePart.SlideLayoutPart!);
+        new SSlideMasterPart(sourceSlidePart.SlideLayoutPart!.SlideMasterPart!).RemoveLayoutsExcept(sourceSlidePart.SlideLayoutPart!);
 
-        var wrappedPresentationPart = new WrappedPresentationPart(targetPresPart);
+        var wrappedPresentationPart = new SPresentationPart(targetPresPart);
         wrappedPresentationPart.AddSlidePart(sourceSlidePart);
         var addedSlidePart = wrappedPresentationPart.Last<SlidePart>();
         var addedSlideMasterPart = wrappedPresentationPart.Last<SlideMasterPart>();

--- a/src/ShapeCrawler/ShapeCollection/ChartCreator.cs
+++ b/src/ShapeCrawler/ShapeCollection/ChartCreator.cs
@@ -1,0 +1,124 @@
+﻿namespace ShapeCrawler.ShapeCollection;
+
+using System;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Presentation;
+using DocumentFormat.OpenXml.Drawing.Charts;
+using A = DocumentFormat.OpenXml.Drawing;
+
+internal class ChartCreator(SlidePart slidePart)
+{
+    internal void AddPieChart()
+    {
+        var chartPart = slidePart.AddNewPart<ChartPart>("rId3");
+        GeneratePieChartContent(chartPart);
+
+        InsertChartGraphicFrame(chartPart);
+    }
+    
+    /// <summary>
+    /// Generates the XML for a simple Pie Chart with 3 categories.
+    /// </summary>
+    private static void GeneratePieChartContent(ChartPart chartPart)
+    {
+        // Create the ChartSpace
+        ChartSpace chartSpace = new ChartSpace();
+        chartSpace.Append(new EditingLanguage() { Val = "en-US" });
+        chartSpace.Append(new RoundedCorners() { Val = false });
+
+        // Create the Chart
+        Chart chart = new Chart();
+        chart.Append(new AutoTitleDeleted() { Val = true }); // Hide default chart title
+
+        PlotArea plotArea = new PlotArea();
+        plotArea.Append(new Layout());
+
+        // Create the PieChart element
+        PieChart pieChart = new PieChart();
+        pieChart.Append(new VaryColors() { Val = true });
+
+        // PieChartSeries: define series index, order, and label
+        PieChartSeries series = new PieChartSeries(
+            new DocumentFormat.OpenXml.Drawing.Charts.Index() { Val = 0 },
+            new Order() { Val = 0 },
+            new SeriesText(new NumericValue() { Text = "Sample Series" })
+        );
+
+        // --- Categories ---
+        StringLiteral stringLiteral = new StringLiteral();
+        stringLiteral.PointCount = new PointCount() { Val = 3 };
+        stringLiteral.Append(new StringPoint() { Index = 0, NumericValue = new NumericValue("Category A") });
+        stringLiteral.Append(new StringPoint() { Index = 1, NumericValue = new NumericValue("Category B") });
+        stringLiteral.Append(new StringPoint() { Index = 2, NumericValue = new NumericValue("Category C") });
+
+        CategoryAxisData categoryAxisData = new CategoryAxisData();
+        categoryAxisData.Append(stringLiteral);
+
+        // --- Values ---
+        NumberLiteral numberLiteral = new NumberLiteral();
+        numberLiteral.FormatCode = new FormatCode("General");
+        numberLiteral.PointCount = new PointCount() { Val = 3 };
+        numberLiteral.Append(new NumericPoint() { Index = 0, NumericValue = new NumericValue("10") });
+        numberLiteral.Append(new NumericPoint() { Index = 1, NumericValue = new NumericValue("30") });
+        numberLiteral.Append(new NumericPoint() { Index = 2, NumericValue = new NumericValue("60") });
+
+        Values values = new Values();
+        values.Append(numberLiteral);
+
+        // Append categories and values to the series
+        series.Append(categoryAxisData);
+        series.Append(values);
+
+        // Add series to the PieChart
+        pieChart.Append(series);
+
+        // Add the PieChart to the PlotArea
+        plotArea.Append(pieChart);
+
+        // Complete the chart
+        chart.Append(plotArea);
+
+        // Add the chart to the ChartSpace
+        chartSpace.Append(chart);
+
+        // Assign ChartSpace to the ChartPart
+        chartPart.ChartSpace = chartSpace;
+    }
+
+    /// <summary>
+    /// Inserts a graphic frame in the slide that references the chart part by ID.
+    /// </summary>
+    private void InsertChartGraphicFrame(ChartPart chartPart)
+    {
+        // Retrieve the shape tree of the slide
+        var shapeTree = slidePart.Slide.CommonSlideData!.ShapeTree;
+
+        // Create a new GraphicFrame
+        GraphicFrame graphicFrame = new GraphicFrame();
+
+        // Give it an ID and name
+        graphicFrame.NonVisualGraphicFrameProperties = new NonVisualGraphicFrameProperties(
+            new NonVisualDrawingProperties() { Id = 2U, Name = "PieChart" },
+            new NonVisualGraphicFrameDrawingProperties(),
+            new ApplicationNonVisualDrawingProperties()
+        );
+
+        // Position/Size of the chart in EMUs (English Metric Units)
+        // For reference: 914400 EMUs = 1 inch
+        graphicFrame.Transform = new Transform(
+            new A.Offset() { X = 1524000L, Y = 1524000L }, // 1.67in from top-left corner
+            new A.Extents() { Cx = 6096000L, Cy = 3429000L } // 6.67in wide, 3.75in high
+        );
+
+        // Link the chart part by relationship ID
+        graphicFrame.Graphic = new A.Graphic(
+            new A.GraphicData(
+                new ChartReference() { Id = slidePart.GetIdOfPart(chartPart) } // "rId3"
+            ) { Uri = "http://schemas.openxmlformats.org/drawingml/2006/chart" }
+        );
+
+        // Append the graphic frame to the shape tree
+        shapeTree!.Append(graphicFrame);
+    }
+}

--- a/src/ShapeCrawler/ShapeCollection/CopyableShape.cs
+++ b/src/ShapeCrawler/ShapeCollection/CopyableShape.cs
@@ -17,6 +17,6 @@ internal abstract class CopyableShape : Shape
         P.ShapeTree pShapeTree,
         IEnumerable<string> existingShapeNames)
     {
-        new WrappedPShapeTree(pShapeTree).Add(this.PShapeTreeElement);
+        new SPShapeTree(pShapeTree).Add(this.PShapeTreeElement);
     }
 }

--- a/src/ShapeCrawler/ShapeCollection/ISlideShapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/ISlideShapes.cs
@@ -71,4 +71,9 @@ public interface ISlideShapes : IShapes
     ///     Adds picture.
     /// </summary>
     void AddPicture(Stream image);
+
+    /// <summary>
+    ///     Adds Pie Chart.
+    /// </summary>
+    void AddPieChart(int x, int y, int width, int height);
 }

--- a/src/ShapeCrawler/ShapeCollection/ReferencedIndentLevel.cs
+++ b/src/ShapeCrawler/ShapeCollection/ReferencedIndentLevel.cs
@@ -106,7 +106,7 @@ internal readonly ref struct ReferencedIndentLevel
 
         var pPlaceholder = pShape.NonVisualShapeProperties!.ApplicationNonVisualDrawingProperties!
             .GetFirstChild<P.PlaceholderShape>() !;
-        var referencedLayoutPShape = new WrappedPShapeTree(slidePart.SlideLayoutPart!.SlideLayout.CommonSlideData!.ShapeTree!).ReferencedPShapeOrNull(pPlaceholder);
+        var referencedLayoutPShape = new SPShapeTree(slidePart.SlideLayoutPart!.SlideLayout.CommonSlideData!.ShapeTree!).ReferencedPShapeOrNull(pPlaceholder);
 
         return referencedLayoutPShape;
     }
@@ -128,7 +128,7 @@ internal readonly ref struct ReferencedIndentLevel
                 .ShapeTree!
         };
 
-        var referencedPShape = new WrappedPShapeTree(slideOrLayoutPShapeTree).ReferencedPShapeOrNull(pPlaceholderShape);
+        var referencedPShape = new SPShapeTree(slideOrLayoutPShapeTree).ReferencedPShapeOrNull(pPlaceholderShape);
 
         return referencedPShape;
     }
@@ -182,7 +182,7 @@ internal readonly ref struct ReferencedIndentLevel
 
         var referencedMasterPShape = this.ReferencedMasterPShapeOrNullOf(pShape);
         var aParagraph = this.aText.Ancestors<A.Paragraph>().First();
-        var indentLevel = new WrappedAParagraph(aParagraph).IndentLevel();
+        var indentLevel = new SAParagraph(aParagraph).IndentLevel();
         if (referencedMasterPShape != null)
         {
             var masterIndentFonts = new IndentFonts(referencedMasterPShape.TextBody!.ListStyle!);
@@ -230,7 +230,7 @@ internal readonly ref struct ReferencedIndentLevel
 
         var referencedLayoutPShape = this.ReferencedLayoutPShapeOrNull(pShape);
         var aParagraph = this.aText.Ancestors<A.Paragraph>().First();
-        var indentLevel = new WrappedAParagraph(aParagraph).IndentLevel();
+        var indentLevel = new SAParagraph(aParagraph).IndentLevel();
         if (referencedLayoutPShape == null)
         {
             var referencedMasterPShape = this.ReferencedMasterPShapeOrNullOf(pShape);
@@ -315,7 +315,7 @@ internal readonly ref struct ReferencedIndentLevel
         }
 
         var referencedLayoutPShapeOrNull = this.ReferencedLayoutPShapeOrNull(slidePShape);
-        var indentLevel = new WrappedAParagraph(aParagraph).IndentLevel();
+        var indentLevel = new SAParagraph(aParagraph).IndentLevel();
         if (referencedLayoutPShapeOrNull == null)
         {
             return this.MasterOfSlideIndentColorType(slidePShape, indentLevel);
@@ -342,7 +342,7 @@ internal readonly ref struct ReferencedIndentLevel
     private bool? SlideFontBoldFlagOrNull()
     {
         var aParagraph = this.aText.Ancestors<A.Paragraph>().First();
-        var indentLevel = new WrappedAParagraph(aParagraph).IndentLevel();
+        var indentLevel = new SAParagraph(aParagraph).IndentLevel();
         var slidePShape = this.aText.Ancestors<P.Shape>().First();
         var slidePh = slidePShape.NonVisualShapeProperties!.ApplicationNonVisualDrawingProperties!
             .GetFirstChild<P.PlaceholderShape>();
@@ -386,7 +386,7 @@ internal readonly ref struct ReferencedIndentLevel
     private int? SlideFontSizeOrNull()
     {
         var aParagraph = this.aText.Ancestors<A.Paragraph>().First();
-        var indentLevel = new WrappedAParagraph(aParagraph).IndentLevel();
+        var indentLevel = new SAParagraph(aParagraph).IndentLevel();
         var slidePShape = this.aText.Ancestors<P.Shape>().FirstOrDefault();
         if (slidePShape == null)
         {
@@ -457,7 +457,7 @@ internal readonly ref struct ReferencedIndentLevel
     private A.LatinFont? SlideALatinFontOrNull(SlidePart sdkSlidePart)
     {
         var aParagraph = this.aText.Ancestors<A.Paragraph>().First();
-        var indentLevel = new WrappedAParagraph(aParagraph).IndentLevel();
+        var indentLevel = new SAParagraph(aParagraph).IndentLevel();
         var pShape = this.aText.Ancestors<P.Shape>().FirstOrDefault();
         if (pShape == null)
         {
@@ -514,7 +514,7 @@ internal readonly ref struct ReferencedIndentLevel
     private A.LatinFont SlideMasterALatinFont()
     {
         var aParagraph = this.aText.Ancestors<A.Paragraph>().First();
-        var indentLevel = new WrappedAParagraph(aParagraph).IndentLevel();
+        var indentLevel = new SAParagraph(aParagraph).IndentLevel();
         var pShape = this.aText.Ancestors<P.Shape>().First();
         var fonts = new IndentFonts(pShape.TextBody!.ListStyle!);
 

--- a/src/ShapeCrawler/ShapeCollection/RootShape.cs
+++ b/src/ShapeCrawler/ShapeCollection/RootShape.cs
@@ -57,7 +57,7 @@ internal sealed class RootShape : CopyableShape, IRootShape
     public void Duplicate()
     {
         var pShapeTree = (P.ShapeTree)this.pShape.Parent!;
-        var autoShapes = new WrappedPShapeTree(pShapeTree);
+        var autoShapes = new SPShapeTree(pShapeTree);
         autoShapes.Add(this.pShape);
     }
 }

--- a/src/ShapeCrawler/ShapeCollection/SPShapeTree.cs
+++ b/src/ShapeCrawler/ShapeCollection/SPShapeTree.cs
@@ -7,11 +7,12 @@ using P = DocumentFormat.OpenXml.Presentation;
 
 namespace ShapeCrawler.ShapeCollection;
 
-internal readonly ref struct WrappedPShapeTree
+// ReSharper disable once InconsistentNaming
+internal readonly ref struct SPShapeTree
 {
     private readonly P.ShapeTree pShapeTree;
 
-    internal WrappedPShapeTree(P.ShapeTree pShapeTree)
+    internal SPShapeTree(P.ShapeTree pShapeTree)
     {
         this.pShapeTree = pShapeTree;
     }

--- a/src/ShapeCrawler/ShapeCollection/SSlidePart.cs
+++ b/src/ShapeCrawler/ShapeCollection/SSlidePart.cs
@@ -7,7 +7,7 @@ using DocumentFormat.OpenXml.Presentation;
 using DocumentFormat.OpenXml.Drawing.Charts;
 using A = DocumentFormat.OpenXml.Drawing;
 
-internal class ChartCreator(SlidePart slidePart)
+internal readonly ref struct SSlidePart(SlidePart slidePart)
 {
     internal void AddPieChart()
     {

--- a/src/ShapeCrawler/ShapeCollection/SSlidePart.cs
+++ b/src/ShapeCrawler/ShapeCollection/SSlidePart.cs
@@ -1,7 +1,5 @@
 ﻿namespace ShapeCrawler.ShapeCollection;
 
-using System;
-using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Presentation;
 using DocumentFormat.OpenXml.Drawing.Charts;
@@ -13,8 +11,7 @@ internal readonly ref struct SSlidePart(SlidePart slidePart)
     {
         var chartPart = slidePart.AddNewPart<ChartPart>("rId3");
         GeneratePieChartContent(chartPart);
-
-        InsertChartGraphicFrame(chartPart);
+        this.InsertChartGraphicFrame(chartPart);
     }
     
     /// <summary>
@@ -42,12 +39,10 @@ internal readonly ref struct SSlidePart(SlidePart slidePart)
         PieChartSeries series = new PieChartSeries(
             new DocumentFormat.OpenXml.Drawing.Charts.Index() { Val = 0 },
             new Order() { Val = 0 },
-            new SeriesText(new NumericValue() { Text = "Sample Series" })
-        );
+            new SeriesText(new NumericValue() { Text = "Sample Series" }));
 
         // --- Categories ---
-        StringLiteral stringLiteral = new StringLiteral();
-        stringLiteral.PointCount = new PointCount() { Val = 3 };
+        var stringLiteral = new StringLiteral { PointCount = new PointCount() { Val = 3 } };
         stringLiteral.Append(new StringPoint() { Index = 0, NumericValue = new NumericValue("Category A") });
         stringLiteral.Append(new StringPoint() { Index = 1, NumericValue = new NumericValue("Category B") });
         stringLiteral.Append(new StringPoint() { Index = 2, NumericValue = new NumericValue("Category C") });
@@ -56,9 +51,7 @@ internal readonly ref struct SSlidePart(SlidePart slidePart)
         categoryAxisData.Append(stringLiteral);
 
         // --- Values ---
-        NumberLiteral numberLiteral = new NumberLiteral();
-        numberLiteral.FormatCode = new FormatCode("General");
-        numberLiteral.PointCount = new PointCount() { Val = 3 };
+        var numberLiteral = new NumberLiteral { FormatCode = new FormatCode("General"), PointCount = new PointCount() { Val = 3 } };
         numberLiteral.Append(new NumericPoint() { Index = 0, NumericValue = new NumericValue("10") });
         numberLiteral.Append(new NumericPoint() { Index = 1, NumericValue = new NumericValue("30") });
         numberLiteral.Append(new NumericPoint() { Index = 2, NumericValue = new NumericValue("60") });
@@ -95,28 +88,24 @@ internal readonly ref struct SSlidePart(SlidePart slidePart)
         var shapeTree = slidePart.Slide.CommonSlideData!.ShapeTree;
 
         // Create a new GraphicFrame
-        GraphicFrame graphicFrame = new GraphicFrame();
-
-        // Give it an ID and name
-        graphicFrame.NonVisualGraphicFrameProperties = new NonVisualGraphicFrameProperties(
-            new NonVisualDrawingProperties() { Id = 2U, Name = "PieChart" },
-            new NonVisualGraphicFrameDrawingProperties(),
-            new ApplicationNonVisualDrawingProperties()
-        );
-
-        // Position/Size of the chart in EMUs (English Metric Units)
-        // For reference: 914400 EMUs = 1 inch
-        graphicFrame.Transform = new Transform(
-            new A.Offset() { X = 1524000L, Y = 1524000L }, // 1.67in from top-left corner
-            new A.Extents() { Cx = 6096000L, Cy = 3429000L } // 6.67in wide, 3.75in high
-        );
-
-        // Link the chart part by relationship ID
-        graphicFrame.Graphic = new A.Graphic(
-            new A.GraphicData(
-                new ChartReference() { Id = slidePart.GetIdOfPart(chartPart) } // "rId3"
-            ) { Uri = "http://schemas.openxmlformats.org/drawingml/2006/chart" }
-        );
+        var graphicFrame = new GraphicFrame
+        {
+            // Give it an ID and name
+            NonVisualGraphicFrameProperties = new NonVisualGraphicFrameProperties(
+                new NonVisualDrawingProperties() { Id = 2U, Name = "PieChart" },
+                new NonVisualGraphicFrameDrawingProperties(),
+                new ApplicationNonVisualDrawingProperties()),
+            
+            // Position/Size of the chart in EMUs (English Metric Units)
+            // For reference: 914400 EMUs = 1 inch
+            Transform = new Transform(
+                new A.Offset() { X = 1524000L, Y = 1524000L }, // 1.67in from top-left corner
+                new A.Extents() { Cx = 6096000L, Cy = 3429000L }), // 6.67in wide, 3.75in high
+            Graphic = new A.Graphic(
+                new A.GraphicData(
+                    new ChartReference() { Id = slidePart.GetIdOfPart(chartPart) }) // "rId3"
+                { Uri = "http://schemas.openxmlformats.org/drawingml/2006/chart" })
+        };
 
         // Append the graphic frame to the shape tree
         shapeTree!.Append(graphicFrame);

--- a/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -6,6 +6,8 @@ using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Drawing.ChartDrawing;
+using DocumentFormat.OpenXml.Office2010.Drawing.ChartDrawing;
 using DocumentFormat.OpenXml.Packaging;
 using ImageMagick;
 using ImageMagick.Formats;
@@ -18,6 +20,8 @@ using A14 = DocumentFormat.OpenXml.Office2010.Drawing;
 using A16 = DocumentFormat.OpenXml.Office2016.Drawing;
 using P = DocumentFormat.OpenXml.Presentation;
 using Position = ShapeCrawler.Positions.Position;
+using C = DocumentFormat.OpenXml.Drawing.Charts;
+using NonVisualDrawingProperties = DocumentFormat.OpenXml.Drawing.ChartDrawing.NonVisualDrawingProperties;
 
 namespace ShapeCrawler.ShapeCollection;
 
@@ -203,10 +207,10 @@ internal sealed class SlideShapes : ISlideShapes
             throw new SCException("The stream is not an image or a non-supported image format. You can raise a discussion at https://github.com/ShapeCrawler/ShapeCrawler/discussions to find out about the possibilities supporting it.");
         }
     }
-
+    
     public void AddPieChart(int x, int y, int width, int height)
     {
-        throw new NotImplementedException();
+        new ChartCreator(this.sdkSlidePart).AddPieChart();
     }
 
     public void AddVideo(int x, int y, Stream stream)

--- a/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
@@ -210,7 +210,7 @@ internal sealed class SlideShapes : ISlideShapes
     
     public void AddPieChart(int x, int y, int width, int height)
     {
-        new ChartCreator(this.sdkSlidePart).AddPieChart();
+        new SSlidePart(this.sdkSlidePart).AddPieChart();
     }
 
     public void AddVideo(int x, int y, Stream stream)

--- a/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
@@ -580,16 +580,16 @@ internal sealed class SlideShapes : ISlideShapes
         return false;
     }
 
-    private P.Picture CreatePPicture(Stream imageStream, string shapeName, string mimeType = "image/png")
+    private P.Picture CreatePPicture(Stream image, string shapeName, string mimeType = "image/png")
     {
-        var scStream = new ImageStream(imageStream);
-        var hash = scStream.Base64Hash;
+        var imageStream = new ImageStream(image);
+        var hash = imageStream.Base64Hash;
 
         // Does this part already exist in the presentation?
         if (!this.TryGetImageRId(hash, out var imgPartRId))
         {
             // No, let's create it!;
-            (imgPartRId, var imagePart) = this.sdkSlidePart.AddImagePart(imageStream, mimeType);
+            (imgPartRId, var imagePart) = this.sdkSlidePart.AddImagePart(image, mimeType);
             this.mediaCollection.SetImagePart(hash, imagePart);
         }
 

--- a/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
@@ -6,8 +6,6 @@ using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using DocumentFormat.OpenXml;
-using DocumentFormat.OpenXml.Drawing.ChartDrawing;
-using DocumentFormat.OpenXml.Office2010.Drawing.ChartDrawing;
 using DocumentFormat.OpenXml.Packaging;
 using ImageMagick;
 using ImageMagick.Formats;
@@ -20,8 +18,6 @@ using A14 = DocumentFormat.OpenXml.Office2010.Drawing;
 using A16 = DocumentFormat.OpenXml.Office2016.Drawing;
 using P = DocumentFormat.OpenXml.Presentation;
 using Position = ShapeCrawler.Positions.Position;
-using C = DocumentFormat.OpenXml.Drawing.Charts;
-using NonVisualDrawingProperties = DocumentFormat.OpenXml.Drawing.ChartDrawing.NonVisualDrawingProperties;
 
 namespace ShapeCrawler.ShapeCollection;
 

--- a/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
@@ -204,6 +204,11 @@ internal sealed class SlideShapes : ISlideShapes
         }
     }
 
+    public void AddPieChart(int x, int y, int width, int height)
+    {
+        throw new NotImplementedException();
+    }
+
     public void AddVideo(int x, int y, Stream stream)
     {
         var sdkPresDocument = (PresentationDocument)this.sdkSlidePart.OpenXmlPackage;

--- a/src/ShapeCrawler/Shared/SOpenXmlPart.cs
+++ b/src/ShapeCrawler/Shared/SOpenXmlPart.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using DocumentFormat.OpenXml.Packaging;
 
-namespace ShapeCrawler.Extensions;
+namespace ShapeCrawler.Shared;
 
 internal readonly ref struct SOpenXmlPart(OpenXmlPart openXmlPart)
 {

--- a/src/ShapeCrawler/Shared/SOpenXmlPart.cs
+++ b/src/ShapeCrawler/Shared/SOpenXmlPart.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.RegularExpressions;
+using DocumentFormat.OpenXml.Packaging;
+
+namespace ShapeCrawler.Extensions;
+
+internal readonly ref struct SOpenXmlPart(OpenXmlPart openXmlPart)
+{
+    internal string NextRelationshipId()
+    {
+        var idNums = new List<long>();
+        var relationships = openXmlPart.ExternalRelationships.Select(r => r.Id)
+            .Union(openXmlPart.HyperlinkRelationships.Select(r => r.Id))
+            .Union(openXmlPart.DataPartReferenceRelationships.Select(r => r.Id))
+            .Union(openXmlPart.Parts.Select(p => p.RelationshipId));
+        foreach (var relationship in relationships)
+        {
+            var match = Regex.Match(relationship, @"\d+", RegexOptions.None, TimeSpan.FromMilliseconds(1000));
+            if (match.Success)
+            {
+                var id = long.Parse(match.Value, NumberStyles.None, NumberFormatInfo.CurrentInfo);
+                idNums.Add(id);
+            }
+        }
+
+        var nextId = 1L;
+        if (idNums.Any())
+        {
+            nextId = idNums.Max() + 1;
+        }
+
+        return $"rId{nextId}";
+    }
+}

--- a/src/ShapeCrawler/SlideMasters/SPSlideMaster.cs
+++ b/src/ShapeCrawler/SlideMasters/SPSlideMaster.cs
@@ -3,11 +3,12 @@ using P = DocumentFormat.OpenXml.Presentation;
 
 namespace ShapeCrawler.SlideMasters;
 
-internal readonly ref struct WrappedPSlideMaster
+// ReSharper disable once InconsistentNaming
+internal readonly ref struct SPSlideMaster
 {
     private readonly P.SlideMaster pSlideMaster;
 
-    internal WrappedPSlideMaster(P.SlideMaster pSlideMaster)
+    internal SPSlideMaster(P.SlideMaster pSlideMaster)
     {
         this.pSlideMaster = pSlideMaster;
     }

--- a/src/ShapeCrawler/Texts/IParagraph.cs
+++ b/src/ShapeCrawler/Texts/IParagraph.cs
@@ -61,21 +61,21 @@ internal sealed class Paragraph : IParagraph
 {
     private readonly OpenXmlPart sdkTypedOpenXmlPart;
     private readonly Lazy<Bullet> bullet;
-    private readonly WrappedAParagraph wrappedAParagraph;
+    private readonly SAParagraph saParagraph;
     private readonly A.Paragraph aParagraph;
 
     private TextHorizontalAlignment? alignment;
     
     internal Paragraph(OpenXmlPart sdkTypedOpenXmlPart, A.Paragraph aParagraph)
-        : this(sdkTypedOpenXmlPart, aParagraph, new WrappedAParagraph(aParagraph))
+        : this(sdkTypedOpenXmlPart, aParagraph, new SAParagraph(aParagraph))
     {
     }
 
-    private Paragraph(OpenXmlPart sdkTypedOpenXmlPart, A.Paragraph aParagraph, WrappedAParagraph wrappedAParagraph)
+    private Paragraph(OpenXmlPart sdkTypedOpenXmlPart, A.Paragraph aParagraph, SAParagraph saParagraph)
     {
         this.sdkTypedOpenXmlPart = sdkTypedOpenXmlPart;
         this.aParagraph = aParagraph;
-        this.wrappedAParagraph = wrappedAParagraph;
+        this.saParagraph = saParagraph;
         this.aParagraph.ParagraphProperties ??= new A.ParagraphProperties();
         this.bullet = new Lazy<Bullet>(this.GetBullet);
         this.Portions = new ParagraphPortions(sdkTypedOpenXmlPart, this.aParagraph);
@@ -179,8 +179,8 @@ internal sealed class Paragraph : IParagraph
 
     public int IndentLevel
     {
-        get => this.wrappedAParagraph.IndentLevel();
-        set => this.wrappedAParagraph.UpdateIndentLevel(value);
+        get => this.saParagraph.IndentLevel();
+        set => this.saParagraph.UpdateIndentLevel(value);
     }
 
     public ISpacing Spacing => this.GetSpacing();

--- a/src/ShapeCrawler/Texts/SAParagraph.cs
+++ b/src/ShapeCrawler/Texts/SAParagraph.cs
@@ -3,11 +3,12 @@ using A = DocumentFormat.OpenXml.Drawing;
 
 namespace ShapeCrawler.Texts;
 
-internal sealed record WrappedAParagraph
+// ReSharper disable once InconsistentNaming
+internal sealed record SAParagraph
 {
     private readonly A.Paragraph aParagraph;
 
-    internal WrappedAParagraph(A.Paragraph aParagraph)
+    internal SAParagraph(A.Paragraph aParagraph)
     {
         this.aParagraph = aParagraph;
     }

--- a/src/ShapeCrawler/Texts/SAText.cs
+++ b/src/ShapeCrawler/Texts/SAText.cs
@@ -3,12 +3,13 @@ using DocumentFormat.OpenXml.Packaging;
 namespace ShapeCrawler.Texts;
 using A = DocumentFormat.OpenXml.Drawing;
 
-internal sealed record WrappedAText
+// ReSharper disable once InconsistentNaming
+internal sealed record SAText
 {
     private readonly OpenXmlPart sdkTypedOpenXmlPart;
     private readonly A.Text aText;
 
-    internal WrappedAText(OpenXmlPart sdkTypedOpenXmlPart, A.Text aText)
+    internal SAText(OpenXmlPart sdkTypedOpenXmlPart, A.Text aText)
     {
         this.sdkTypedOpenXmlPart = sdkTypedOpenXmlPart;
         this.aText = aText;

--- a/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
@@ -1118,6 +1118,7 @@ public class ShapeCollectionTests : SCTest
     }
     
     [Test]
+    [Ignore("WIP")]
     public void AddPieChart_add_pie_chart()
     {
         var pres = new Presentation(@"c:\temp\pie chart.pptx");

--- a/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
@@ -1116,4 +1116,13 @@ public class ShapeCollectionTests : SCTest
         addedPictureResolution.X.Should().BeApproximately(384, 0.1);
         addedPictureResolution.Y.Should().BeApproximately(384, 0.1);
     }
+    
+    [Test]
+    public void AddPieChart_add_pie_chart()
+    {
+        var pres = new Presentation(@"c:\Repo\Shape\test\ShapeCrawler.Tests.Unit\Assets\charts\001 bar chart.pptx");
+        var shapes = pres.Slide(1).Shapes;
+        
+        shapes.AddPieChart(100, 100, 400, 300);
+    }
 }

--- a/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
@@ -1120,9 +1120,12 @@ public class ShapeCollectionTests : SCTest
     [Test]
     public void AddPieChart_add_pie_chart()
     {
-        var pres = new Presentation(@"c:\Repo\Shape\test\ShapeCrawler.Tests.Unit\Assets\charts\001 bar chart.pptx");
+        var pres = new Presentation(@"c:\temp\pie chart.pptx");
         var shapes = pres.Slide(1).Shapes;
         
         shapes.AddPieChart(100, 100, 400, 300);
+        
+        pres.SaveAs(@"c:\temp\output.pptx");
+        pres.Validate();
     }
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on refactoring the codebase by replacing instances of `Wrapped` classes with their `S` counterparts, enhancing clarity and consistency. Additionally, it introduces a new method for adding pie charts.

### Detailed summary
- Replaced `WrappedImagePart` with `SImagePart` in `ShapeFillImage.cs` and `SlidePictureImage.cs`.
- Added `AddPieChart` method to `ISlideShapes.cs` and implemented it in `SlideShapes.cs`.
- Replaced `WrappedPShapeTree` with `SPShapeTree` in multiple files.
- Updated `WrappedAParagraph` to `SAParagraph` throughout the code.
- Introduced `SOpenXmlPart` to manage relationship IDs.
- Added methods for pie chart generation in `SSlidePart.cs`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->