### PR TITLE
Fix for Possible loss of precision

### DIFF
--- a/src/Paragraphs/TextParagraphPortion.cs
+++ b/src/Paragraphs/TextParagraphPortion.cs
@@ -67,7 +67,7 @@ internal sealed class TextParagraphPortion : IParagraphPortion
         var color = new Color(hex);
 
         var aAlphaValue = aSrgbClr.GetFirstChild<A.Alpha>()?.Val ?? 100000;
-        color.Alpha = Color.Opacity / (100000 / aAlphaValue);
+        color.Alpha = Color.Opacity * (double)aAlphaValue / 100000d;
 
         return color;
     }


### PR DESCRIPTION
In general, to avoid precision loss when converting an integer division result to floating point, at least one operand of the division should be a floating-point value so that the division is carried out in floating-point arithmetic. Here, the problematic part is `Color.Opacity / (100000 / aAlphaValue)`: `100000 / aAlphaValue` is integer division. The existing formula simplifies algebraically to `Color.Opacity * aAlphaValue / 100000`, but more importantly, we want the scaling factor `aAlphaValue / 100000` to be evaluated in floating point, preserving fractional opacity.

The safest fix, without changing the intended semantics, is to make the divisor computed in floating point. A clear and readable way is to rewrite line 70 as:

```csharp
color.Alpha = Color.Opacity * (double)aAlphaValue / 100000d;
```

This preserves proportional scaling while using floating-point division. It also avoids dividing by a fraction, which is slightly opaque to read, and makes the intended mapping (from OpenXML alpha value 0–100000 to your opacity range) explicit. We do not need any new imports or methods; the change is a local expression adjustment in `GetTextHighlight` within `src/Paragraphs/TextParagraphPortion.cs`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._