### PR TITLE
Update changelog and release notes for version 0.64.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog  
 
-## Version 0.64.2 - Unreleased
+## Version 0.64.2 - 2025-03-12
 🐞Fixed saving presentation in file stream [#953](https://github.com/ShapeCrawler/ShapeCrawler/issues/953)
 
 ## Version 0.64.1 - 2025-02-15

--- a/README.md
+++ b/README.md
@@ -109,8 +109,7 @@ Pull Requests are welcome! Please read the [Contribution Guide](https://github.c
 
 ## Changelog  
 
-### Version 0.64.1 - 2025-02-15
-🐞Fixed updating table cell margins [#916](https://github.com/ShapeCrawler/ShapeCrawler/issues/916)  
-🐞Fixed font size [#905](https://github.com/ShapeCrawler/ShapeCrawler/issues/905) 
+### Version 0.64.2 - 2025-03-12
+🐞Fixed saving presentation in file stream [#953](https://github.com/ShapeCrawler/ShapeCrawler/issues/953)
 
 Visit [CHANGELO.md](https://github.com/ShapeCrawler/ShapeCrawler/blob/master/CHANGELOG.md) to see the full change history.

--- a/src/ShapeCrawler/ShapeCrawler.csproj
+++ b/src/ShapeCrawler/ShapeCrawler.csproj
@@ -10,8 +10,7 @@ This library provides a simplified object model on top of the Open XML SDK for m
     <PackageTags>ShapeCrawler Presentation PPTX  PowerPoint Slides OpenXml OOXML</PackageTags>
     <NeutralLanguage>en</NeutralLanguage>
     <LangVersion>latest</LangVersion>
-    <PackageReleaseNotes>🐞Fixed updating table cell margins [#916](https://github.com/ShapeCrawler/ShapeCrawler/issues/916)  
-🐞Fixed font size [#905](https://github.com/ShapeCrawler/ShapeCrawler/issues/905)  </PackageReleaseNotes>
+    <PackageReleaseNotes>🐞Fixed saving presentation in file stream [#953](https://github.com/ShapeCrawler/ShapeCrawler/issues/953)</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/ShapeCrawler/ShapeCrawler</PackageProjectUrl>
     <RepositoryType>Git</RepositoryType>
     <RepositoryUrl>https://github.com/ShapeCrawler/ShapeCrawler</RepositoryUrl>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the version number in the `CHANGELOG.md` and `ShapeCrawler.csproj` files to reflect the release of version `0.64.2`, along with fixing the release notes related to saving presentations in file streams.

### Detailed summary
- Updated version in `CHANGELOG.md` from "Unreleased" to "2025-03-12" for version `0.64.2`.
- Added note for fixing saving presentation in file stream in `CHANGELOG.md` for version `0.64.2`.
- Updated `<PackageReleaseNotes>` in `ShapeCrawler.csproj` to reflect the new fix for saving presentations.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->