### PR TITLE
Fix for issue  #552 : Table height is not updating 

### DIFF
--- a/src/ShapeCrawler/Tables/ITable.cs
+++ b/src/ShapeCrawler/Tables/ITable.cs
@@ -86,6 +86,12 @@ internal sealed class Table : CopyableShape, ITable
         set => this.SetTableStyle(value);
     }
 
+    public new decimal Height 
+    { 
+        get => base.Height;
+        set => this.UpdateTableHeight(value); 
+    }
+
     public ITableStyleOptions TableStyleOptions { get; }
 
     public override bool Removeable => true;
@@ -144,6 +150,11 @@ internal sealed class Table : CopyableShape, ITable
 
     public override ITable AsTable() => this;
 
+    internal void SetTableHeight(decimal value)
+    {
+        base.Height = value;
+    }
+
     private void SetTableStyle(ITableStyle style)
     {
         this.ATable.TableProperties!.GetFirstChild<A.TableStyleId>() !.Text = ((TableStyle)style).Guid;
@@ -160,6 +171,18 @@ internal sealed class Table : CopyableShape, ITable
         }
 
         return this.tableStyle;
+    }
+
+    private void UpdateTableHeight(decimal value)
+    {
+        var percent_new_height = value / base.Height;
+
+        base.Height = value;
+
+        foreach (TableRow row in this.Rows)
+        {
+            row.SetHeight((int)(row.Height * percent_new_height));
+        }
     }
 
     private void RemoveRowIfNeeded()

--- a/src/ShapeCrawler/Tables/ITableRow.cs
+++ b/src/ShapeCrawler/Tables/ITableRow.cs
@@ -23,7 +23,7 @@ public interface ITableRow
     ///     Gets or sets height in points.
     /// </summary>
     int Height { get; set; }
-
+    
     /// <summary>
     ///     Creates a duplicate of the current row and adds this at the table end.
     /// </summary>
@@ -58,7 +58,7 @@ internal sealed class TableRow : ITableRow
             var columnIdx = 0;
             foreach (var aTc in aTcList)
             {
-                var mergedWithPreviousHorizontal = aTc.HorizontalMerge is not null; 
+                var mergedWithPreviousHorizontal = aTc.HorizontalMerge is not null;
                 if (mergedWithPreviousHorizontal)
                 {
                     cells.Add(addedCell);
@@ -104,6 +104,19 @@ internal sealed class TableRow : ITableRow
         return this.ATableRow;
     }
 
+    internal void SetHeight(int newPixels)
+    {
+        var currentPixels = this.GetHeight();
+
+        if (currentPixels == newPixels)
+        {
+            return;
+        }
+
+        var newEmu = UnitConverter.PointToEmu(newPixels);
+        this.ATableRow.Height!.Value = newEmu;
+    }
+
     private int GetHeight()
     {
         return (int)UnitConverter.EmuToPoint((int)this.ATableRow.Height!.Value);
@@ -126,13 +139,13 @@ internal sealed class TableRow : ITableRow
         {
             var diffPoints = newPoints - currentPoints;
             var diffPixels = (int)UnitConverter.PointToPixel(diffPoints);
-            parentTable.Height += diffPixels;
+            parentTable.SetTableHeight(parentTable.Height + diffPixels);
         }
         else
         {
             var diffPoints = currentPoints - newPoints;
             var diffPixels = (int)UnitConverter.PointToPixel(diffPoints);
-            parentTable.Height -= diffPixels;
+            parentTable.SetTableHeight(parentTable.Height - diffPixels);
         }
     }
 }

--- a/test/ShapeCrawler.Tests.Unit/TableTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/TableTests.cs
@@ -1225,7 +1225,6 @@ public class TableTests : SCTest
     }
     
     [Test]
-    [Explicit("https://github.com/ShapeCrawler/ShapeCrawler/issues/552")]
     public void Height_Setter_should_proportionally_increase_the_row_heights_When_the_new_table_height_is_bigger()
     {
         // Arrange
@@ -1234,11 +1233,12 @@ public class TableTests : SCTest
         var addedTable = pres.Slide(1).Shapes.Last<ITable>();
         
         // Act
-        addedTable.Height = 100;
+        var currentRowsHeight = addedTable.Rows[0].Height;
+        addedTable.Height *= 1.5m;
         
         // Assert
-        addedTable.Rows[0].Height.Should().Be(40);
-        addedTable.Rows[1].Height.Should().Be(40);
+        addedTable.Rows[0].Height.Should().Be((int)(currentRowsHeight * 1.5));
+        addedTable.Rows[1].Height.Should().Be((int)(currentRowsHeight * 1.5));
         pres.Validate();
     }
 }


### PR DESCRIPTION
Also fix the unit test

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `Height` property functionality for tables in the `ShapeCrawler` library. It ensures that when the table height is updated, the row heights are proportionally adjusted.

### Detailed summary
- Removed the `[Explicit]` attribute from the test `Height_Setter_should_proportionally_increase_the_row_heights_When_the_new_table_height_is_bigger`.
- Changed the height assignment to use a proportional increase based on the current row height.
- Added a new `Height` property in `ITable` that overrides the base property and calls `UpdateTableHeight`.
- Introduced `SetTableHeight` method in `ITable` to set the height and update row heights accordingly.
- Added `UpdateTableHeight` method in `ITable` to calculate and set new row heights based on the updated table height.
- Implemented `SetHeight` method in `ITableRow` to adjust the row height in pixels. 
- Updated height adjustments in `UpdateHeight` to call `SetTableHeight` instead of directly modifying the parent table height.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->