### PR TITLE
Add test to reproduce issue of Discussion #950

### DIFF
--- a/src/ShapeCrawler/Presentations/IPresentation.cs
+++ b/src/ShapeCrawler/Presentations/IPresentation.cs
@@ -58,13 +58,9 @@ public interface IPresentation
     ///     Saves presentation to the stream.
     /// </summary>
     void Save(Stream stream);
-    
+
     /// <summary>
     ///     Saves presentation to the file.
     /// </summary>
-    public void Save(string file)
-    {
-        using var stream = new FileStream(file, FileMode.Create);
-        this.Save(stream);
-    }
+    public void Save(string file);
 }

--- a/src/ShapeCrawler/Presentations/IPresentation.cs
+++ b/src/ShapeCrawler/Presentations/IPresentation.cs
@@ -55,7 +55,16 @@ public interface IPresentation
     void Save();
 
     /// <summary>
-    ///     Copies presentation to the specified stream.
+    ///     Saves presentation to the stream.
     /// </summary>
-    void Copy(Stream stream);
+    void Save(Stream stream);
+    
+    /// <summary>
+    ///     Saves presentation to the file.
+    /// </summary>
+    public void Save(string file)
+    {
+        using var stream = new FileStream(file, FileMode.Create);
+        this.Save(stream);
+    }
 }

--- a/src/ShapeCrawler/Presentations/Presentation.cs
+++ b/src/ShapeCrawler/Presentations/Presentation.cs
@@ -100,10 +100,19 @@ public sealed class Presentation : IPresentation
     public void Save() => this.presDocument.Save();
     
     /// <inheritdoc />
-    public void Copy(Stream stream)
+    public void Save(Stream stream)
     {
+        this.Save();
         this.Properties.Modified = SCSettings.TimeProvider.UtcNow;
         this.presDocument.Clone(stream);
+    }
+    
+    /// <inheritdoc />
+    public void Save(string file)
+    {
+        this.Save();
+        using var stream = new FileStream(file, FileMode.Create);
+        this.Save(stream);
     }
 
     internal void Validate()

--- a/test/ShapeCrawler.Tests.Unit/BulletTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/BulletTests.cs
@@ -24,7 +24,7 @@ public class BulletTests : SCTest
         bullet.Character.Should().Be("*");
 
         var savedPreStream = new MemoryStream();
-        pres.Copy(savedPreStream);
+        pres.Save(savedPreStream);
         var newPresentation = new Presentation(savedPreStream);
         shape = newPresentation.Slides[0].Shapes.GetByName<IShape>("AutoShape 1");
         bullet = shape.TextBox!.Paragraphs[0].Bullet;
@@ -55,7 +55,7 @@ public class BulletTests : SCTest
         addedParagraph.Bullet.Size.Should().Be(100);
         addedParagraph.Bullet.FontName.Should().Be("Tahoma");
 
-        presentation.Copy(mStream);
+        presentation.Save(mStream);
 
         presentation = new Presentation(mStream);
         placeholderAutoShape = presentation.Slides[2].Shapes.First(sp => sp.Id == 7);
@@ -87,7 +87,7 @@ public class BulletTests : SCTest
         addedParagraph.Bullet.Size.Should().Be(100);
         addedParagraph.Bullet.FontName.Should().Be("Tahoma");
 
-        presentation.Copy(mStream);
+        presentation.Save(mStream);
 
         presentation = new Presentation(mStream);
         placeholderAutoShape = (IShape)presentation.Slides[2].Shapes.First(sp => sp.Id == 7);

--- a/test/ShapeCrawler.Tests.Unit/ChartTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ChartTests.cs
@@ -189,7 +189,7 @@ public class ChartTests : SCTest
 
         // Assert
         pieChart.Categories[0].Name.Should().Be("Category 1_new");
-        pres.Copy(mStream);
+        pres.Save(mStream);
         pres = new Presentation(mStream);
         pieChart = pres.Slides[0].Shapes.GetById<IChart>(7);
         pieChart.Categories[0].Name.Should().Be("Category 1_new");
@@ -327,7 +327,7 @@ public class ChartTests : SCTest
         barChart.Axes.ValueAxis.Minimum = 1;
 
         // Assert
-        pres.Copy(mStream);
+        pres.Save(mStream);
         barChart = new Presentation(mStream).Slides[0].Shapes.GetByName<IChart>("Bar Chart 1");
         barChart.Axes.ValueAxis.Minimum.Should().Be(1);
         pres.Validate();

--- a/test/ShapeCrawler.Tests.Unit/FontColorTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/FontColorTests.cs
@@ -114,7 +114,7 @@ public class FontColorTests : SCTest
         // Assert
         fontColor.Hex.Should().Be("008000");
 
-        pres.Copy(mStream);
+        pres.Save(mStream);
         pres = new Presentation(mStream);
         fontColor = portionQuery.Get(pres).Font!.Color;
         fontColor.Hex.Should().Be("008000");
@@ -132,7 +132,7 @@ public class FontColorTests : SCTest
         fontColor.Update("#007F00");
         
         // Assert
-        pres.Copy(stream);
+        pres.Save(stream);
         pres = new Presentation(stream);
         pres.Validate();
         fontColor = pres.SlideMasters[0].Shapes.GetByName("TextBox 1").TextBox.Paragraphs[0].Portions[0].Font!.Color;
@@ -153,7 +153,7 @@ public class FontColorTests : SCTest
         // Assert
         color.Hex.Should().Be("008000");
 
-        pres.Copy(mStream);
+        pres.Save(mStream);
         pres = new Presentation(mStream);
         color = portionQuery.Get(pres).Font!.Color;
         color.Hex.Should().Be("008000");

--- a/test/ShapeCrawler.Tests.Unit/FontTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/FontTests.cs
@@ -173,7 +173,7 @@ public class FontTests : SCTest
 
         // Assert
         portion.Font.IsBold.Should().BeTrue();
-        presentation.Copy(mStream);
+        presentation.Save(mStream);
         presentation = new Presentation(mStream);
         nonPlaceholderAutoShape = (IShape)presentation.Slides[0].Shapes.First(sp => sp.Id == 2);
         portion = nonPlaceholderAutoShape.TextBox.Paragraphs[0].Portions[0];
@@ -219,7 +219,7 @@ public class FontTests : SCTest
 
         // Assert
         portion.Font.IsItalic.Should().BeTrue();
-        presentation.Copy(mStream);
+        presentation.Save(mStream);
         presentation = new Presentation(mStream);
         nonPlaceholderAutoShape = (IShape)presentation.Slides[0].Shapes.First(sp => sp.Id == 2);
         portion = nonPlaceholderAutoShape.TextBox.Paragraphs[0].Portions[0];
@@ -240,7 +240,7 @@ public class FontTests : SCTest
 
         // Assert
         portion.Font.IsItalic.Should().BeFalse();
-        presentation.Copy(mStream);
+        presentation.Save(mStream);
 
         presentation = new Presentation(mStream);
         placeholderAutoShape = (IShape)presentation.Slides[2].Shapes.First(sp => sp.Id == 7);
@@ -262,7 +262,7 @@ public class FontTests : SCTest
 
         // Assert
         portion.Font.Underline.Should().Be(DocumentFormat.OpenXml.Drawing.TextUnderlineValues.Single);
-        presentation.Copy(mStream);
+        presentation.Save(mStream);
 
         presentation = new Presentation(mStream);
         placeholderAutoShape = (IShape)presentation.Slides[2].Shapes.First(sp => sp.Id == 7);
@@ -395,7 +395,7 @@ public class FontTests : SCTest
 
         // Assert
         pres.Validate();
-        pres.Copy(mStream);
+        pres.Save(mStream);
         pres = new Presentation(mStream);
         font = pres.Slides[slideNumber - 1].Shapes.GetByName(shapeName).TextBox!.Paragraphs[0].Portions[0].Font;
         font.Size.Should().Be(newSize);
@@ -417,7 +417,7 @@ public class FontTests : SCTest
 
         // Assert
         font.IsBold.Should().BeTrue();
-        pres.Copy(mStream);
+        pres.Save(mStream);
         pres = new Presentation(mStream);
         placeholder = pres.Slides[slideNumber - 1].Shapes.GetById<IShape>(shapeId);
         font = placeholder.TextBox.Paragraphs[0].Portions[0].Font;
@@ -454,7 +454,7 @@ public class FontTests : SCTest
 
         // Act
         font.OffsetEffect = expectedOffsetEffect;
-        pres.Copy(mStream);
+        pres.Save(mStream);
 
         // Assert
         pres = new Presentation(mStream);

--- a/test/ShapeCrawler.Tests.Unit/Helpers/SCTest.cs
+++ b/test/ShapeCrawler.Tests.Unit/Helpers/SCTest.cs
@@ -55,7 +55,7 @@ public abstract class SCTest
     protected static Presentation SaveAndOpenPresentation(IPresentation presentation)
     {
         var stream = new MemoryStream();
-        presentation.Copy(stream);
+        presentation.Save(stream);
 
         return new Presentation(stream);
     }
@@ -63,7 +63,7 @@ public abstract class SCTest
     protected static PresentationDocument SaveAndOpenPresentationAsSdk(IPresentation presentation)
     {
         var stream = new MemoryStream();
-        presentation.Copy(stream);
+        presentation.Save(stream);
         stream.Position = 0;
 
         return PresentationDocument.Open(stream, true);

--- a/test/ShapeCrawler.Tests.Unit/ParagraphTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ParagraphTests.cs
@@ -279,7 +279,7 @@ public class ParagraphTests : SCTest
         // Assert
         paragraph.HorizontalAlignment.Should().Be(TextHorizontalAlignment.Right);
 
-        pres.Copy(mStream);
+        pres.Save(mStream);
         pres = new Presentation(mStream);
         paragraph = pres.Slides[slideNumber - 1].Shapes.GetByName<IShape>(shapeName).TextBox.Paragraphs[0];
         paragraph.HorizontalAlignment.Should().Be(TextHorizontalAlignment.Right);
@@ -306,7 +306,7 @@ public class ParagraphTests : SCTest
         paragraph.Text.Should().BeEquivalentTo(paraText);
         paragraph.Portions.Count.Should().Be(expectedPortionsCount);
 
-        pres.Copy(mStream);
+        pres.Save(mStream);
         pres = new Presentation(mStream);
         paragraph = pres.Slides[slideNumber - 1].Shapes.GetById<IShape>(shapeId).TextBox.Paragraphs[paraNumber - 1];
         paragraph.Text.Should().BeEquivalentTo(paraText);
@@ -385,7 +385,7 @@ public class ParagraphTests : SCTest
         paragraph.Spacing.BeforeSpacingPoints.Should().Be(50);
 
         using var mStream = new MemoryStream();
-        pres.Copy(mStream);
+        pres.Save(mStream);
         pres = new Presentation(mStream);
         paragraph = pres.Slides[0].Shapes.Last().TextBox.Paragraphs[0];
         paragraph.Spacing.BeforeSpacingPoints.Should().Be(50);
@@ -408,7 +408,7 @@ public class ParagraphTests : SCTest
         // Assert
         paragraph.Spacing.AfterSpacingPoints.Should().Be(50);
         var mStream = new MemoryStream();
-        pres.Copy(mStream);
+        pres.Save(mStream);
         pres = new Presentation(mStream);
         paragraph = pres.Slides[0].Shapes.Last().TextBox.Paragraphs[0];
         paragraph.Spacing.AfterSpacingPoints.Should().Be(50);

--- a/test/ShapeCrawler.Tests.Unit/PictureTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/PictureTests.cs
@@ -92,7 +92,7 @@ public class PictureTests : SCTest
         image.Update(pngStream);
 
         // Assert
-        pres.Copy(mStream);
+        pres.Save(mStream);
         pres = new Presentation(mStream);
         picture = pres.Slides[1].Shapes.GetByName<IPicture>("Picture 1");
         var lengthAfter = picture.Image!.AsByteArray().Length;
@@ -130,7 +130,7 @@ public class PictureTests : SCTest
         groupedPicture1.Image!.Update(image);
 
         // Assert
-        pres.Copy(stream);
+        pres.Save(stream);
         var pictureContent1 = groupedPicture1.Image.AsByteArray();
         var pictureContent2 = groupedPicture2.Image!.AsByteArray();
         pictureContent1.SequenceEqual(pictureContent2).Should().BeFalse();

--- a/test/ShapeCrawler.Tests.Unit/PresentationTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/PresentationTests.cs
@@ -524,18 +524,4 @@ public class PresentationTests : SCTest
         // Assert
         pres.Properties.Modified.Should().Be(expectedModified);
     }
-
-    [Test]
-    [Explicit]
-    public void Discussion_950()
-    {
-        var pres = new Presentation();
-        var shapes = pres.Slide(1).Shapes;
-        shapes.AddTable(100,100,2,2);
-        var table = shapes.Last<ITable>();
-
-        table.Rows[0].Cells[0].TextBox.Text = "Paragraph 1\nParagraph 2";
-        
-        pres.Save(@"c:\temp\output.pptx");
-    }
 }

--- a/test/ShapeCrawler.Tests.Unit/PresentationTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/PresentationTests.cs
@@ -120,7 +120,7 @@ public class PresentationTests : SCTest
         // Assert
         destPre.Slides.Count.Should().Be(expectedSlidesCount, "because the new slide has been added");
 
-        destPre.Copy(savedPre);
+        destPre.Save(savedPre);
         destPre = new Presentation(savedPre);
         destPre.Slides.Count.Should().Be(expectedSlidesCount, "because the new slide has been added");
     }
@@ -141,7 +141,7 @@ public class PresentationTests : SCTest
         // Assert
         destPres.Slides.Count.Should().Be(expectedCount);
 
-        destPres.Copy(savedPre);
+        destPres.Save(savedPre);
         destPres = new Presentation(savedPre);
         destPres.Slides.Count.Should().Be(expectedCount);
         destPres.Slides[1].SlideLayout.SlideMaster.SlideLayouts.Count.Should().Be(1);
@@ -228,7 +228,7 @@ public class PresentationTests : SCTest
         // Assert
         sectionSlides.Count.Should().Be(0);
 
-        pres.Copy(mStream);
+        pres.Save(mStream);
         pres = new Presentation(mStream);
         sectionSlides = pres.Sections[0].Slides;
         sectionSlides.Count.Should().Be(0);
@@ -354,7 +354,7 @@ public class PresentationTests : SCTest
         var stream = new MemoryStream();
 
         // Act
-        pres.Copy(stream);
+        pres.Save(stream);
 
         // Assert
         stream.Position = 0;
@@ -416,7 +416,7 @@ public class PresentationTests : SCTest
         // Assert
         destPre.Slides.Count.Should().Be(expectedSlidesCount, "because the new slide has been added");
 
-        destPre.Copy(savedPre);
+        destPre.Save(savedPre);
         destPre = new Presentation(savedPre);
         destPre.Slides.Count.Should().Be(expectedSlidesCount, "because the new slide has been added");
     }
@@ -437,7 +437,7 @@ public class PresentationTests : SCTest
         // Assert
         pres.Slides.Should().HaveCount(expectedSlidesCount);
 
-        pres.Copy(mStream);
+        pres.Save(mStream);
         pres = new Presentation(mStream);
         pres.Slides.Should().HaveCount(expectedSlidesCount);
     }
@@ -488,7 +488,7 @@ public class PresentationTests : SCTest
         pres.Properties.Title = "Properties_setter_survives_round_trip";
         pres.Properties.Created = expectedCreated;
         pres.Properties.RevisionNumber = 100;
-        pres.Copy(stream);
+        pres.Save(stream);
         
         // Assert
         stream.Position = 0;
@@ -523,5 +523,19 @@ public class PresentationTests : SCTest
 
         // Assert
         pres.Properties.Modified.Should().Be(expectedModified);
+    }
+
+    [Test]
+    [Explicit]
+    public void Discussion_950()
+    {
+        var pres = new Presentation();
+        var shapes = pres.Slide(1).Shapes;
+        shapes.AddTable(100,100,2,2);
+        var table = shapes.Last<ITable>();
+
+        table.Rows[0].Cells[0].TextBox.Text = "Paragraph 1\nParagraph 2";
+        
+        pres.Save(@"c:\temp\output.pptx");
     }
 }

--- a/test/ShapeCrawler.Tests.Unit/ShapeTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/ShapeTests.cs
@@ -89,7 +89,7 @@ public class ShapeTests : SCTest
         int pic6LengthAfter = picture6.Image.AsByteArray().Length;
         pic6LengthAfter.Should().Be(pic6LengthBefore);
 
-        presentation.Copy(modifiedPresentation);
+        presentation.Save(modifiedPresentation);
         presentation = new Presentation(modifiedPresentation);
         picture6 = (IPicture)presentation.Slides[3].Shapes.First(sp => sp.Id == 6);
         pic6LengthBefore = picture6.Image.AsByteArray().Length;
@@ -285,7 +285,7 @@ public class ShapeTests : SCTest
 
         // Act
         shape.CustomData = customDataString;
-        presentation.Copy(savedPreStream);
+        presentation.Save(savedPreStream);
 
         // Assert
         presentation = new Presentation(savedPreStream);
@@ -370,7 +370,7 @@ public class ShapeTests : SCTest
         shape.X = 400;
 
         // Assert
-        pres.Copy(stream);
+        pres.Save(stream);
         pres = new Presentation(stream);
         shape = pres.Slides[slideNumber - 1].Shapes.GetByName<IShape>(shapeName);
         shape.X.Should().Be(400);
@@ -391,7 +391,7 @@ public class ShapeTests : SCTest
         shape.Width = 600;
 
         // Assert
-        pres.Copy(stream);
+        pres.Save(stream);
         pres = new Presentation(stream);
         shape = pres.Slides[slideNumber - 1].Shapes.GetByName(shapeName);
         shape.Width.Should().Be(600);
@@ -741,7 +741,7 @@ public class ShapeTests : SCTest
         shape.Name = "New Name";
 
         // Assert
-        pres.Copy(stream);
+        pres.Save(stream);
         pres = new Presentation(stream);
         shape = pres.Slides[0].Shapes.GetByName("New Name");
         shape.Name.Should().Be("New Name");
@@ -761,7 +761,7 @@ public class ShapeTests : SCTest
         groupShape.Name = "New Group Name";
 
         // Assert
-        pres.Copy(stream);
+        pres.Save(stream);
         pres = new Presentation(stream);
         groupShape = pres.Slides[0].Shapes.GetByName<IGroupShape>("New Group Name");
         groupShape.Name.Should().Be("New Group Name");

--- a/test/ShapeCrawler.Tests.Unit/SlideTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/SlideTests.cs
@@ -144,7 +144,7 @@ public class SlideTests : SCTest
         slide.CustomData = customDataString;
 
         var savedPreStream = new MemoryStream();
-        originPre.Copy(savedPreStream);
+        originPre.Save(savedPreStream);
         var savedPre = new Presentation(savedPreStream);
         var customData = savedPre.Slides.First().CustomData;
 

--- a/test/ShapeCrawler.Tests.Unit/TableTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/TableTests.cs
@@ -38,7 +38,7 @@ public class TableTests : SCTest
 
 		// Assert
 		table.TableStyle.Should().BeEquivalentTo(TableStyle.ThemedStyle1Accent4);
-		pres.Copy(mStream);
+		pres.Save(mStream);
 		pres = new Presentation(mStream);
         table = pres.Slide(3).Table("Таблица 4");
 		table.TableStyle.Should().BeEquivalentTo(TableStyle.ThemedStyle1Accent4);
@@ -72,7 +72,7 @@ public class TableTests : SCTest
 
 		// Assert
 		table[1, 2].RightBorder.Color.Should().Be("00FF00");
-		pres.Copy(mStream);
+		pres.Save(mStream);
 
 		pres = new Presentation(mStream);
         table = pres.Slide(1).Table("Table 1");
@@ -112,7 +112,7 @@ public class TableTests : SCTest
 
 		// Assert
 		tableCell.TextBox.TopMargin.Should().Be(1.4M);
-		pres.Copy(mStream);
+		pres.Save(mStream);
 
 		pres = new Presentation(mStream);
         table = pres.Slide(1).Table("Table 2");
@@ -155,7 +155,7 @@ public class TableTests : SCTest
         // Assert
 		tableCell.TextBox.VerticalAlignment.Should().Be(TextVerticalAlignment.Middle);
         tableCell.TextBox.Paragraphs[0].HorizontalAlignment.Should().Be(TextHorizontalAlignment.Center);
-		pres.Copy(mStream);
+		pres.Save(mStream);
 
 		pres = new Presentation(mStream);
         table = pres.Slide(1).Table("Table 2");
@@ -182,7 +182,7 @@ public class TableTests : SCTest
 
         // Assert
         table.Columns.Should().HaveCount(expectedColumnsCount);
-        pres.Copy(ms);
+        pres.Save(ms);
         pres = new Presentation(ms);
         table = pres.Slides[0].Shapes.GetByName<ITable>("Table 1");
         table.Columns.Should().HaveCount(expectedColumnsCount);
@@ -336,7 +336,7 @@ public class TableTests : SCTest
 
         // Assert
         table.Rows.Should().HaveCountLessThan(originRowsCount);
-        pres.Copy(mStream);
+        pres.Save(mStream);
         table = (ITable)new Presentation(mStream).Slides[2].Shapes.First(sp => sp.Id == 3);
         table.Rows.Should().HaveCountLessThan(originRowsCount);
     }
@@ -449,7 +449,7 @@ public class TableTests : SCTest
         // Assert
         table.Columns[0].Width.Should().Be(newColumnWidth);
 
-        pres.Copy(mStream);
+        pres.Save(mStream);
         pres = new Presentation(mStream);
         table = (ITable)pres.Slides[1].Shapes.First(sp => sp.Id == 3);
         table.Columns[0].Width.Should().Be(newColumnWidth);
@@ -574,7 +574,7 @@ public class TableTests : SCTest
         table[0, 1].IsMergedCell.Should().BeTrue();
         table[0, 0].TextBox.Text.Should().Be($"id5{Environment.NewLine}Text0_1");
 
-        presentation.Copy(mStream);
+        presentation.Save(mStream);
         presentation = new Presentation(mStream);
         table = (ITable)presentation.Slides[2].Shapes.First(sp => sp.Id == 5);
         table[0, 0].IsMergedCell.Should().BeTrue();
@@ -595,7 +595,7 @@ public class TableTests : SCTest
 
         // Assert
         AssertTable(table);
-        presentation.Copy(mStream);
+        presentation.Save(mStream);
         presentation = new Presentation(mStream);
         table = (ITable)presentation.Slides[2].Shapes.First(sp => sp.Id == 3);
         AssertTable(table);
@@ -625,7 +625,7 @@ public class TableTests : SCTest
         table[0, 1].IsMergedCell.Should().BeTrue();
         table[0, 2].IsMergedCell.Should().BeTrue();
 
-        presentation.Copy(mStream);
+        presentation.Save(mStream);
         presentation = new Presentation(mStream);
         table = (ITable)presentation.Slides[2].Shapes.First(sp => sp.Id == 3);
         table[0, 0].IsMergedCell.Should().BeTrue();
@@ -649,7 +649,7 @@ public class TableTests : SCTest
         table[0, 1].IsMergedCell.Should().BeTrue();
         table[0, 2].IsMergedCell.Should().BeTrue();
 
-        presentation.Copy(mStream);
+        presentation.Save(mStream);
         presentation = new Presentation(mStream);
         table = (ITable)presentation.Slides[2].Shapes.First(sp => sp.Id == 7);
         table[0, 0].IsMergedCell.Should().BeTrue();
@@ -671,7 +671,7 @@ public class TableTests : SCTest
 
         // Assert
         AssertTable(table);
-        pres.Copy(mStream);
+        pres.Save(mStream);
         pres = new Presentation(mStream);
         table = (ITable)pres.Slides[2].Shapes.First(sp => sp.Id == 5);
         AssertTable(table);
@@ -734,7 +734,7 @@ public class TableTests : SCTest
         table[1, 1].IsMergedCell.Should().BeTrue();
         table[0, 0].IsMergedCell.Should().BeFalse();
 
-        presentation.Copy(mStream);
+        presentation.Save(mStream);
         presentation = new Presentation(mStream);
         table = (ITable)presentation.Slides[2].Shapes.First(sp => sp.Id == 3);
         table[0, 1].IsMergedCell.Should().BeTrue();
@@ -760,7 +760,7 @@ public class TableTests : SCTest
         table[1, 1].IsMergedCell.Should().BeTrue();
         table[0, 2].IsMergedCell.Should().BeFalse();
 
-        presentation.Copy(mStream);
+        presentation.Save(mStream);
         presentation = new Presentation(mStream);
         table = (ITable)presentation.Slides[2].Shapes.First(sp => sp.Id == 10);
         table[0, 0].IsMergedCell.Should().BeTrue();
@@ -792,7 +792,7 @@ public class TableTests : SCTest
         
         table[3, 2].IsMergedCell.Should().BeFalse();
 
-        presentation.Copy(mStream);
+        presentation.Save(mStream);
         presentation = new Presentation(mStream);
         table = (ITable)presentation.Slides[1].Shapes.First(sp => sp.Id == 5);
         table[1, 1].IsMergedCell.Should().BeTrue();
@@ -829,7 +829,7 @@ public class TableTests : SCTest
         cell_0_0.ColumnIndex.Should().Be(cell_1_1.ColumnIndex);
         
         table[0, 2].IsMergedCell.Should().BeFalse();
-        pres.Copy(mStream);
+        pres.Save(mStream);
         pres = new Presentation(mStream);
         table = (ITable)pres.Slides[3].Shapes.First(sp => sp.Id == 2);
         table[0, 0].IsMergedCell.Should().BeTrue();
@@ -857,7 +857,7 @@ public class TableTests : SCTest
         table.Rows.Should().HaveCount(1);
         table.Rows[0].Cells.Should().HaveCount(1);
 
-        pres.Copy(mStream);
+        pres.Save(mStream);
         pres = new Presentation(mStream);
         table = (ITable)pres.Slides[3].Shapes.First(sp => sp.Id == 3);
         table.Columns.Should().HaveCount(1);
@@ -882,7 +882,7 @@ public class TableTests : SCTest
         // Assert
         AssertTable(table, mergedColumnWidth, mergedRowHeight);
 
-        pres.Copy(mStream);
+        pres.Save(mStream);
         pres = new Presentation(mStream);
         table = pres.Slides[2].Shapes.GetByName<ITable>("Table 5");
         AssertTable(table, mergedColumnWidth, mergedRowHeight);
@@ -912,7 +912,7 @@ public class TableTests : SCTest
         // Assert
         AssertTable(table, mergedColumnWidth);
 
-        presentation.Copy(mStream);
+        presentation.Save(mStream);
         presentation = new Presentation(mStream);
         table = (ITable)presentation.Slides[3].Shapes.First(sp => sp.Id == 6);
         AssertTable(table, mergedColumnWidth);
@@ -942,7 +942,7 @@ public class TableTests : SCTest
         // Assert
         AssertTable(table, expectedNewColumnWidth);
 
-        pres.Copy(mStream);
+        pres.Save(mStream);
         pres = new Presentation(mStream);
         table = (ITable)pres.Slides[3].Shapes.First(sp => sp.Id == 6);
         AssertTable(table, expectedNewColumnWidth);
@@ -1139,7 +1139,7 @@ public class TableTests : SCTest
         table[rowIdx1, colIdx1].IsMergedCell.Should().BeTrue();
         table[rowIdx2, colIdx2].IsMergedCell.Should().BeTrue();
 
-        pres.Copy(mStream);
+        pres.Save(mStream);
         pres = new Presentation(mStream);
         table = (ITable)pres.Slides[1].Shapes.First(sp => sp.Id == 4);
         table[rowIdx1, colIdx1].IsMergedCell.Should().BeTrue();
@@ -1192,7 +1192,7 @@ public class TableTests : SCTest
         table.TableStyleOptions.HasBandedColumns = hasBandedColumns;
 
         // Assert
-        pres.Copy(mStream);
+        pres.Save(mStream);
         pres = new Presentation(mStream);
         table = pres.Slides[0].Shapes.Last<ITable>();
         table.TableStyleOptions.HasHeaderRow.Should().Be(hasHeaderRow);

--- a/test/ShapeCrawler.Tests.Unit/TextBoxTests.cs
+++ b/test/ShapeCrawler.Tests.Unit/TextBoxTests.cs
@@ -64,7 +64,7 @@ namespace ShapeCrawler.Tests.Unit
             textFrame.Text = newText;
 
             // Assert
-            pres.Copy(modifiedPres);
+            pres.Save(modifiedPres);
             pres = new Presentation(modifiedPres);
             textFrame = pres.Slides[0].Shapes.GetByName<IShape>("TextBox 1").TextBox;
             textFrame.Text.Should().Contain("confirm this");
@@ -234,7 +234,7 @@ namespace ShapeCrawler.Tests.Unit
             lastPara.Text.Should().BeEquivalentTo(TEST_TEXT);
             textFrame.Paragraphs.Should().HaveCountGreaterThan(originParagraphsCount);
 
-            pres.Copy(mStream);
+            pres.Save(mStream);
             pres = new Presentation(mStream);
             textFrame = ((IShape)pres.Slides[0].Shapes.First(sp => sp.Id == 4)).TextBox;
             textFrame.Paragraphs.Last().Text.Should().BeEquivalentTo(TEST_TEXT);
@@ -379,7 +379,7 @@ namespace ShapeCrawler.Tests.Unit
             textFrame.Text.Should().BeEquivalentTo("Test");
             textFrame.Paragraphs.Should().HaveCount(1);
 
-            pres.Copy(mStream);
+            pres.Save(mStream);
             pres = new Presentation(mStream);
             textFrame = pres.Slides[slideNumber - 1].Shapes.GetByName<IShape>(shapeName).TextBox;
             textFrame.Text.Should().BeEquivalentTo("Test");
@@ -547,7 +547,7 @@ namespace ShapeCrawler.Tests.Unit
 			// Assert
 			textbox.VerticalAlignment.Should().Be(TextVerticalAlignment.Bottom);
 
-			pres.Copy(mStream);
+			pres.Save(mStream);
 			pres = new Presentation(mStream);
 			textbox = pres.Slides[slideNumber - 1].Shapes.GetByName<IShape>(shapeName).TextBox;
 			textbox.VerticalAlignment.Should().Be(TextVerticalAlignment.Bottom);


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on renaming the `Copy` method to `Save` in the `IPresentation` interface and its implementations, reflecting a change in functionality from copying to saving presentations. It also updates related test cases to use the new method.

### Detailed summary
- Renamed `Copy(Stream stream)` to `Save(Stream stream)` in `IPresentation` and `Presentation` classes.
- Added `Save(string file)` method to `IPresentation`.
- Updated all occurrences of `presentation.Copy(stream)` to `presentation.Save(stream)` in unit tests.
- Adjusted test cases to reflect changes in method names and functionality.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->