### PR TITLE
Remove tIME chunk from generated PNGs

### DIFF
--- a/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
+++ b/src/ShapeCrawler/ShapeCollection/SlideShapes.cs
@@ -175,6 +175,8 @@ internal sealed class SlideShapes : ISlideShapes
             {
                 ExcludeChunks = PngChunkFlags.date
             });
+            
+            imageMagick.Settings.SetDefine("png:exclude-chunk", "tIME");
 
             var rasterStream = new MemoryStream();
             imageMagick.Write(rasterStream);

--- a/test/ShapeCrawler.Tests.Load/ShapeCollectionTests.cs
+++ b/test/ShapeCrawler.Tests.Load/ShapeCollectionTests.cs
@@ -6,8 +6,6 @@ namespace ShapeCrawler.Tests.Load;
 public class ShapeCollectionTests : SCTest
 {
     [Test]
-    [Repeat(40)]
-    [Explicit("Flaky test. Read https://github.com/ShapeCrawler/ShapeCrawler/issues/883")]
     public void AddPicture_should_not_duplicate_the_image_source_When_the_same_svg_image_is_added_to_a_loaded_presentation()
     {
         // Arrange
@@ -19,6 +17,7 @@ public class ShapeCollectionTests : SCTest
         var loadedPres = SaveAndOpenPresentation(pres);
 
         // Act
+        Thread.Sleep(1000);
         shapes = loadedPres.Slides[0].Shapes;
         shapes.AddPicture(image);
 
@@ -32,8 +31,6 @@ public class ShapeCollectionTests : SCTest
     }
     
     [Test]
-    [Repeat(40)]
-    [Explicit("Flaky test. Read https://github.com/ShapeCrawler/ShapeCrawler/issues/883")]
     public void AddPicture_should_not_duplicate_the_image_source_When_the_same_svg_image_is_added_twice()
     {
         // Arrange
@@ -43,6 +40,7 @@ public class ShapeCollectionTests : SCTest
 
         // Act
         shapes.AddPicture(svgImage);
+        Thread.Sleep(1000);
         shapes.AddPicture(svgImage);
 
         // Assert

--- a/test/ShapeCrawler.Tests.Load/ShapeCollectionTests.cs
+++ b/test/ShapeCrawler.Tests.Load/ShapeCollectionTests.cs
@@ -6,7 +6,8 @@ namespace ShapeCrawler.Tests.Load;
 public class ShapeCollectionTests : SCTest
 {
     [Test]
-    public async Task AddPicture_should_not_duplicate_the_image_source_When_the_same_svg_image_is_added_to_a_loaded_presentation()
+    [Repeat(40)]
+    public void AddPicture_should_not_duplicate_the_image_source_When_the_same_svg_image_is_added_to_a_loaded_presentation()
     {
         // Arrange
         var pres = new Presentation();
@@ -17,7 +18,6 @@ public class ShapeCollectionTests : SCTest
         var loadedPres = SaveAndOpenPresentation(pres);
 
         // Act
-        await Task.Delay(1000);
         shapes = loadedPres.Slides[0].Shapes;
         shapes.AddPicture(image);
 
@@ -31,7 +31,8 @@ public class ShapeCollectionTests : SCTest
     }
     
     [Test]
-    public async Task AddPicture_should_not_duplicate_the_image_source_When_the_same_svg_image_is_added_twice()
+    [Repeat(40)]
+    public void AddPicture_should_not_duplicate_the_image_source_When_the_same_svg_image_is_added_twice()
     {
         // Arrange
         var pres = new Presentation();
@@ -40,7 +41,6 @@ public class ShapeCollectionTests : SCTest
 
         // Act
         shapes.AddPicture(svgImage);
-        await Task.Delay(1000);
         shapes.AddPicture(svgImage);
 
         // Assert

--- a/test/ShapeCrawler.Tests.Load/ShapeCollectionTests.cs
+++ b/test/ShapeCrawler.Tests.Load/ShapeCollectionTests.cs
@@ -6,7 +6,6 @@ namespace ShapeCrawler.Tests.Load;
 public class ShapeCollectionTests : SCTest
 {
     [Test]
-    [Repeat(40)]
     public void AddPicture_should_not_duplicate_the_image_source_When_the_same_svg_image_is_added_to_a_loaded_presentation()
     {
         // Arrange
@@ -18,6 +17,7 @@ public class ShapeCollectionTests : SCTest
         var loadedPres = SaveAndOpenPresentation(pres);
 
         // Act
+        Task.Delay(1000).Wait();
         shapes = loadedPres.Slides[0].Shapes;
         shapes.AddPicture(image);
 
@@ -31,7 +31,6 @@ public class ShapeCollectionTests : SCTest
     }
     
     [Test]
-    [Repeat(40)]
     public void AddPicture_should_not_duplicate_the_image_source_When_the_same_svg_image_is_added_twice()
     {
         // Arrange
@@ -41,6 +40,7 @@ public class ShapeCollectionTests : SCTest
 
         // Act
         shapes.AddPicture(svgImage);
+        Task.Delay(1000).Wait();
         shapes.AddPicture(svgImage);
 
         // Assert
@@ -74,28 +74,5 @@ public class ShapeCollectionTests : SCTest
         var imageParts = sdkPres.PresentationPart!.SlideParts.SelectMany(slidePart => slidePart.ImageParts).Select(imagePart => imagePart.Uri)
             .ToHashSet();
         imageParts.Count.Should().Be(1);
-    }
-    
-    [Test]
-    public void AddPicture_should_not_duplicate_the_png_image_source_When_the_same_svg_image_is_added_a_second_apart()
-    {
-        // Arrange
-        var pres = new Presentation();
-        pres.Slides.AddEmptySlide(SlideLayoutType.Blank);
-        var shapesSlide1 = pres.Slides[0].Shapes;
-        var shapesSlide2 = pres.Slides[1].Shapes;
-
-        var image = TestAsset("063 vector image.svg");
-
-        // Act
-        shapesSlide1.AddPicture(image);
-        Task.Delay(1000).Wait();
-        shapesSlide2.AddPicture(image);
-
-        // Assert
-        var sdkPres = SaveAndOpenPresentationAsSdk(pres);
-        var imageParts = sdkPres.PresentationPart!.SlideParts.SelectMany(slidePart => slidePart.ImageParts).Select(imagePart => imagePart.Uri)
-            .ToHashSet();
-        imageParts.Count.Should().Be(2);
     }
 }

--- a/test/ShapeCrawler.Tests.Load/ShapeCollectionTests.cs
+++ b/test/ShapeCrawler.Tests.Load/ShapeCollectionTests.cs
@@ -6,7 +6,7 @@ namespace ShapeCrawler.Tests.Load;
 public class ShapeCollectionTests : SCTest
 {
     [Test]
-    public void AddPicture_should_not_duplicate_the_image_source_When_the_same_svg_image_is_added_to_a_loaded_presentation()
+    public async Task AddPicture_should_not_duplicate_the_image_source_When_the_same_svg_image_is_added_to_a_loaded_presentation()
     {
         // Arrange
         var pres = new Presentation();
@@ -17,7 +17,7 @@ public class ShapeCollectionTests : SCTest
         var loadedPres = SaveAndOpenPresentation(pres);
 
         // Act
-        Thread.Sleep(1000);
+        await Task.Delay(1000);
         shapes = loadedPres.Slides[0].Shapes;
         shapes.AddPicture(image);
 
@@ -31,7 +31,7 @@ public class ShapeCollectionTests : SCTest
     }
     
     [Test]
-    public void AddPicture_should_not_duplicate_the_image_source_When_the_same_svg_image_is_added_twice()
+    public async Task AddPicture_should_not_duplicate_the_image_source_When_the_same_svg_image_is_added_twice()
     {
         // Arrange
         var pres = new Presentation();
@@ -40,7 +40,7 @@ public class ShapeCollectionTests : SCTest
 
         // Act
         shapes.AddPicture(svgImage);
-        Thread.Sleep(1000);
+        await Task.Delay(1000);
         shapes.AddPicture(svgImage);
 
         // Assert

--- a/test/ShapeCrawler.Tests.Load/ShapeCollectionTests.cs
+++ b/test/ShapeCrawler.Tests.Load/ShapeCollectionTests.cs
@@ -49,4 +49,53 @@ public class ShapeCollectionTests : SCTest
         imageParts.Length.Should().Be(2,
             "SVG image adds two parts: One for the vector and one for the auto-generated raster");
     }
+    
+    [TestCase("08 jpeg image-500w.jpg")]
+    [TestCase("09 png image.png")]
+    [TestCase("03 gif image.gif")]
+    [TestCase("07 tiff image.tiff")]
+    public void AddPicture_should_not_duplicate_the_image_source_When_the_same_image_is_added_a_second_apart(string fileName)
+    {
+        // Arrange
+        var pres = new Presentation();
+        pres.Slides.AddEmptySlide(SlideLayoutType.Blank);
+        var shapesSlide1 = pres.Slides[0].Shapes;
+        var shapesSlide2 = pres.Slides[1].Shapes;
+
+        var image = TestAsset(fileName);
+
+        // Act
+        shapesSlide1.AddPicture(image);
+        Task.Delay(1000).Wait();
+        shapesSlide2.AddPicture(image);
+
+        // Assert
+        var sdkPres = SaveAndOpenPresentationAsSdk(pres);
+        var imageParts = sdkPres.PresentationPart!.SlideParts.SelectMany(slidePart => slidePart.ImageParts).Select(imagePart => imagePart.Uri)
+            .ToHashSet();
+        imageParts.Count.Should().Be(1);
+    }
+    
+    [Test]
+    public void AddPicture_should_not_duplicate_the_png_image_source_When_the_same_svg_image_is_added_a_second_apart()
+    {
+        // Arrange
+        var pres = new Presentation();
+        pres.Slides.AddEmptySlide(SlideLayoutType.Blank);
+        var shapesSlide1 = pres.Slides[0].Shapes;
+        var shapesSlide2 = pres.Slides[1].Shapes;
+
+        var image = TestAsset("063 vector image.svg");
+
+        // Act
+        shapesSlide1.AddPicture(image);
+        Task.Delay(1000).Wait();
+        shapesSlide2.AddPicture(image);
+
+        // Assert
+        var sdkPres = SaveAndOpenPresentationAsSdk(pres);
+        var imageParts = sdkPres.PresentationPart!.SlideParts.SelectMany(slidePart => slidePart.ImageParts).Select(imagePart => imagePart.Uri)
+            .ToHashSet();
+        imageParts.Count.Should().Be(2);
+    }
 }

--- a/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
@@ -393,55 +393,6 @@ public class ShapeCollectionTests : SCTest
         imageParts.Count.Should().Be(1);
     }
     
-    [TestCase("08 jpeg image-500w.jpg")]
-    [TestCase("09 png image.png")]
-    [TestCase("03 gif image.gif")]
-    [TestCase("07 tiff image.tiff")]
-    public void AddPicture_should_not_duplicate_the_image_source_When_the_same_image_is_added_a_second_apart(string fileName)
-    {
-        // Arrange
-        var pres = new Presentation();
-        pres.Slides.AddEmptySlide(SlideLayoutType.Blank);
-        var shapesSlide1 = pres.Slides[0].Shapes;
-        var shapesSlide2 = pres.Slides[1].Shapes;
-
-        var image = TestAsset(fileName);
-
-        // Act
-        shapesSlide1.AddPicture(image);
-        Task.Delay(1000).Wait();
-        shapesSlide2.AddPicture(image);
-
-        // Assert
-        var sdkPres = SaveAndOpenPresentationAsSdk(pres);
-        var imageParts = sdkPres.PresentationPart!.SlideParts.SelectMany(slidePart => slidePart.ImageParts).Select(imagePart => imagePart.Uri)
-            .ToHashSet();
-        imageParts.Count.Should().Be(1);
-    }
-    
-    [Test]
-    public void AddPicture_should_not_duplicate_the_png_image_source_When_the_same_svg_image_is_added_a_second_apart()
-    {
-        // Arrange
-        var pres = new Presentation();
-        pres.Slides.AddEmptySlide(SlideLayoutType.Blank);
-        var shapesSlide1 = pres.Slides[0].Shapes;
-        var shapesSlide2 = pres.Slides[1].Shapes;
-
-        var image = TestAsset("063 vector image.svg");
-
-        // Act
-        shapesSlide1.AddPicture(image);
-        Task.Delay(1000).Wait();
-        shapesSlide2.AddPicture(image);
-
-        // Assert
-        var sdkPres = SaveAndOpenPresentationAsSdk(pres);
-        var imageParts = sdkPres.PresentationPart!.SlideParts.SelectMany(slidePart => slidePart.ImageParts).Select(imagePart => imagePart.Uri)
-            .ToHashSet();
-        imageParts.Count.Should().Be(2);
-    }
-    
     [Test]
     [Explicit("Should be fixed")]
     public void AddPicture_should_not_duplicate_the_image_source_When_slide_is_copied()

--- a/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
@@ -420,6 +420,29 @@ public class ShapeCollectionTests : SCTest
     }
     
     [Test]
+    public void AddPicture_should_not_duplicate_the_png_image_source_When_the_same_svg_image_is_added_a_second_apart()
+    {
+        // Arrange
+        var pres = new Presentation();
+        pres.Slides.AddEmptySlide(SlideLayoutType.Blank);
+        var shapesSlide1 = pres.Slides[0].Shapes;
+        var shapesSlide2 = pres.Slides[1].Shapes;
+
+        var image = TestAsset("063 vector image.svg");
+
+        // Act
+        shapesSlide1.AddPicture(image);
+        Task.Delay(1000).Wait();
+        shapesSlide2.AddPicture(image);
+
+        // Assert
+        var sdkPres = SaveAndOpenPresentationAsSdk(pres);
+        var imageParts = sdkPres.PresentationPart!.SlideParts.SelectMany(slidePart => slidePart.ImageParts).Select(imagePart => imagePart.Uri)
+            .ToHashSet();
+        imageParts.Count.Should().Be(2);
+    }
+    
+    [Test]
     [Explicit("Should be fixed")]
     public void AddPicture_should_not_duplicate_the_image_source_When_slide_is_copied()
     {


### PR DESCRIPTION
Removed tIME chunk from generated PNG to fix #883 (again!) this keep all tests passing.

I would use the PngChunkFlags enum, however, it does not include tIME flag, so it has to be this hard-coded string.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing image handling in the `ShapeCrawler` library by ensuring that adding the same image multiple times does not create duplicates in presentations. It introduces a setting to exclude certain PNG chunks and updates existing tests for better reliability.

### Detailed summary
- Added `imageMagick.Settings.SetDefine("png:exclude-chunk", "tIME")` in `SlideShapes.cs`.
- Removed multiple test cases for image duplication in `ShapeCollectionTests.cs`.
- Introduced a new test case for image duplication with a delay in `ShapeCollectionTests.cs`.
- Updated `AddPicture_should_not_duplicate_the_image_source_When_the_same_svg_image_is_added_to_a_loaded_presentation` to include a delay.
- Ensured that the same image added twice results in only one instance in the presentation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->