### PR TITLE
Chart Title Setter

### DIFF
--- a/src/Charts/IChart.cs
+++ b/src/Charts/IChart.cs
@@ -17,9 +17,11 @@ public interface IChart
     ChartType Type { get; }
 
     /// <summary>
-    ///     Gets title. Returns <c>null</c> if the chart doesn't have a title.
+    ///     Gets and sets title.
+    ///     Returns <c>null</c> if the chart doesn't have a title.
+    ///     If you set a title to null or empty, the existing title will be removed.
     /// </summary>
-    string? Title { get; }
+    string? Title { get; set; }
 
     /// <summary>
     ///     Gets category collection. Returns <c>null</c> if the chart type doesn't have categories, e.g., Scatter.

--- a/tests/ShapeCrawler.DevTests/ChartTests.cs
+++ b/tests/ShapeCrawler.DevTests/ChartTests.cs
@@ -78,6 +78,24 @@ public class ChartTests : SCTest
         charTitleCase10.Should().BeEquivalentTo("Sales4");
         charTitleCase11.Should().BeEquivalentTo("Sales5");
     }
+
+    [Test]
+    public void Title_Setter_updates_chart_title()
+    {
+        // Arrange
+        var chart1 = new Presentation(TestAsset("018.pptx")).Slide(1).Shape(6).Chart;
+        var chart2 = new Presentation(TestAsset("025_chart.pptx")).Slide(1).Shape(7).Chart;
+
+        var newTitle = "To infinity and beyond!";
+
+        // Act
+        chart1.Title = newTitle;
+        chart2.Title = null;
+
+        // Assert
+        chart1.Title.Should().Be(newTitle);
+        chart2.Title.Should().BeNull();
+    }
         
     [Test]
     public void SeriesCollection_Series_Points_returns_chart_point_collection()


### PR DESCRIPTION
This will resolve issue #50 (Update chart title).

### Requirement
Allow users to update chart title text.

### Description
A setter is added for the `Title` property in `IChart`.
Usage example:
```csharp
var pres = new Presentation(expandableStream);
var chart = pres.Slide(1).Shape(2).Chart;

// To add/update the title text
chart.Title = "Some title text";

// To remove the title
chart.Title = null;
```