### PR TITLE
Change insert after method to use new column create method.

### DIFF
--- a/src/ShapeCrawler/Tables/IColumn.cs
+++ b/src/ShapeCrawler/Tables/IColumn.cs
@@ -44,33 +44,36 @@ internal sealed class Column : IColumn
 
     public void Duplicate()
     {
-        var tableGrid = this.AGridColumn.Parent!;
+        var tableGrid = this.AGridColumn.Parent as A.TableGrid;
         
-        var totalWidth = tableGrid.Elements<A.GridColumn>()
-            .Sum(col => col.Width!.Value);
+        var newGridColumn = CreateNewColumn(tableGrid!, this.AGridColumn.Width!.Value);
         
-        var newTotalWidth = totalWidth + this.AGridColumn.Width!.Value;
-        var ratio = (double)totalWidth / newTotalWidth;
-        
-        var newGridColumn = new A.GridColumn
-        {
-            Width = (int)Math.Round(this.AGridColumn.Width!.Value * ratio) 
-        };
-        
-        tableGrid.Append(newGridColumn);
-
-        foreach (var col in tableGrid.Elements<A.GridColumn>())
-        {
-            col.Width = (int)Math.Round(col.Width!.Value * ratio);
-        }
+        tableGrid!.Append(newGridColumn);
         
         var table = tableGrid.Parent as A.Table;
+        
         foreach(A.TableRow tr in table!.Elements<A.TableRow>())
         {
             var cells = tr.Elements<A.TableCell>().ToList();
             var cloneCell = cells[this.index].Clone();
             tr.InsertAfter((A.TableCell)cloneCell, cells[^1]);
         }
+    }
+    
+    internal static A.GridColumn CreateNewColumn(A.TableGrid tableGrid, long width)
+    {
+        var totalWidth = tableGrid.Elements<A.GridColumn>().Sum(col => col.Width!.Value);
+        var newTotalWidth = totalWidth + width;
+        var ratio = (double)totalWidth / newTotalWidth;
+
+        var newGridColumn = new A.GridColumn { Width = (int)Math.Round(width * ratio) };
+
+        foreach (var col in tableGrid.Elements<A.GridColumn>())
+        {
+            col.Width = (int)Math.Round(col.Width!.Value * ratio);
+        }
+
+        return newGridColumn;
     }
 
     private int GetWidth()

--- a/src/ShapeCrawler/Tables/ITableColumns.cs
+++ b/src/ShapeCrawler/Tables/ITableColumns.cs
@@ -83,7 +83,7 @@ internal sealed class TableColumns : ITableColumns
         var tableGrid = this.aTable.TableGrid!;
         var existingColumns = this.Columns().Select(x => x.AGridColumn).ToList();
 
-        var gridColumn = this.CreateColumnWithAdjustedWidth(existingColumns);
+        var gridColumn = Column.CreateNewColumn(tableGrid, existingColumns[columnIndex].Width!.Value);
         var targetColumn = existingColumns[columnIndex];
         tableGrid.InsertAfter(gridColumn, targetColumn);
 
@@ -96,20 +96,6 @@ internal sealed class TableColumns : ITableColumns
     IEnumerator<IColumn> IEnumerable<IColumn>.GetEnumerator() => this.Columns().GetEnumerator();
 
     IEnumerator IEnumerable.GetEnumerator() => this.Columns().GetEnumerator();
-
-    private A.GridColumn CreateColumnWithAdjustedWidth(List<A.GridColumn> existingColumns)
-    {
-        var totalWidth = existingColumns.Sum(col => col.Width!.Value);
-        var newColumnWidth = totalWidth / (existingColumns.Count + 1);
-
-        // Adjust existing column widths
-        foreach (var col in existingColumns)
-        {
-            col.Width = newColumnWidth;
-        }
-
-        return new A.GridColumn { Width = newColumnWidth };
-    }
 
     private List<Column> Columns() => this.aTable.TableGrid!.Elements<A.GridColumn>()
         .Select((aGridColumn, index) => new Column(aGridColumn, index)).ToList();

--- a/test/ShapeCrawler.Tests.Unit/TableTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/TableTests.cs
@@ -84,6 +84,27 @@ public class TableTests : SCTest
     }
     
     [Test]
+    public void AddColumn_sets_width_of_all_columns_proportionally()
+    {
+        // Arrange
+        var pptx = TestAsset("table-case003.pptx");
+        var pres = new Presentation(pptx);
+        var table = pres.Slides[0].Shapes.GetByName<ITable>("Table 1");
+        var columnsCountBefore = table.Columns.Count;
+        var columnWidthBefore = table.Columns.Select(c => c.Width).ToList();
+        var totalWidthBefore = table.Columns.Sum(c => c.Width);
+        var newTotalWidth = totalWidthBefore + table.Columns[columnsCountBefore - 1].Width;
+        
+        // Act
+        table.Columns.Add();
+
+        // Assert
+        var widthRatio = (double)totalWidthBefore / newTotalWidth;
+        table.Columns.Select(c => c.Width).ToList().Take(columnsCountBefore).Should()
+            .BeEquivalentTo(columnWidthBefore.Select(w => (int)(w * widthRatio)));
+    }
+    
+    [Test]
     public void InsertColumnAfter_inserts_column_after_the_specified_column_number()
     {
         // Arrange
@@ -97,6 +118,27 @@ public class TableTests : SCTest
         // Assert
         cell.TextBox.Text.Should().BeEmpty("because before adding column the cell (1,2) was not empty.");
         pres.Validate();
+    }
+    
+    [Test]
+    public void InsertColumnAfter_sets_width_of_all_columns_proportionally()
+    {
+        // Arrange
+        var pptx = TestAsset("table-case003.pptx");
+        var pres = new Presentation(pptx);
+        var table = pres.Slides[0].Shapes.GetByName<ITable>("Table 1");
+        var columnsCountBefore = table.Columns.Count;
+        var columnWidthBefore = table.Columns.Select(c => c.Width).ToList();
+        var totalWidthBefore = table.Columns.Sum(c => c.Width);
+        var newTotalWidth = totalWidthBefore + table.Columns[2].Width;
+        
+        // Act
+        table.Columns.InsertAfter(3);
+
+        // Assert
+        var widthRatio = (double)totalWidthBefore / newTotalWidth;
+        table.Columns.Select(c => c.Width).ToList().Take(columnsCountBefore).Should()
+            .BeEquivalentTo(columnWidthBefore.Select(w => (int)(w * widthRatio)));
     }
     
     [Test]

--- a/test/ShapeCrawler.Tests.Unit/TableTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/TableTests.cs
@@ -84,7 +84,7 @@ public class TableTests : SCTest
     }
     
     [Test]
-    public void AddColumn_sets_width_of_all_columns_proportionally()
+    public void Columns_Add_sets_width_of_all_columns_proportionally()
     {
         // Arrange
         var pptx = TestAsset("table-case003.pptx");
@@ -121,7 +121,7 @@ public class TableTests : SCTest
     }
     
     [Test]
-    public void InsertColumnAfter_sets_width_of_all_columns_proportionally()
+    public void Columns_InsertAfter_sets_width_of_all_columns_proportionally()
     {
         // Arrange
         var pptx = TestAsset("table-case003.pptx");


### PR DESCRIPTION
Added a static method CreateNewColumn to handle the creation of a new column and adjust the widths of existing columns proportionally. Use this in the ShapeCrawler.Tables.TableColumns.InsertAfter method.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the functionality of column management in tables, specifically the creation and insertion of columns while ensuring proportional width adjustments.

### Detailed summary
- Replaced `CreateColumnWithAdjustedWidth` with `CreateNewColumn` in `ITableColumns.cs`.
- `CreateNewColumn` calculates and sets proportional widths for new and existing columns.
- Added tests in `TableTests.cs` to verify proportional width adjustments during column addition and insertion.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->