### PR TITLE
Add test for #552

### DIFF
--- a/test/ShapeCrawler.Tests.Unit/TableTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/TableTests.cs
@@ -1059,4 +1059,22 @@ public class TableTests : SCTest
         options.HasLastColumn.Should().BeFalse();
         options.HasBandedColumns.Should().BeFalse();
     }
+    
+    [Test]
+    [Explicit("https://github.com/ShapeCrawler/ShapeCrawler/issues/552")]
+    public void Height_Setter_should_proportionally_increase_the_row_heights_When_the_new_table_height_is_bigger()
+    {
+        // Arrange
+        var pres = new Presentation();
+        pres.Slide(1).Shapes.AddTable(10, 10, 2, 2);
+        var addedTable = pres.Slide(1).Shapes.Last<ITable>();
+        
+        // Act
+        addedTable.Height = 100;
+        
+        // Assert
+        addedTable.Rows[0].Height.Should().Be(40);
+        addedTable.Rows[1].Height.Should().Be(40);
+        pres.Validate();
+    }
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new unit test to verify that when the height of a table is increased, the row heights are adjusted proportionally.

### Detailed summary
- Added a new test method `Height_Setter_should_proportionally_increase_the_row_heights_When_the_new_table_height_is_bigger`.
- The test checks if the heights of the rows in the `ITable` are proportionally set to 40 when the table height is set to 100.
- Utilizes `Presentation` to create and manipulate the table for testing.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->