### PR TITLE
Remove unnecessary System.Drawing.Common dependency

### DIFF
--- a/src/ShapeCrawler.csproj
+++ b/src/ShapeCrawler.csproj
@@ -72,8 +72,7 @@ This library provides a simplified object model on top of the Open XML SDK for m
 
   <ItemGroup>
     <PackageReference Include="DocumentFormat.OpenXml" Version="3.3.0" />
-    <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.5.0" />
-    <PackageReference Include="Magick.NET.SystemDrawing" Version="8.0.5" />
+    <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.6.0" />
     <PackageReference Include="DocumentFormat.OpenXml.Linq" Version="3.3.0" />
     <PackageReference Include="PolySharp" Version="1.15.0">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
The Magick.NET.SystemDrawing package is a "glue" package (not part of MagickNET core library) and adds the System.Drawing.Common dependency, that is not supported on platforms other than Windows in recent .NET versions.  
Since it is not actively used in ShapeCrawler, the package should be removed to improve cross-platform support.