### PR TITLE
Fix invalid paragraph indent level output

### DIFF
--- a/src/Paragraphs/SCAParagraph.cs
+++ b/src/Paragraphs/SCAParagraph.cs
@@ -1,4 +1,5 @@
-﻿using DocumentFormat.OpenXml;
+﻿using System;
+using DocumentFormat.OpenXml;
 using A = DocumentFormat.OpenXml.Drawing;
 
 // ReSharper disable InconsistentNaming
@@ -17,5 +18,13 @@ internal sealed class SCAParagraph(A.Paragraph aParagraph)
         return level + 1;
     }
 
-    internal void UpdateIndentLevel(int level) => aParagraph.ParagraphProperties!.Level = new Int32Value(level - 1);
+    internal void UpdateIndentLevel(int level)
+    {
+        if (level is < 1 or > 9)
+        {
+            throw new ArgumentOutOfRangeException(nameof(level), level, "Indent level must be between 1 and 9.");
+        }
+
+        aParagraph.ParagraphProperties!.Level = new Int32Value(level - 1);
+    }
 }

--- a/tests/ShapeCrawler.DevTests/ParagraphTests.cs
+++ b/tests/ShapeCrawler.DevTests/ParagraphTests.cs
@@ -24,6 +24,23 @@ public class ParagraphTests : SCTest
         paragraph.IndentLevel.Should().Be(2);
     }
 
+    [TestCase(0)]
+    [TestCase(10)]
+    public void IndentLevel_Setter_rejects_invalid_indent_level(int indentLevel)
+    {
+        // Arrange
+        var pres = new Presentation(p => p.Slide());
+        pres.Slides[0].Shapes.AddShape(100, 100, 500, 100);
+        var paragraph = pres.Slides[0].Shapes.Last().TextBox!.Paragraphs[0];
+
+        // Act
+        var settingIndentLevel = () => paragraph.IndentLevel = indentLevel;
+
+        // Assert
+        settingIndentLevel.Should().Throw<ArgumentOutOfRangeException>();
+        ValidatePresentation(pres);
+    }
+
     [Test]
     public void HorizontalAlignment_Setter_sets_horizontal_alignment()
     {


### PR DESCRIPTION
## Summary

Fixes invalid Open XML output when `IParagraph.IndentLevel` is set outside the valid paragraph level range.

ShapeCrawler exposes paragraph indent levels as 1-based values, while DrawingML stores paragraph levels as 0-based `a:pPr/@lvl` values. Without validation, `IndentLevel = 0` was serialized as `lvl="-1"` and `IndentLevel = 10` was serialized as `lvl="9"`, both of which fail Open XML validation.

## Changes

- Validate paragraph indent levels before writing them to `a:pPr/@lvl`.
- Reject public `IndentLevel` values outside `1..9` with `ArgumentOutOfRangeException`.
- Add a regression test for the invalid lower and upper bounds.
- Validate the saved presentation in the regression test.

## Related Issue

Fixes #1286.

## Validation

Ran on Windows:

```powershell
dotnet build src/ShapeCrawler.csproj --configuration Release --framework net10.0
dotnet test tests/ShapeCrawler.DevTests/ShapeCrawler.DevTests.csproj --configuration Release --framework net10.0
```

Result:

```text
Build succeeded
Passed: 785, Skipped: 3, Failed: 0
```

Also verified on Linux:

```bash
dotnet build ShapeCrawler.Dev.sln -c Release
dotnet test tests/ShapeCrawler.DevTests/ShapeCrawler.DevTests.csproj
```

Result:

```text
Build succeeded
Passed: 772, Skipped: 3, Failed: 0
```
