### PR TITLE
Correct wrong cast in point

### DIFF
--- a/src/ShapeCrawler/Units/Points.cs
+++ b/src/ShapeCrawler/Units/Points.cs
@@ -2,9 +2,9 @@
 
 internal readonly ref struct Points(decimal points)
 {
-    internal long AsEmus() => (long)points * 12700;
+    internal long AsEmus() => (long)(points * 12700);
 
     internal float AsPixels() => (float)points * 96 / 72;
 
-    internal int AsHundredPoints() => (int)points * 100;
+    internal int AsHundredPoints() => (int)(points * 100);
 }


### PR DESCRIPTION
I finally found why I didn't use Point class for cell border : point get truncate by the cast when try to convert to other value.