### PR TITLE
Fix hyperlink break when duplicating slides

### DIFF
--- a/src/Slides/UpdatedSlideCollection.cs
+++ b/src/Slides/UpdatedSlideCollection.cs
@@ -111,6 +111,7 @@ internal sealed class UpdatedSlideCollection(SlideCollection slideCollection, Pr
 
         CopySlideContent(sourceSlidePart, clonedSlidePart);
         CopyCustomXmlParts(sourceSlidePart, clonedSlidePart);
+        CopySlideHyperlinks(sourceSlidePart, clonedSlidePart);
         LinkToLayoutPart(sourceSlidePart, clonedSlidePart, presentationPart);
         InsertSlideAtPosition(presentationPart, newSlideRelId, number);
         
@@ -175,6 +176,17 @@ internal sealed class UpdatedSlideCollection(SlideCollection slideCollection, Pr
             sourceStream.Position = 0;
             using var destStream = newCustomXmlPart.GetStream(FileMode.Create, FileAccess.Write);
             sourceStream.CopyTo(destStream);
+        }
+    }
+
+    private static void CopySlideHyperlinks(SlidePart sourceSlidePart, SlidePart clonedSlidePart)
+    {
+        foreach (var idPart in sourceSlidePart.Parts)
+        {
+            if (idPart.OpenXmlPart is SlidePart relatedSlide)
+            {
+                clonedSlidePart.AddPart(relatedSlide, idPart.RelationshipId!);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- preserve hyperlinks when adding slides at a specific position

## Testing
- `dotnet test ShapeCrawler.sln --no-build --verbosity minimal` *(fails: invalid arguments)*

------
https://chatgpt.com/codex/tasks/task_e_683f3c20a1e4832d81ebe7b3045594c4