### PR TITLE
Fix for issues #905

### DIFF
--- a/src/ShapeCrawler/ShapeCollection/ReferencedIndentLevel.cs
+++ b/src/ShapeCrawler/ShapeCollection/ReferencedIndentLevel.cs
@@ -477,7 +477,7 @@ internal readonly ref struct ReferencedIndentLevel
             var refMasterPShape = this.ReferencedMasterPShapeOrNullOf(pShape);
             if (refMasterPShape == null)
             {
-                if (pPlaceholderShape.Type!.Value == P.PlaceholderValues.CenteredTitle)
+                if (pPlaceholderShape.Type?.Value == P.PlaceholderValues.CenteredTitle)
                 {
                     return sdkSlidePart.SlideLayoutPart!.SlideMasterPart!.SlideMaster.TextStyles!.TitleStyle!
                         .Level1ParagraphProperties!

--- a/src/ShapeCrawler/ShapeCollection/SPShapeTree.cs
+++ b/src/ShapeCrawler/ShapeCollection/SPShapeTree.cs
@@ -61,45 +61,23 @@ internal readonly ref struct SPShapeTree
                 continue;
             }
 
-            if (pPlaceholder.Index is not null
-                && layoutPPlaceholder.Index is not null
-                && pPlaceholder.Index == layoutPPlaceholder.Index)
-            {
-                return layoutPShape;
-            }
-
-            if (pPlaceholder.Type == null || layoutPPlaceholder.Type == null)
-            {
-                return layoutPShape;
-            }
-
-            if (pPlaceholder.Type == P.PlaceholderValues.Body
-                && pPlaceholder.Index is not null
-                && layoutPPlaceholder.Index is not null)
-            {
-                if (pPlaceholder.Index == layoutPPlaceholder.Index)
-                {
-                    return layoutPShape;
-                }
-            }
-
-            if (pPlaceholder.Type == P.PlaceholderValues.Title && layoutPPlaceholder.Type == P.PlaceholderValues.Title)
-            {
-                return layoutPShape;
-            }
-
-            if (pPlaceholder.Type == P.PlaceholderValues.CenteredTitle && layoutPPlaceholder.Type == P.PlaceholderValues.CenteredTitle)
+            if (pPlaceholder.Type?.Value == layoutPPlaceholder.Type?.Value &&
+                pPlaceholder.Index?.Value == layoutPPlaceholder.Index?.Value)
             {
                 return layoutPShape;
             }
         }
 
-        var byType = pShapes.FirstOrDefault(layoutPShape =>
-            layoutPShape.NonVisualShapeProperties!.ApplicationNonVisualDrawingProperties!
-                .GetFirstChild<P.PlaceholderShape>()?.Type?.Value == pPlaceholder.Type?.Value);
-        if (byType != null)
+        if (pPlaceholder.Type?.Value is not null)
         {
-            return byType;
+            var byType = pShapes.FirstOrDefault(layoutPShape => 
+                layoutPShape.NonVisualShapeProperties!.ApplicationNonVisualDrawingProperties!
+                    .GetFirstChild<P.PlaceholderShape>()?.Type?.Value == pPlaceholder.Type.Value);
+
+            if (byType != null)
+            {
+                return byType;
+            }
         }
 
         return null;

--- a/test/ShapeCrawler.Tests.Unit/FontTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/FontTests.cs
@@ -89,7 +89,7 @@ public class FontTests : SCTest
     [Test]
     [SlideShape("028.pptx", 1, 4098, 32)]
     [SlideShape("029.pptx", 1, "Content Placeholder 2", 25)]
-    // [SlideShape("072 content placeholder.pptx", 1, "Content Placeholder 1", 18)]
+    [SlideShape("072 content placeholder.pptx", 1, "Content Placeholder 1", 18)]
     public void Size_Getter_returns_font_size_of_Placeholder(IShape shape, int expectedSize)
     {
         // Arrange


### PR DESCRIPTION
- Use null-conditional operator in `ReferencedIndentLevel.cs` for better null safety.
- Refactor and simplify placeholder matching logic in `SPShapeTree.cs`, removing redundant checks.
- Reactivate a previously commented-out test case in `FontTests.cs`.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving null-checks and conditional logic in the code, enhancing safety and readability. It also includes a minor adjustment in test annotations.

### Detailed summary
- Updated null-checks in `ReferencedIndentLevel.cs` to use the null-conditional operator (`?.`).
- Adjusted test annotation in `FontTests.cs` to uncomment a specific test case.
- Refined conditional logic in `SPShapeTree.cs` to improve clarity and safety.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->