### PR TITLE
Refactor points

### DIFF
--- a/src/ShapeCrawler/Units/Points.cs
+++ b/src/ShapeCrawler/Units/Points.cs
@@ -1,17 +1,10 @@
 ﻿namespace ShapeCrawler.Units;
 
-internal readonly ref struct Points
+internal readonly ref struct Points(decimal points)
 {
-    private readonly decimal points;
+    internal long AsEmus() => (long)points * 12700;
 
-    internal Points(decimal points)
-    {
-        this.points = points;
-    }
+    internal float AsPixels() => (float)points * 96 / 72;
 
-    internal long AsEmus() => (long)this.points * 12700;
-
-    internal float AsPixels() => (float)this.points * 96 / 72;
-
-    internal int AsHundredsOfPoints() => (int)this.points * 100;
+    internal int AsHundredsOfPoints() => (int)points * 100;
 }

--- a/src/ShapeCrawler/Units/Points.cs
+++ b/src/ShapeCrawler/Units/Points.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace ShapeCrawler.Units;
+﻿namespace ShapeCrawler.Units;
 
 internal readonly ref struct Points
 {
@@ -15,5 +13,5 @@ internal readonly ref struct Points
 
     internal float AsPixels() => (float)this.points * 96 / 72;
 
-    internal int AsHundredsOfPoints() => (int)Math.Round(this.points * 100);
+    internal int AsHundredsOfPoints() => (int)this.points * 100;
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on refactoring the `Points` struct in the `ShapeCrawler.Units` namespace. It simplifies the code by removing the private field and directly using the constructor parameter throughout the struct's methods.

### Detailed summary
- Removed the private field `private readonly decimal points;`.
- Changed method implementations to use the constructor parameter `points` directly:
  - `AsEmus()`
  - `AsPixels()`
  - `AsHundredsOfPoints()`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->