### PR TITLE
Fix SetText crash when placeholder master font is missing

### DIFF
--- a/src/Shapes/ReferencedFont.cs
+++ b/src/Shapes/ReferencedFont.cs
@@ -243,15 +243,23 @@ internal sealed class ReferencedFont(ReferencedFontColor fontColor, A.Text aText
             return fonts.ALatinFontOrNull(indentLevel);
         }
 
-        var layoutFonts = new IndentFonts(refLayoutPShape.TextBody!.ListStyle!);
-        var layoutIndentColorType = layoutFonts.FontOrNull(indentLevel);
-        if (layoutIndentColorType.HasValue)
+        if (refLayoutPShape.TextBody?.ListStyle != null)
         {
-            return layoutIndentColorType.Value.ALatinFont;
+            var layoutFonts = new IndentFonts(refLayoutPShape.TextBody.ListStyle);
+            var layoutIndentColorType = layoutFonts.FontOrNull(indentLevel);
+            if (layoutIndentColorType.HasValue)
+            {
+                return layoutIndentColorType.Value.ALatinFont;
+            }
         }
 
         var refMasterPShapeOfLayout = this.ReferencedMasterPShapeOrNull(refLayoutPShape);
-        var masterFontsOfLayout = new IndentFonts(refMasterPShapeOfLayout!.TextBody!.ListStyle!);
+        if (refMasterPShapeOfLayout?.TextBody?.ListStyle == null)
+        {
+            return null;
+        }
+
+        var masterFontsOfLayout = new IndentFonts(refMasterPShapeOfLayout.TextBody.ListStyle);
         var masterOfLayoutIndentColorType = masterFontsOfLayout.FontOrNull(indentLevel);
         if (masterOfLayoutIndentColorType.HasValue)
         {

--- a/src/Shapes/ReferencedFont.cs
+++ b/src/Shapes/ReferencedFont.cs
@@ -48,10 +48,10 @@ internal sealed class ReferencedFont(ReferencedFontColor fontColor, A.Text aText
         if (refLayoutPShapeOfSlide == null)
         {
             var refMasterPShape = this.ReferencedMasterPShapeOrNull(slidePShape);
-            if (refMasterPShape != null)
+            var refMasterPShapeFonts = IndentFontsOrNull(refMasterPShape);
+            if (refMasterPShapeFonts.HasValue)
             {
-                var fonts = new IndentFonts(refMasterPShape.TextBody!.ListStyle!);
-                var font = fonts.FontOrNull(indentLevel);
+                var font = refMasterPShapeFonts.Value.FontOrNull(indentLevel);
                 if (font.HasValue)
                 {
                     return (int)font.Value.Size! / 100m;
@@ -70,11 +70,14 @@ internal sealed class ReferencedFont(ReferencedFontColor fontColor, A.Text aText
             return null;
         }
 
-        var layoutFonts = new IndentFonts(refLayoutPShapeOfSlide.TextBody!.ListStyle!);
-        var layoutIndentFont = layoutFonts.FontOrNull(indentLevel);
-        if (layoutIndentFont is { Size: not null })
+        var layoutFonts = IndentFontsOrNull(refLayoutPShapeOfSlide);
+        if (layoutFonts.HasValue)
         {
-            return (int)layoutIndentFont.Value.Size! / 100m;
+            var layoutIndentFont = layoutFonts.Value.FontOrNull(indentLevel);
+            if (layoutIndentFont is { Size: not null })
+            {
+                return (int)layoutIndentFont.Value.Size! / 100m;
+            }
         }
 
         return this.MasterFontSizeOrNull(refLayoutPShapeOfSlide, indentLevel) / 100m;
@@ -90,6 +93,13 @@ internal sealed class ReferencedFont(ReferencedFontColor fontColor, A.Text aText
             NotesSlidePart notesSlidePart => this.NotesSlideALatinFontOrNull(notesSlidePart),
             _ => throw new SCException("Not implemented.")
         };
+    }
+
+    private static IndentFonts? IndentFontsOrNull(P.Shape? pShape)
+    {
+        return pShape?.TextBody?.ListStyle == null
+            ? null
+            : new IndentFonts(pShape.TextBody.ListStyle);
     }
 
     private P.Shape? ReferencedLayoutPShapeOrNull(P.Shape pShape)
@@ -163,21 +173,24 @@ internal sealed class ReferencedFont(ReferencedFontColor fontColor, A.Text aText
             return fonts.BoldFlagOrNull(indentLevel);
         }
 
-        var layoutFonts = new IndentFonts(refLayoutPShapeOfSlide.TextBody!.ListStyle!);
-        var layoutIndentColorType = layoutFonts.FontOrNull(indentLevel);
-        if (layoutIndentColorType.HasValue)
+        var layoutFonts = IndentFontsOrNull(refLayoutPShapeOfSlide);
+        if (layoutFonts.HasValue)
         {
-            return layoutIndentColorType.Value.IsBold;
+            var layoutIndentColorType = layoutFonts.Value.FontOrNull(indentLevel);
+            if (layoutIndentColorType.HasValue)
+            {
+                return layoutIndentColorType.Value.IsBold;
+            }
         }
 
         var refMasterPShapeOfLayout = this.ReferencedMasterPShapeOrNull(refLayoutPShapeOfSlide);
-        if (refMasterPShapeOfLayout == null)
+        var masterFontsOfLayout = IndentFontsOrNull(refMasterPShapeOfLayout);
+        if (!masterFontsOfLayout.HasValue)
         {
             return null;
         }
 
-        var masterFontsOfLayout = new IndentFonts(refMasterPShapeOfLayout.TextBody!.ListStyle!);
-        var masterOfLayoutIndentColorType = masterFontsOfLayout.FontOrNull(indentLevel);
+        var masterOfLayoutIndentColorType = masterFontsOfLayout.Value.FontOrNull(indentLevel);
         if (masterOfLayoutIndentColorType.HasValue)
         {
             return masterOfLayoutIndentColorType.Value.IsBold;
@@ -189,13 +202,13 @@ internal sealed class ReferencedFont(ReferencedFontColor fontColor, A.Text aText
     private int? MasterFontSizeOrNull(P.Shape refLayoutPShapeOfSlide, int indentLevel)
     {
         var refMasterPShapeOfLayout = this.ReferencedMasterPShapeOrNull(refLayoutPShapeOfSlide);
-        if (refMasterPShapeOfLayout == null)
+        var masterFontsOfLayout = IndentFontsOrNull(refMasterPShapeOfLayout);
+        if (!masterFontsOfLayout.HasValue)
         {
             return null;
         }
 
-        var masterFontsOfLayout = new IndentFonts(refMasterPShapeOfLayout.TextBody!.ListStyle!);
-        var masterOfLayoutIndentColorType = masterFontsOfLayout.FontOrNull(indentLevel);
+        var masterOfLayoutIndentColorType = masterFontsOfLayout.Value.FontOrNull(indentLevel);
         if (masterOfLayoutIndentColorType is { Size: not null })
         {
             return (int)masterOfLayoutIndentColorType.Value.Size!;
@@ -238,9 +251,13 @@ internal sealed class ReferencedFont(ReferencedFontColor fontColor, A.Text aText
                 return null;
             }
 
-            var fonts = new IndentFonts(refMasterPShape.TextBody!.ListStyle!);
+            var fonts = IndentFontsOrNull(refMasterPShape);
+            if (!fonts.HasValue)
+            {
+                return null;
+            }
 
-            return fonts.ALatinFontOrNull(indentLevel);
+            return fonts.Value.ALatinFontOrNull(indentLevel);
         }
 
         if (refLayoutPShape.TextBody?.ListStyle != null)

--- a/src/Shapes/ReferencedFontColor.cs
+++ b/src/Shapes/ReferencedFontColor.cs
@@ -22,6 +22,13 @@ internal sealed class ReferencedFontColor(A.Text aText)
         };
     }
 
+    private static IndentFonts? IndentFontsOrNull(P.Shape? pShape)
+    {
+        return pShape?.TextBody?.ListStyle == null
+            ? null
+            : new IndentFonts(pShape.TextBody.ListStyle);
+    }
+
     private string? SlideColorHexOrNull()
     {
         // Get basic shape and placeholder information
@@ -74,10 +81,10 @@ internal sealed class ReferencedFontColor(A.Text aText)
         var referencedMasterPShape = this.ReferencedMasterPShapeOrNull(pShape);
         var aParagraph = aText.Ancestors<A.Paragraph>().First();
         var indentLevel = new SCAParagraph(aParagraph).GetIndentLevel();
-        if (referencedMasterPShape != null)
+        var masterIndentFonts = IndentFontsOrNull(referencedMasterPShape);
+        if (masterIndentFonts.HasValue)
         {
-            var masterIndentFonts = new IndentFonts(referencedMasterPShape.TextBody!.ListStyle!);
-            var masterIndentFont = masterIndentFonts.FontOrNull(indentLevel);
+            var masterIndentFont = masterIndentFonts.Value.FontOrNull(indentLevel);
             if (masterIndentFont != null && this.HexFromName(masterIndentFont, out var masterColor))
             {
                 return masterColor;
@@ -174,12 +181,14 @@ internal sealed class ReferencedFontColor(A.Text aText)
             return this.GetColorFromMasterShape(pShape, indentLevel);
         }
 
-        // Check color from layout shape
-        var layoutFonts = new IndentFonts(referencedLayoutPShape.TextBody!.ListStyle!);
-        var layoutIndentFontOfSlide = layoutFonts.FontOrNull(indentLevel);
-        if (layoutIndentFontOfSlide != null && this.HexFromName(layoutIndentFontOfSlide, out var layoutColorOfSlide))
+        var layoutFonts = IndentFontsOrNull(referencedLayoutPShape);
+        if (layoutFonts.HasValue)
         {
-            return layoutColorOfSlide;
+            var layoutIndentFontOfSlide = layoutFonts.Value.FontOrNull(indentLevel);
+            if (layoutIndentFontOfSlide != null && this.HexFromName(layoutIndentFontOfSlide, out var layoutColorOfSlide))
+            {
+                return layoutColorOfSlide;
+            }
         }
 
         // Try master shape of layout if no color found
@@ -189,13 +198,13 @@ internal sealed class ReferencedFontColor(A.Text aText)
     private string? GetColorFromMasterShape(P.Shape pShape, int indentLevel)
     {
         var referencedMasterPShape = this.ReferencedMasterPShapeOrNull(pShape);
-        if (referencedMasterPShape == null)
+        var masterFontsOfSlide = IndentFontsOrNull(referencedMasterPShape);
+        if (!masterFontsOfSlide.HasValue)
         {
             return null;
         }
 
-        var masterFontsOfSlide = new IndentFonts(referencedMasterPShape.TextBody!.ListStyle!);
-        var masterIndentFontOfSlide = masterFontsOfSlide.FontOrNull(indentLevel);
+        var masterIndentFontOfSlide = masterFontsOfSlide.Value.FontOrNull(indentLevel);
 
         return this.HexFromName(masterIndentFontOfSlide, out var masterColorOfSlide)
             ? masterColorOfSlide
@@ -205,13 +214,13 @@ internal sealed class ReferencedFontColor(A.Text aText)
     private string? GetColorFromMasterShapeOfLayout(P.Shape layoutShape, int indentLevel)
     {
         var refMasterPShapeOfLayout = this.ReferencedMasterPShapeOrNull(layoutShape);
-        if (refMasterPShapeOfLayout == null)
+        var masterFontsOfLayout = IndentFontsOrNull(refMasterPShapeOfLayout);
+        if (!masterFontsOfLayout.HasValue)
         {
             return null;
         }
 
-        var masterFontsOfLayout = new IndentFonts(refMasterPShapeOfLayout.TextBody!.ListStyle!);
-        var masterIndentFontOfLayout = masterFontsOfLayout.FontOrNull(indentLevel);
+        var masterIndentFontOfLayout = masterFontsOfLayout.Value.FontOrNull(indentLevel);
 
         return (masterIndentFontOfLayout != null &&
                 this.HexFromName(masterIndentFontOfLayout, out var masterColorOfLayout))

--- a/tests/ShapeCrawler.DevTests/TextBoxTests.cs
+++ b/tests/ShapeCrawler.DevTests/TextBoxTests.cs
@@ -1,7 +1,9 @@
 using FluentAssertions;
+using DocumentFormat.OpenXml.Packaging;
 using NUnit.Framework;
 using ShapeCrawler.DevTests.Helpers;
 using ShapeCrawler.Texts;
+using P = DocumentFormat.OpenXml.Presentation;
 
 namespace ShapeCrawler.DevTests
 {
@@ -93,6 +95,36 @@ namespace ShapeCrawler.DevTests
 
             // Assert
             textBox.Paragraphs[0].Portions[0].Font!.LatinName.Should().BeEquivalentTo(expectedFont);
+        }
+
+        [Test]
+        public void SetText_updates_placeholder_When_master_placeholder_is_missing()
+        {
+            // Arrange
+            var presStream = TestAsset("031.pptx");
+            using (var presDocument = PresentationDocument.Open(presStream, true))
+            {
+                var master = presDocument.PresentationPart!.SlideMasterParts.First().SlideMaster;
+                var titleShape = master.Descendants<P.Shape>().First(shape =>
+                    shape.NonVisualShapeProperties?.ApplicationNonVisualDrawingProperties?
+                        .GetFirstChild<P.PlaceholderShape>()?.Type?.Value == P.PlaceholderValues.Title);
+
+                titleShape.Remove();
+                master.Save();
+            }
+
+            presStream.Position = 0;
+            var pres = new Presentation(presStream);
+            var layout = pres.SlideMaster(1).LayoutSlides.First(l => l.Name == "Title Slide");
+            pres.Slides.Add(layout.Number);
+            var textBox = pres.Slides.Last().Shapes.First(shape => shape.PlaceholderType == PlaceholderType.Title).TextBox!;
+
+            // Act
+            textBox.SetText("Test title");
+
+            // Assert
+            textBox.Text.Should().Be("Test title");
+            ValidatePresentation(pres);
         }
 
         [Test]


### PR DESCRIPTION
## Summary

Fixes a `NullReferenceException` in `TextBox.SetText(...)` when a slide placeholder resolves to a layout placeholder, but the matching master placeholder/font data is missing.

In that case, `ReferencedFont.SlideALatinFontOrNull(...)` was dereferencing the missing master placeholder with `!` before the caller could fall back to the theme font.

## Changes

- Guard against missing layout text style data before reading inherited latin font information.
- Guard against missing referenced master placeholder/style data and return `null` instead of throwing.
- Add a regression test that removes the matching title placeholder from the slide master, then verifies `SetText(...)` still updates the placeholder text.
- Validate the saved presentation in the regression test.

## Related Issue

Fixes #1284.

## Validation

Ran on Windows:

```powershell
dotnet test .\ShapeCrawler.Dev.sln --configuration Release --filter "FullyQualifiedName~TextBoxTests.SetText_updates_placeholder_When_master_placeholder_is_missing"
```

Result:

```text
Test summary: total: 2, failed: 0, succeeded: 2, skipped: 0
Build succeeded
```

Also verified on Linux:

```bash
sfw dotnet build /tmp/ShapeCrawler-0.79.1/ShapeCrawler.Dev.sln --configuration Release
sfw dotnet test /tmp/ShapeCrawler-0.79.1/tests/ShapeCrawler.DevTests/ShapeCrawler.DevTests.csproj --framework net10.0 --configuration Release --filter "FullyQualifiedName~TextBoxTests.SetText_updates_placeholder_When_master_placeholder_is_missing"
```
