### PR TITLE
Remove open presentation from path

### DIFF
--- a/src/ShapeCrawler/Presentations/IPresentation.cs
+++ b/src/ShapeCrawler/Presentations/IPresentation.cs
@@ -11,11 +11,6 @@ namespace ShapeCrawler;
 public interface IPresentation : IPresentationProperties
 {
     /// <summary>
-    ///     Saves presentation in the specified file path.
-    /// </summary>
-    void SaveAs(string path);
-
-    /// <summary>
     ///     Saves presentation in specified stream.
     /// </summary>
     void SaveAs(Stream stream);

--- a/test/ShapeCrawler.Tests.Unit/Helpers/SCTest.cs
+++ b/test/ShapeCrawler.Tests.Unit/Helpers/SCTest.cs
@@ -68,20 +68,6 @@ public abstract class SCTest
         return PresentationDocument.Open(stream, true);
     }
 
-#if DEBUG
-
-    protected void SaveResult(IPresentation pres)
-    {
-
-        var testFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", "TestResults",
-            TestContext.CurrentContext.Test.MethodName);
-        Directory.CreateDirectory(testFolder);
-
-        pres.SaveAs(Path.Combine(testFolder, "result.pptx"));
-    }
-
-#endif
-
     private static IPresentation GetPresentationFromAssembly(string fileName)
     {
         var stream = TestAsset(fileName);

--- a/test/ShapeCrawler.Tests.Unit/PresentationTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/PresentationTests.cs
@@ -480,25 +480,27 @@ public class PresentationTests : SCTest
         File.Delete(originalPath);
         File.Delete(newPath);
     }
-
+    
     [Test]
-    [Parallelizable(ParallelScope.None)]
     public void Slides_Add_adds_slide()
     {
         // Arrange
-        var source = new Presentation(TestAsset("001.pptx"));
-        var targetPath = GetTestPath("008.pptx");
-        var target = new Presentation(targetPath);
-        var copyingSlide = source.Slides[0];
+        var sourceSlide = new Presentation(TestAsset("001.pptx")).Slides[0];
+        var pptx = TestAsset("002.pptx");
+        var destPre = new Presentation(pptx);
+        var originSlidesCount = destPre.Slides.Count;
+        var expectedSlidesCount = ++originSlidesCount;
+        MemoryStream savedPre = new ();
 
         // Act
-        var slideAdding = () => target.Slides.Add(copyingSlide);
+        destPre.Slides.Add(sourceSlide);
 
         // Assert
-        slideAdding.Should().NotThrow();
+        destPre.Slides.Count.Should().Be(expectedSlidesCount, "because the new slide has been added");
 
-        // Clean
-        File.Delete(targetPath);
+        destPre.SaveAs(savedPre);
+        destPre = new Presentation(savedPre);
+        destPre.Slides.Count.Should().Be(expectedSlidesCount, "because the new slide has been added");
     }
     
     [Test]

--- a/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeCollectionTests.cs
@@ -913,28 +913,6 @@ public class ShapeCollectionTests : SCTest
         numberSlidesCase1.Should().Be(1);
         numberSlidesCase2.Should().Be(1);
     }
-
-    [Test]
-    public void Add_adds_external_slide()
-    {
-        // Arrange
-        var sourceSlide = new Presentation(TestAsset("001.pptx")).Slides[0];
-        var pptx = TestAsset("002.pptx");
-        var destPre = new Presentation(pptx);
-        var originSlidesCount = destPre.Slides.Count;
-        var expectedSlidesCount = ++originSlidesCount;
-        MemoryStream savedPre = new ();
-
-        // Act
-        destPre.Slides.Add(sourceSlide);
-
-        // Assert
-        destPre.Slides.Count.Should().Be(expectedSlidesCount, "because the new slide has been added");
-
-        destPre.SaveAs(savedPre);
-        destPre = new Presentation(savedPre);
-        destPre.Slides.Count.Should().Be(expectedSlidesCount, "because the new slide has been added");
-    }
     
     [Test]
     public void Add_adds_slide_from_the_Same_presentation()


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on removing the `SaveAs` method from the `IPresentation` interface and related test methods, while enhancing the slide addition functionality in tests.

### Detailed summary
- Removed `SaveAs(string path)` method from `IPresentation`.
- Deleted conditional `SaveResult` method in `SCTest.cs`.
- Refactored slide addition tests in `ShapeCollectionTests.cs` and `PresentationTests.cs` to improve clarity and functionality.
- Ensured proper assertions after adding slides in tests.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->