### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Release
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ShapeCrawler/ShapeCrawler/security/code-scanning/6](https://github.com/ShapeCrawler/ShapeCrawler/security/code-scanning/6)

The correct way to fix this issue is to explicitly define the `permissions` block at the job or workflow level, specifying the least privilege necessary. For this workflow, only `contents: read` is required, as code checkout and reading repository content is the only operation performed (everything else is performed via secrets or external services). This can be added at the top of the workflow (applies to all jobs) or inside the `publish` job (better if you expect to have multiple jobs in the future with different permissions). For this case, adding at the workflow root is the clearest and minimizes the privilege surface.

**What to change:**  
- In `.github/workflows/release.yml`, add a block:
    ```yaml
    permissions:
      contents: read
    ```
  immediately after the `name: Release` line, before `on:` at line 3.

No additional methods, imports, or external dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
