### PR TITLE
Remove unused dependencies

### DIFF
--- a/test/ShapeCrawler.Tests.Load/ShapeCrawler.Tests.Load.csproj
+++ b/test/ShapeCrawler.Tests.Load/ShapeCrawler.Tests.Load.csproj
@@ -18,7 +18,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="FluentAssertions" Version="[7.1.0]" />
     <PackageReference Include="NUnit" Version="4.3.2" />

--- a/test/ShapeCrawler.Tests.Unit/ShapeCrawler.Tests.Unit.csproj
+++ b/test/ShapeCrawler.Tests.Unit/ShapeCrawler.Tests.Unit.csproj
@@ -19,15 +19,10 @@
   <ItemGroup>
     <PackageReference Include="ClosedXML" Version="0.95.4" />
     <PackageReference Include="FluentAssertions" Version="[7.1.0]" />
-    <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the package references in the project files for `ShapeCrawler.Tests.Load` and `ShapeCrawler.Tests.Unit`. It removes certain packages and consolidates versions for better compatibility.

### Detailed summary
- Removed `<PackageReference Include="coverlet.collector" Version="6.0.0" />` from `ShapeCrawler.Tests.Load.csproj`.
- Removed `<PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.4.0" />` from `ShapeCrawler.Tests.Unit.csproj`.
- Removed `<PackageReference Include="coverlet.collector" Version="6.0.2">` from `ShapeCrawler.Tests.Unit.csproj`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->