### PR TITLE
Rename IFileProperties

### DIFF
--- a/src/ShapeCrawler/Presentations/IPresentationMetadata.cs
+++ b/src/ShapeCrawler/Presentations/IPresentationMetadata.cs
@@ -6,12 +6,9 @@ namespace ShapeCrawler;
 #pragma warning restore IDE0130
 
 /// <summary>
-///     Represents the core properties of the presentation file.
+///     Represents the metadata of the presentation file.
 /// </summary>
-/// <remarks>
-///     These properties are not related to the presentation itself, but rather the containing file.
-/// </remarks>
-public interface IFileProperties
+public interface IPresentationMetadata
 {
     /// <summary>
     ///     Gets or sets the categories.
@@ -105,7 +102,7 @@ public interface IFileProperties
     string? Version { get; set; }
 }
 
-internal class FileProperties : IFileProperties
+internal class FileProperties : IPresentationMetadata
 {
     private readonly DocumentFormat.OpenXml.Packaging.IPackageProperties sdkPackageProperties;
 

--- a/src/ShapeCrawler/Presentations/IPresentationProperties.cs
+++ b/src/ShapeCrawler/Presentations/IPresentationProperties.cs
@@ -38,12 +38,9 @@ public interface IPresentationProperties
     IFooter Footer { get; }
 
     /// <summary>
-    ///     Gets the properties (meta-data) of the file.
+    ///     Gets the metadata of the presentation file.
     /// </summary>
-    /// <remarks>
-    ///     These properties are not presentation-specific.
-    /// </remarks>
-    IFileProperties FileProperties { get; }
+    IPresentationMetadata Metadata { get; }
     
     /// <summary>
     ///     Returns slide with specified number.

--- a/src/ShapeCrawler/Presentations/PathPresentation.cs
+++ b/src/ShapeCrawler/Presentations/PathPresentation.cs
@@ -44,5 +44,5 @@ internal sealed record PathPresentation : IValidateable
 
     public IFooter Footer => this.presentationCore.Footer;
 
-    public IFileProperties FileProperties => this.presentationCore.FileProperties;
+    public IPresentationMetadata Metadata => this.presentationCore.FileProperties;
 }

--- a/src/ShapeCrawler/Presentations/Presentation.cs
+++ b/src/ShapeCrawler/Presentations/Presentation.cs
@@ -36,8 +36,8 @@ public sealed class Presentation : IPresentation
         var assets = new Assets(Assembly.GetExecutingAssembly());
         var stream = assets.StreamOf("new-presentation.pptx");
         this.validateable = new StreamPresentation(stream);
-        this.validateable.FileProperties.Modified =
-            this.validateable.FileProperties.Created = SCSettings.TimeProvider.UtcNow;
+        this.validateable.Metadata.Modified =
+            this.validateable.Metadata.Created = SCSettings.TimeProvider.UtcNow;
     }
 
     /// <inheritdoc />
@@ -67,7 +67,7 @@ public sealed class Presentation : IPresentation
     public IFooter Footer => this.validateable.Footer;
     
     /// <inheritdoc />
-    public IFileProperties FileProperties => this.validateable.FileProperties;
+    public IPresentationMetadata Metadata => this.validateable.Metadata;
 
     /// <inheritdoc />
     public void Save() => this.validateable.Save();

--- a/src/ShapeCrawler/Presentations/StreamPresentation.cs
+++ b/src/ShapeCrawler/Presentations/StreamPresentation.cs
@@ -36,7 +36,7 @@ internal sealed class StreamPresentation : IValidateable
 
     public IFooter Footer => this.presentationCore.Footer;
 
-    public IFileProperties FileProperties => this.presentationCore.FileProperties;
+    public IPresentationMetadata Metadata => this.presentationCore.FileProperties;
 
     public ISlide Slide(int number) => this.presentationCore.Slides[number - 1];
 

--- a/test/ShapeCrawler.Tests.Unit/PresentationTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/PresentationTests.cs
@@ -380,7 +380,7 @@ public class PresentationTests : SCTest
         // Assert
         stream.Position = 0;
         var updatedPres = new Presentation(stream);
-        updatedPres.FileProperties.Created.Should().Be(expectedCreated);
+        updatedPres.Metadata.Created.Should().Be(expectedCreated);
     }
     
     [Test]
@@ -400,7 +400,7 @@ public class PresentationTests : SCTest
         // Assert
         stream.Position = 0;
         var updatedPres = new Presentation(stream);
-        updatedPres.FileProperties.Modified.Should().Be(expectedModified);
+        updatedPres.Metadata.Modified.Should().Be(expectedModified);
     } 
     
     [Test]
@@ -548,12 +548,12 @@ public class PresentationTests : SCTest
         var expectedCreated = new DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Local);
 
         // Act
-        pres.FileProperties.Title = "Properties_setter_sets_values";
-        pres.FileProperties.Created = expectedCreated;
+        pres.Metadata.Title = "Properties_setter_sets_values";
+        pres.Metadata.Created = expectedCreated;
         
         // Assert
-        pres.FileProperties.Title.Should().Be("Properties_setter_sets_values");
-        pres.FileProperties.Created.Should().Be(expectedCreated);
+        pres.Metadata.Title.Should().Be("Properties_setter_sets_values");
+        pres.Metadata.Created.Should().Be(expectedCreated);
     }
 
     [Test]
@@ -565,17 +565,17 @@ public class PresentationTests : SCTest
         var stream = new MemoryStream();
 
         // Act
-        pres.FileProperties.Title = "Properties_setter_survives_round_trip";
-        pres.FileProperties.Created = expectedCreated;
-        pres.FileProperties.RevisionNumber = 100;
+        pres.Metadata.Title = "Properties_setter_survives_round_trip";
+        pres.Metadata.Created = expectedCreated;
+        pres.Metadata.RevisionNumber = 100;
         pres.SaveAs(stream);
         
         // Assert
         stream.Position = 0;
         var updatePres = new Presentation(stream);
-        updatePres.FileProperties.Title.Should().Be("Properties_setter_survives_round_trip");
-        updatePres.FileProperties.Created.Should().Be(expectedCreated);
-        pres.FileProperties.RevisionNumber.Should().Be(100);
+        updatePres.Metadata.Title.Should().Be("Properties_setter_survives_round_trip");
+        updatePres.Metadata.Created.Should().Be(expectedCreated);
+        pres.Metadata.RevisionNumber.Should().Be(100);
     }
 
     [Test]
@@ -585,10 +585,10 @@ public class PresentationTests : SCTest
         var expectedModified = DateTime.Parse("2024-12-16T17:11:58Z", CultureInfo.InvariantCulture);
 
         // Act-Assert
-        pres.FileProperties.Modified.Should().Be(expectedModified);
-        pres.FileProperties.Title.Should().Be("");
-        pres.FileProperties.RevisionNumber.Should().Be(7);
-        pres.FileProperties.Comments.Should().BeNull();
+        pres.Metadata.Modified.Should().Be(expectedModified);
+        pres.Metadata.Title.Should().Be("");
+        pres.Metadata.RevisionNumber.Should().Be(7);
+        pres.Metadata.Comments.Should().BeNull();
     }
     
     [Test]
@@ -602,6 +602,14 @@ public class PresentationTests : SCTest
         var pres = new Presentation();
 
         // Assert
-        pres.FileProperties.Modified.Should().Be(expectedModified);
+        pres.Metadata.Modified.Should().Be(expectedModified);
+    }
+
+    [Test]
+    public void WIP()
+    {
+        var pres = new Presentation(@"c:\temp\google presentation.pptx");
+
+        var slidesCount = pres.Slides.Count;
     }
 }

--- a/test/ShapeCrawler.Tests.Unit/PresentationTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/PresentationTests.cs
@@ -604,12 +604,4 @@ public class PresentationTests : SCTest
         // Assert
         pres.Metadata.Modified.Should().Be(expectedModified);
     }
-
-    [Test]
-    public void WIP()
-    {
-        var pres = new Presentation(@"c:\temp\google presentation.pptx");
-
-        var slidesCount = pres.Slides.Count;
-    }
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR refactors the presentation file properties by replacing `IFileProperties` with `IPresentationMetadata`, updating related references throughout the codebase to enhance clarity and maintainability.

### Detailed summary
- Replaced `IFileProperties` with `IPresentationMetadata` in multiple files.
- Updated property accessors for `Metadata` instead of `FileProperties`.
- Modified comments to reflect changes in metadata terminology.
- Adjusted unit tests to check for `Metadata` instead of `FileProperties`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->